### PR TITLE
nit: ask user to modify devOptions.port when addr in use for dev

### DIFF
--- a/.changeset/stupid-dryers-bow.md
+++ b/.changeset/stupid-dryers-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+nit: ask user to modify devOptions.port when addr in use for dev

--- a/packages/astro/src/dev.ts
+++ b/packages/astro/src/dev.ts
@@ -2,7 +2,7 @@ import 'source-map-support/register.js';
 import type { AstroConfig } from './@types/astro';
 import type { LogOptions } from './logger.js';
 
-import { green } from 'kleur/colors';
+import { green, red } from 'kleur/colors';
 import http from 'http';
 import path from 'path';
 import { performance } from 'perf_hooks';
@@ -101,9 +101,18 @@ export default async function dev(astroConfig: AstroConfig) {
   });
 
   const port = astroConfig.devOptions.port;
-  server.listen(port, hostname, () => {
-    const endServerTime = performance.now();
-    info(logging, 'dev server', green(`Server started in ${Math.floor(endServerTime - startServerTime)}ms.`));
-    info(logging, 'dev server', `${green('Local:')} http://${hostname}:${port}/`);
-  });
+  server
+    .listen(port, hostname, () => {
+      const endServerTime = performance.now();
+      info(logging, 'dev server', green(`Server started in ${Math.floor(endServerTime - startServerTime)}ms.`));
+      info(logging, 'dev server', `${green('Local:')} http://${hostname}:${port}/`);
+    })
+    .on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code && err.code === 'EADDRINUSE') {
+        error(logging, 'dev server', `Address ${hostname}:${port} already in use. Try changing devOptions.port in your config file`);
+      } else {
+        error(logging, 'dev server', err.stack);
+      }
+      process.exit(1);
+    });
 }

--- a/packages/astro/src/dev.ts
+++ b/packages/astro/src/dev.ts
@@ -2,7 +2,7 @@ import 'source-map-support/register.js';
 import type { AstroConfig } from './@types/astro';
 import type { LogOptions } from './logger.js';
 
-import { green, red } from 'kleur/colors';
+import { green } from 'kleur/colors';
 import http from 'http';
 import path from 'path';
 import { performance } from 'perf_hooks';


### PR DESCRIPTION
## Changes

Closes #345
Slight tweak of the error message on addr already used for dev server.

Before:
```
$ astro dev
[01:09:24] [snowpack] Ready!
[01:09:24] [snowpack] watching for file changes...
Error: listen EADDRINUSE: address already in use 127.0.0.1:3000
    at Server.setupListenHandle [as _listen2] (node:net:1306:16)
    at listenInCluster (node:net:1354:12)
    at doListen (node:net:1492:7)
    at processTicksAndRejections (node:internal/process/task_queues:84:21)
```
After
```
$ node ../../packages/astro/astro.mjs dev .
[01:42:40] [snowpack] Ready!
[01:42:40] [snowpack] watching for file changes...
[dev server] Address 127.0.0.1:3000 already in use. Try changing devOptions.port in your config file
```

## Testing

<!-- How can a reviewer test your code themselves? -->

- [x] Tests are passing
- [ ] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
