### PR TITLE
docs: fix browserlists link

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -80,7 +80,7 @@ Astro also supports [Sass][sass] out-of-the-box. To enable for each framework:
 
 ### 🦊 Autoprefixer
 
-We also automatically add browser prefixes using [Autoprefixer][autoprefixer]. By default, Astro loads the [Browserslist defaults][browserslist-defaults], but you may also specify your own by placing a [Browserslist][browserslist] file in your project root.
+We also automatically add browser prefixes using [Autoprefixer][autoprefixer]. By default, Astro loads the [Browserslist defaults](https://github.com/browserslist/browserslist#full-list), but you may also specify your own by placing a [Browserslist][browserslist] file in your project root.
 
 ### 🍃 Tailwind
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -80,7 +80,7 @@ Astro also supports [Sass][sass] out-of-the-box. To enable for each framework:
 
 ### 🦊 Autoprefixer
 
-We also automatically add browser prefixes using [Autoprefixer][autoprefixer]. By default, Astro loads the [Browserslist defaults](https://github.com/browserslist/browserslist#full-list), but you may also specify your own by placing a [Browserslist][browserslist] file in your project root.
+We also automatically add browser prefixes using [Autoprefixer][autoprefixer]. By default, Astro loads the [Browserslist defaults][browserslist-defaults], but you may also specify your own by placing a [Browserslist][browserslist] file in your project root.
 
 ### 🍃 Tailwind
 
@@ -466,7 +466,7 @@ Also please check out the [Stylelint][stylelint] project to whip your styles int
 [bem]: http://getbem.com/introduction/
 [box-model]: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/The_box_model
 [browserslist]: https://github.com/browserslist/browserslist
-[browserslist-default]: https://github.com/browserslist/browserslist#queries
+[browserslist-defaults]: https://github.com/browserslist/browserslist#queries
 [cassie-evans-css]: https://twitter.com/cassiecodes/status/1392756828786790400?s=20
 [container-queries]: https://ishadeed.com/article/say-hello-to-css-container-queries/
 [css-modules]: https://github.com/css-modules/css-modules


### PR DESCRIPTION
I'm not sure where the browserslist default link should redirect to, but I assumed: https://github.com/browserslist/browserslist#full-list