### PR TITLE
Prevent postcss from crashing when scoping class without a body

### DIFF
--- a/.changeset/silent-rocks-relax.md
+++ b/.changeset/silent-rocks-relax.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent dev from locking up on empty selectors

--- a/packages/astro/src/compiler/transform/postcss-scoped-styles/index.ts
+++ b/packages/astro/src/compiler/transform/postcss-scoped-styles/index.ts
@@ -96,10 +96,14 @@ export function scopeRule(selector: string, className: string) {
 
 /** PostCSS Scope plugin */
 export default function astroScopedStyles(options: AstroScopedOptions): Plugin {
+  const rulesScopedCache = new WeakSet();
   return {
     postcssPlugin: '@astrojs/postcss-scoped-styles',
     Rule(rule) {
-      rule.selector = scopeRule(rule.selector, options.className);
+      if(!rulesScopedCache.has(rule)) {
+        rule.selector = scopeRule(rule.selector, options.className);
+        rulesScopedCache.add(rule);
+      }
     },
   };
 }

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -40,4 +40,11 @@ Basics('Correctly serializes boolean attributes', async ({ runtime }) => {
   assert.equal($('h2').attr('not-data-ok'), '');
 });
 
+Basics('Selector with an empty body', async ({ runtime }) => {
+  const result = await runtime.load('/empty-class');
+  const html = result.contents;
+  const $ = doc(html);
+  assert.equal($('.author').length, 1, 'author class added');
+});
+
 Basics.run();

--- a/packages/astro/test/fixtures/astro-basic/src/pages/empty-class.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/empty-class.astro
@@ -1,0 +1,15 @@
+---
+
+---
+<html>
+<head>
+  <title>Testing</title>
+  <style>
+  .author {
+  }
+  </style>
+</head>
+<body>
+  <div class="author"></div>
+</body>
+</html>


### PR DESCRIPTION
Closes #340

## Changes

For some reason postcss will keep running the plugin over and over on a class without a body if we modify the `selector` (this triggers it as being "dirty"). It doesn't do this for selectors with a body. But the fix was easy enough, only scope a rule once.

## Testing

Added a test for this scenario.

## Docs

N/A