### PR TITLE
Fix usage of arrow functions as components

### DIFF
--- a/packages/astro/test/fixtures/preact-component/src/components/ArrowFunction.jsx
+++ b/packages/astro/test/fixtures/preact-component/src/components/ArrowFunction.jsx
@@ -1,0 +1,5 @@
+import { h, Component } from 'preact';
+
+export default () => {
+  return <div id="arrow-fn-component"></div>;
+}

--- a/packages/astro/test/fixtures/preact-component/src/pages/fn.astro
+++ b/packages/astro/test/fixtures/preact-component/src/pages/fn.astro
@@ -1,5 +1,6 @@
 ---
 import FunctionComponent from '../components/Function.jsx';
+import ArrowFunctionComponent from '../components/ArrowFunction.jsx';
 ---
 
 <html>
@@ -8,5 +9,6 @@ import FunctionComponent from '../components/Function.jsx';
 </head>
 <body>
   <FunctionComponent />
+  <ArrowFunctionComponent />
 </body>
 </html>

--- a/packages/astro/test/fixtures/react-component/src/components/ArrowFunction.jsx
+++ b/packages/astro/test/fixtures/react-component/src/components/ArrowFunction.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default () => {
+  return <div id="arrow-fn-component"></div>;
+}

--- a/packages/astro/test/fixtures/react-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/react-component/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Hello from '../components/Hello.jsx';
 import Later from '../components/Goodbye.vue'; // use different specifier
+import ArrowFunction from '../components/ArrowFunction.jsx';
 ---
 
 <html>
@@ -10,5 +11,6 @@ import Later from '../components/Goodbye.vue'; // use different specifier
   <body>
     <Hello name="world" />
     <Later name="baby" />
+    <ArrowFunction />
   </body>
 </html>

--- a/packages/astro/test/preact-component.test.js
+++ b/packages/astro/test/preact-component.test.js
@@ -21,6 +21,7 @@ PreactComponent('Can load function component', async ({ runtime }) => {
 
   const $ = doc(result.contents);
   assert.equal($('#fn-component').length, 1, 'Can use function components');
+  assert.equal($('#arrow-fn-component').length, 1, 'Can use function components');
 });
 
 PreactComponent('Can use hooks', async ({ runtime }) => {

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -39,6 +39,7 @@ React('Can load React', async () => {
 
   const $ = doc(result.contents);
   assert.equal($('#react-h2').text(), 'Hello world!');
+  assert.equal($('#arrow-fn-component').length, 1, 'Can use function components');
 });
 
 React('Can load Vue', async () => {

--- a/packages/renderers/renderer-preact/server.js
+++ b/packages/renderers/renderer-preact/server.js
@@ -5,7 +5,7 @@ import StaticHtml from './static-html.js';
 function check(Component, props, children) {
   if (typeof Component !== 'function') return false;
 
-  if (typeof Component.prototype.render === 'function') {
+  if (Component.prototype != null && typeof Component.prototype.render === 'function') {
     return BaseComponent.isPrototypeOf(Component);
   }
 

--- a/packages/renderers/renderer-react/server.js
+++ b/packages/renderers/renderer-react/server.js
@@ -7,8 +7,8 @@ const reactTypeof = Symbol.for('react.element');
 function check(Component, props, children) {
   if (typeof Component !== 'function') return false;
 
-  if (Component.render != null && typeof Component.prototype.render === 'function') {
-    return BaseComponent.isPrototypeOf(Componentm);
+  if (Component.prototype != null && typeof Component.prototype.render === 'function') {
+    return BaseComponent.isPrototypeOf(Component);
   }
 
   let error = null;

--- a/packages/renderers/renderer-react/server.js
+++ b/packages/renderers/renderer-react/server.js
@@ -7,8 +7,8 @@ const reactTypeof = Symbol.for('react.element');
 function check(Component, props, children) {
   if (typeof Component !== 'function') return false;
 
-  if (typeof Component.prototype.render === 'function') {
-    return BaseComponent.isPrototypeOf(Component);
+  if (Component.render != null && typeof Component.prototype.render === 'function') {
+    return BaseComponent.isPrototypeOf(Componentm);
   }
 
   let error = null;


### PR DESCRIPTION
This fixes the React and Preact component as arrow function use-case by checking for the prototype property (arrow functions don't)

## Changes

Checks for `Component.prototype` because arrow funtions don't have them.

## Testing

Added test to the Preact and React renderer.

## Docs

N/A
