### PR TITLE
Make doctype be case insensitive

### DIFF
--- a/packages/astro/src/compiler/transform/doctype.ts
+++ b/packages/astro/src/compiler/transform/doctype.ts
@@ -9,7 +9,7 @@ export default function (_opts: { filename: string; fileID: string }): Transform
       html: {
         Element: {
           enter(node, parent, _key, index) {
-            if (node.name === '!doctype') {
+            if (node.name === '!doctype' || node.name === '!DOCTYPE') {
               hasDoctype = true;
             }
             if (node.name === 'html' && !hasDoctype) {

--- a/packages/astro/src/compiler/transform/doctype.ts
+++ b/packages/astro/src/compiler/transform/doctype.ts
@@ -9,7 +9,7 @@ export default function (_opts: { filename: string; fileID: string }): Transform
       html: {
         Element: {
           enter(node, parent, _key, index) {
-            if (node.name === '!doctype' || node.name === '!DOCTYPE') {
+            if (node.name.toLowerCase() === '!doctype') {
               hasDoctype = true;
             }
             if (node.name === 'html' && !hasDoctype) {

--- a/packages/astro/src/compiler/transform/postcss-scoped-styles/index.ts
+++ b/packages/astro/src/compiler/transform/postcss-scoped-styles/index.ts
@@ -28,9 +28,7 @@ export const NEVER_SCOPED_TAGS = new Set<string>([
   'noscript',
   'script',
   'style',
-  'title',
-  '!doctype',
-  '!DOCTYPE'
+  'title'
 ]);
 /**
  * Scope Rules
@@ -92,7 +90,7 @@ export function scopeRule(selector: string, className: string) {
     }
 
     // don’t scope body, title, etc.
-    if (CSS_SEPARATORS.has(value) || NEVER_SCOPED_TAGS.has(value)) {
+    if (CSS_SEPARATORS.has(value) || NEVER_SCOPED_TAGS.has(value) || value.toLowerCase() === '!doctype') {
       ss = head + value + tail;
       continue;
     }

--- a/packages/astro/src/compiler/transform/postcss-scoped-styles/index.ts
+++ b/packages/astro/src/compiler/transform/postcss-scoped-styles/index.ts
@@ -90,7 +90,7 @@ export function scopeRule(selector: string, className: string) {
     }
 
     // don’t scope body, title, etc.
-    if (CSS_SEPARATORS.has(value) || NEVER_SCOPED_TAGS.has(value) || value.toLowerCase() === '!doctype') {
+    if (CSS_SEPARATORS.has(value) || NEVER_SCOPED_TAGS.has(value)) {
       ss = head + value + tail;
       continue;
     }

--- a/packages/astro/src/compiler/transform/postcss-scoped-styles/index.ts
+++ b/packages/astro/src/compiler/transform/postcss-scoped-styles/index.ts
@@ -30,6 +30,7 @@ export const NEVER_SCOPED_TAGS = new Set<string>([
   'style',
   'title',
   '!doctype',
+  '!DOCTYPE'
 ]);
 /**
  * Scope Rules

--- a/packages/astro/src/compiler/transform/styles.ts
+++ b/packages/astro/src/compiler/transform/styles.ts
@@ -4,13 +4,12 @@ import type { TemplateNode } from '@astrojs/parser';
 import crypto from 'crypto';
 import { createRequire } from 'module';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import autoprefixer from 'autoprefixer';
 import postcss, { Plugin } from 'postcss';
 import postcssKeyframes from 'postcss-icss-keyframes';
 import findUp from 'find-up';
 import sass from 'sass';
-import { debug, error, LogOptions } from '../../logger.js';
+import { error, LogOptions } from '../../logger.js';
 import astroScopedStyles, { NEVER_SCOPED_TAGS } from './postcss-scoped-styles/index.js';
 import slash from 'slash';
 

--- a/packages/astro/src/compiler/transform/styles.ts
+++ b/packages/astro/src/compiler/transform/styles.ts
@@ -221,7 +221,9 @@ export default function transformStyles({ compileOptions, filename, fileID }: Tr
             }
 
             // 2. add scoped HTML classes
-            if (NEVER_SCOPED_TAGS.has(node.name)) return; // only continue if this is NOT a <script> tag, etc.
+            if (NEVER_SCOPED_TAGS.has(node.name) || node.name.toLowerCase() === '!doctype') {
+              return; // only continue if this is NOT a <script> tag, etc.
+            }
             // Note: currently we _do_ scope web components/custom elements. This seems correct?
 
             injectScopedClassAttribute(node, scopedClass);

--- a/packages/astro/src/internal/h.ts
+++ b/packages/astro/src/internal/h.ts
@@ -7,8 +7,8 @@ const voidTags = new Set(['area', 'base', 'br', 'col', 'command', 'embed', 'hr',
 
 /** Generator for primary h() function */
 function* _h(tag: string, attrs: HProps, children: Array<HChild>) {
-  if (tag === '!doctype') {
-    yield '<!doctype ';
+  if (tag === '!doctype' || tag === '!DOCTYPE') {
+    yield `<${tag} `;
     if (attrs) {
       yield Object.keys(attrs).join(' ');
     }

--- a/packages/astro/src/internal/h.ts
+++ b/packages/astro/src/internal/h.ts
@@ -7,7 +7,7 @@ const voidTags = new Set(['area', 'base', 'br', 'col', 'command', 'embed', 'hr',
 
 /** Generator for primary h() function */
 function* _h(tag: string, attrs: HProps, children: Array<HChild>) {
-  if (tag === '!doctype' || tag === '!DOCTYPE') {
+  if (tag.toLowerCase() === '!doctype') {
     yield `<${tag} `;
     if (attrs) {
       yield Object.keys(attrs).join(' ');

--- a/packages/astro/test/astro-doctype.test.js
+++ b/packages/astro/test/astro-doctype.test.js
@@ -56,4 +56,13 @@ DType.skip('Preserves user provided doctype', async () => {
   assert.ok(html.startsWith('<!doctype HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">'), 'Doctype included was preserved');
 });
 
+DType('User provided doctype is case insensitive', async () => {
+  const result = await runtime.load('/capital');
+  if (result.error) throw new Error(result.error);
+
+  const html = result.contents.toString('utf-8');
+  assert.ok(html.startsWith('<!DOCTYPE html>'), 'Doctype left alone');
+  assert.not.ok(html.includes('</!DOCTYPE>'), 'There should not be a closing tag');
+});
+
 DType.run();

--- a/packages/astro/test/fixtures/astro-doctype/src/pages/capital.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/pages/capital.astro
@@ -1,0 +1,9 @@
+---
+let title = 'My Site';
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head><title>{title}</title></head>
+  <body><h1>Hello world</h1></body>
+</html>


### PR DESCRIPTION
Fixes #413

## Changes

Makes all of the places where we special case the doctype be case insensitive.

## Testing

Added a test for all-caps doctype as is typical to write.

## Docs

N/A
