### PR TITLE
Add .svelte to the tailwind config

### DIFF
--- a/examples/tailwindcss/tailwind.config.js
+++ b/examples/tailwindcss/tailwind.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   mode: 'jit',
-  purge: ['./public/**/*.html', './src/**/*.{astro,js,jsx,ts,tsx,vue}'],
+  purge: ['./public/**/*.html', './src/**/*.{astro,js,jsx,ts,tsx,vue,svelte}'],
 };


### PR DESCRIPTION
Add .svelte files to tailwind config so that svelte components can use tailwind classes.

## Changes

- What does this change?
This changes the tailwind's config.

- Be short and concise. Bullet points can help!
Add .svelte files to tailwind config so that svelte components can use tailwind classes.

- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
N/A

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
