### PR TITLE
Give the blog template a default `site`

### DIFF
--- a/examples/blog/astro.config.mjs
+++ b/examples/blog/astro.config.mjs
@@ -4,7 +4,7 @@ export default {
   // dist: './dist',       // When running `astro build`, path to final static output
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
-    // site: '',           // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.
+    site: 'http://example.com',           // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.
     // sitemap: true,      // Generate sitemap (set to "false" to disable)
   },
   devOptions: {


### PR DESCRIPTION
## Changes

Not having this causes it to throw in the build

## Testing

N/A

## Docs

N/A