### PR TITLE
Pass configured Tailwind config file to the `tailwindcss` plugin

### DIFF
--- a/.changeset/breezy-parrots-bathe.md
+++ b/.changeset/breezy-parrots-bathe.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Pass configured Tailwind config file to the tailwindcss plugin

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -107,7 +107,7 @@ Be sure to add the config path to `astro.config.mjs`, so that Astro enables JIT 
   // astro.config.mjs
   export default {
 +   devOptions: {
-+     tailwindConfig: './tailwindConfig.js',
++     tailwindConfig: './tailwind.config.js',
 +   },
   };
 ```

--- a/packages/astro/src/@types/compiler.ts
+++ b/packages/astro/src/@types/compiler.ts
@@ -7,5 +7,4 @@ export interface CompileOptions {
   astroConfig: AstroConfig;
   hmrPort?: number;
   mode: RuntimeMode;
-  tailwindConfig?: string;
 }

--- a/packages/astro/src/compiler/transform/styles.ts
+++ b/packages/astro/src/compiler/transform/styles.ts
@@ -125,7 +125,7 @@ async function transformStyle(code: string, { logging, type, filename, scopedCla
     try {
       const require = createRequire(import.meta.url);
       const tw = require.resolve('tailwindcss', { paths: [import.meta.url, process.cwd()] });
-      postcssPlugins.push(require(tw) as any);
+      postcssPlugins.push(require(tw)(tailwindConfig) as any);
     } catch (err) {
       error(logging, 'transform', err);
       throw new Error(`tailwindcss not installed. Try running \`npm install tailwindcss\` and trying again.`);
@@ -215,7 +215,7 @@ export default function transformStyles({ compileOptions, filename, fileID }: Tr
                   type: (langAttr && langAttr.value[0] && langAttr.value[0].data) || undefined,
                   filename,
                   scopedClass,
-                  tailwindConfig: compileOptions.tailwindConfig,
+                  tailwindConfig: compileOptions.astroConfig.devOptions.tailwindConfig,
                 })
               );
               return;

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -396,7 +396,7 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
           config: {
             plugins: {
               [resolveDependency('autoprefixer')]: {},
-              ...(astroConfig.devOptions.tailwindConfig ? { [resolveDependency('tailwindcss')]: {} } : {}),
+              ...(astroConfig.devOptions.tailwindConfig ? { [resolveDependency('tailwindcss')]: astroConfig.devOptions.tailwindConfig } : {}),
             },
           },
         },


### PR DESCRIPTION
Hey, congratulations on the launch! 🚀 

## Changes

This pull request ensures that the configured Tailwind config file (`devOptions.tailwindConfig`) is passed to the `tailwindcss` plugin. As far as I can tell currently this option is only used as a "flag" to enable `tailwindcss` and the actual path is not used.

This pull request also updates the styling docs to fix what I think is a typo in the Tailwind config path.

**One question I have related to this, is whether the `tailwindConfig` option should also be passed in to [the other `transformStyle` call](https://github.com/snowpackjs/astro/blob/9c7f07aebdd7d762f2f86dd3752773ce851cde65/packages/astro/src/compiler/transform/styles.ts#L243-L248) in the style transformer?**

## Testing

Example project: https://github.com/bradlc/astro-tailwind

`devOptions.tailwindConfig` is set to `./tailwind.js` but this config file is not used. The app should display a `tomato` square but it does not.

- [X] Tests are passing
- [X] Tests updated where necessary

## Docs

- [X] Docs / READMEs updated
- [X] Code comments added where helpful

<!-- Notes, if any -->
