### PR TITLE
Pass Astro `site` to snowpack `baseUrl`

### DIFF
--- a/.changeset/stale-cameras-teach.md
+++ b/.changeset/stale-cameras-teach.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Pass "site" config to Snowpack as "baseUrl"

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -406,6 +406,7 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
       tailwindConfig: astroConfig.devOptions.tailwindConfig,
     },
     buildOptions: {
+      baseUrl: astroConfig.buildOptions.site,
       out: astroConfig.dist,
     },
     packageOptions: {


### PR DESCRIPTION
## Changes

Passes the Astro `site` config to Snowpack as `baseUrl`

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

No tests needed

<!-- How can a reviewer test your code themselves? -->

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

No docs needed either

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
