### PR TITLE
fix create-astro template issue

### DIFF
--- a/.changeset/polite-coats-study.md
+++ b/.changeset/polite-coats-study.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+fix issue with empty prompt

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -4,7 +4,7 @@ import { bold, cyan, gray, green, red } from 'kleur/colors';
 import prompts from 'prompts';
 import degit from 'degit';
 import yargs from 'yargs-parser';
-import { TEMPLATES } from './templates';
+import { TEMPLATES } from './templates.js';
 const args = yargs(process.argv);
 prompts.override(args);
 
@@ -60,6 +60,7 @@ export async function main() {
 
   try {
     // emitter.on('info', info => { console.log(info.message) });
+    console.log(green(`>`) + gray(` Copying project files...`));
     await emitter.clone(cwd);
   } catch (err) {
     // degit is compiled, so the stacktrace is pretty noisy. Just report the message.

--- a/packages/create-astro/src/templates.ts
+++ b/packages/create-astro/src/templates.ts
@@ -1,5 +1,4 @@
 export const TEMPLATES = [
-  ,
   {
     title: 'Starter Kit (Generic)',
     value: 'starter',


### PR DESCRIPTION
## Changes

- the prompts package fails when it sees an empty option
- a bad commit added an empty object to the "select template" screen

## Testing

- Not testable since it only happened in interactive mode
- Tests continue to pass