### PR TITLE
Add `<>` fragment support for expressions

### DIFF
--- a/.changeset/mean-ligers-nail.md
+++ b/.changeset/mean-ligers-nail.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/parser': patch
+---
+
+Add support for Fragments with `<>` and `</>` syntax

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -113,28 +113,52 @@ export let name;
 </main>
 ```
 
+### Fragments
+
+At the top-level of an `.astro` file, you may render any number of elements.
+
+```html
+<!-- Look, no Fragment! -->
+<div id="a" />
+<div id="b" />
+<div id="c" />
+```
+
+Inside of an expression, you must wrap multiple elements in a Fragment. Fragments must open with `<>` and close with `</>`.
+
+```jsx
+<div>
+{[0, 1, 2].map(id => (
+  <>
+    <div id={`a-${id}`} />
+    <div id={`b-${id}`} />
+    <div id={`c-${id}`} />
+  </>
+))}
+</div>
+```
+
 ### `.astro` versus `.jsx`
 
 `.astro` files can end up looking very similar to `.jsx` files, but there are a few key differences. Here's a comparison between the two formats.
 
-| Feature                      | Astro                                    | JSX                                                |
-| ---------------------------- | ---------------------------------------- | -------------------------------------------------- |
-| File extension               | `.astro`                                 | `.jsx` or `.tsx`                                   |
-| User-Defined Components      | `<Capitalized>`                          | `<Capitalized>`                                    |
-| Expression Syntax            | `{}`                                     | `{}`                                               |
-| Spread Attributes            | `{...props}`                             | `{...props}`                                       |
-| Boolean Attributes           | `autocomplete` === `autocomplete={true}` | `autocomplete` === `autocomplete={true}`           |
-| Inline Functions             | `{items.map(item => <li>{item}</li>)}`   | `{items.map(item => <li>{item}</li>)}`             |
-| IDE Support                  | WIP - [VS Code][code-ext]                | Phenomenal                                         |
-| Requires JS import           | No                                       | Yes, `jsxPragma` (`React` or `h`) must be in scope |
-| Fragments                    | Automatic                                | Wrap with `<Fragment>` or `<>`                     |
-| Multiple frameworks per-file | Yes                                      | No                                                 |
-| Modifying `<head>`           | Just use `<head>`                        | Per-framework (`<Head>`, `<svelte:head>`, etc)     |
-| Comment Style                | `<!-- HTML -->`                          | `{/* JavaScript */}`                               |
-| Special Characters           | `&nbsp;`                                 | `{'\xa0'}` or `{String.fromCharCode(160)}`         |
-| Attributes                   | `dash-case`                              | `camelCase`                                        |
+| Feature                      | Astro                                        | JSX                                                |
+| ---------------------------- | -------------------------------------------- | -------------------------------------------------- |
+| File extension               | `.astro`                                     | `.jsx` or `.tsx`                                   |
+| User-Defined Components      | `<Capitalized>`                              | `<Capitalized>`                                    |
+| Expression Syntax            | `{}`                                         | `{}`                                               |
+| Spread Attributes            | `{...props}`                                 | `{...props}`                                       |
+| Boolean Attributes           | `autocomplete` === `autocomplete={true}`     | `autocomplete` === `autocomplete={true}`           |
+| Inline Functions             | `{items.map(item => <li>{item}</li>)}`       | `{items.map(item => <li>{item}</li>)}`             |
+| IDE Support                  | WIP - [VS Code][code-ext]                    | Phenomenal                                         |
+| Requires JS import           | No                                           | Yes, `jsxPragma` (`React` or `h`) must be in scope |
+| Fragments                    | Automatic top-level, `<>` inside functions   | Wrap with `<Fragment>` or `<>`                     |
+| Multiple frameworks per-file | Yes                                          | No                                                 |
+| Modifying `<head>`           | Just use `<head>`                            | Per-framework (`<Head>`, `<svelte:head>`, etc)     |
+| Comment Style                | `<!-- HTML -->`                              | `{/* JavaScript */}`                               |
+| Special Characters           | `&nbsp;`                                     | `{'\xa0'}` or `{String.fromCharCode(160)}`         |
+| Attributes                   | `dash-case`                                  | `camelCase`                                        |
 
-### TODO: Styling
 
 ### TODO: Composition (Slots)
 

--- a/packages/astro-parser/src/parse/state/tag.ts
+++ b/packages/astro-parser/src/parse/state/tag.ts
@@ -13,7 +13,7 @@ const valid_tag_name = /^\!?[a-zA-Z]{1,}:?[a-zA-Z0-9\-]*/;
 
 const meta_tags = new Map([
   ['astro:head', 'Head'],
-  // ['slot:body', 'Body'],
+  ['', 'SlotTemplate'],
   // ['astro:options', 'Options'],
   // ['astro:window', 'Window'],
   // ['astro:body', 'Body'],
@@ -118,8 +118,8 @@ export default function tag(parser: Parser) {
     ? meta_tags.get(name)
     : /[A-Z]/.test(name[0]) || name === 'astro:self' || name === 'astro:component'
     ? 'InlineComponent'
-    : name === 'astro:fragment'
-    ? 'SlotTemplate'
+    : name === ''
+    ? 'Fragment'
     : name === 'title' && parent_is_head(parser.stack)
     ? 'Title'
     : name === 'slot' && !parser.customElement

--- a/packages/astro-parser/src/parse/state/tag.ts
+++ b/packages/astro-parser/src/parse/state/tag.ts
@@ -119,7 +119,7 @@ export default function tag(parser: Parser) {
     : /[A-Z]/.test(name[0]) || name === 'astro:self' || name === 'astro:component'
     ? 'InlineComponent'
     : name === ''
-    ? 'Fragment'
+    ? 'SlotTemplate'
     : name === 'title' && parent_is_head(parser.stack)
     ? 'Title'
     : name === 'slot' && !parser.customElement

--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -494,6 +494,11 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
             return;
           case 'Fragment':
             break;
+          case 'SlotTemplate': {
+            buffers[curr] += `h(Fragment, null, children`;
+            paren++;
+            return;
+          }
           case 'Slot':
           case 'Head':
           case 'InlineComponent': {
@@ -630,6 +635,7 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
           case 'CodeSpan':
           case 'CodeFence':
             return;
+          case 'SlotTemplate':
           case 'Slot':
           case 'Head':
           case 'Body':

--- a/packages/astro/test/astro-expr.test.js
+++ b/packages/astro/test/astro-expr.test.js
@@ -58,6 +58,17 @@ Expressions('Allows multiple JSX children in mustache', async ({ runtime }) => {
   assert.ok(result.contents.includes('#f') && !result.contents.includes('#t'));
 });
 
+Expressions('Allows <> Fragments in expressions', async ({ runtime }) => {
+  const result = await runtime.load('/multiple-children');
+  if (result.error) throw new Error(result.error);
+  const $ = doc(result.contents);
+
+  assert.equal($('#fragment').children().length, 3);
+  assert.equal($('#fragment').children('#a').length, 1);
+  assert.equal($('#fragment').children('#b').length, 1);
+  assert.equal($('#fragment').children('#c').length, 1);
+})
+
 Expressions('Does not render falsy values using &&', async ({ runtime }) => {
   const result = await runtime.load('/falsy');
   if (result.error) throw new Error(result.error);

--- a/packages/astro/test/fixtures/astro-expr/src/pages/multiple-children.astro
+++ b/packages/astro/test/fixtures/astro-expr/src/pages/multiple-children.astro
@@ -10,5 +10,15 @@ let title = 'My Site';
   <h1>{title}</h1>
 
   {false ? <h1>#t</h1> : <h1>#f</h1>}
+
+  <div id="fragment">
+    {(
+      <>
+        <div id="a" />
+        <div id="b" />
+        <div id="c" />
+      </>
+    )}
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Changes

- Adds automatic Fragment support for inline expressions in `.astro` files
- Not any code changes, multiple top-level elements remains supported
- Not any code changes, users may use array syntax `[<a>, <b>, <c>]` for inline expressions
- Closes #405.

## Testing

Manually, but should probably add a real test for this.

## Docs

Yes, Syntax doc has been updated.
