### PR TITLE
watch files during development in both snowpack instances

### DIFF
--- a/.changeset/fair-students-cough.md
+++ b/.changeset/fair-students-cough.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix an issue with how files are watched during development

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -428,7 +428,7 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
       lockfile: null,
     },
     {
-      isWatch: isHmrEnabled,
+      isWatch: mode === 'development',
     }
   );
   const snowpackRuntime = snowpack.getServerRuntime();


### PR DESCRIPTION
## Changes

- During build, we were seeing the file watcher running twice
- Last night I pushed a fix to turn this off, but the fix was too aggressive and ended up disabling file watching on the frontend during development
- This PR fixes that issue

## Testing

- [X] Tests are passing
- [X] Tests updated where necessary - don't have coverage on file updates yet