### PR TITLE
Less verbose HMR script

### DIFF
--- a/packages/astro/src/compiler/transform/head.ts
+++ b/packages/astro/src/compiler/transform/head.ts
@@ -62,7 +62,7 @@ export default function (opts: TransformOptions): Transformer {
             type: 'Element',
             name: 'script',
             attributes: [],
-            children: [{ type: 'Text', data: `window.HMR_WEBSOCKET_URL = window.HMR_WEBSOCKET_URL || 'ws://localhost:${hmrPort}';`, start: 0, end: 0 }],
+            children: [{ type: 'Text', data: `window.HMR_WEBSOCKET_PORT = ${hmrPort};`, start: 0, end: 0 }],
             start: 0,
             end: 0,
           },

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -23,13 +23,13 @@ Basics('Can load page', async ({ runtime }) => {
 Basics('Sets the HMR port when dynamic components used', async ({ runtime }) => {
   const result = await runtime.load('/client');
   const html = result.contents;
-  assert.ok(/HMR_WEBSOCKET_URL/.test(html), 'Sets the websocket port');
+  assert.ok(/HMR_WEBSOCKET_PORT/.test(html), 'Sets the websocket port');
 });
 
 Basics('Does not set the HMR port when no dynamic component used', async ({ runtime }) => {
   const result = await runtime.load('/');
   const html = result.contents;
-  assert.ok(!/HMR_WEBSOCKET_URL/.test(html), 'Does not set the websocket port');
+  assert.ok(!/HMR_WEBSOCKET_PORT/.test(html), 'Does not set the websocket port');
 });
 
 Basics('Correctly serializes boolean attributes', async ({ runtime }) => {

--- a/packages/astro/test/astro-hmr.test.js
+++ b/packages/astro/test/astro-hmr.test.js
@@ -16,7 +16,7 @@ HMR('Honors the user provided port', async ({ runtime }) => {
   if (result.error) throw new Error(result.error);
 
   const html = result.contents;
-  assert.ok(/window\.HMR_WEBSOCKET_URL = window\.HMR_WEBSOCKET_URL || 'ws:\/\/localhost:5555'/.test(html), "Uses the user's websocket port");
+  assert.ok(/window\.HMR_WEBSOCKET_PORT = 5555/.test(html), "Uses the user's websocket port");
 });
 
 HMR('Does not override script added by the user', async ({ runtime }) => {
@@ -25,8 +25,8 @@ HMR('Does not override script added by the user', async ({ runtime }) => {
 
   const html = result.contents;
 
-  assert.ok(!/window\.HMR_WEBSOCKET_URL = 'ws:\/\/localhost:3333'/.test(html), 'Users script included');
-  assert.ok(/window\.HMR_WEBSOCKET_URL = window\.HMR_WEBSOCKET_URL || 'ws:\/\/localhost:5555'/.test(html), 'Our script defers to the port already being set');
+  assert.ok(/window\.HMR_WEBSOCKET_URL = 'wss:\/\/example.com:3333'/.test(html), "User's script included");
+  assert.ok(/window\.HMR_WEBSOCKET_PORT = 5555/.test(html), 'Ignored when window.HMR_WEBSOCKET_URL set');
 });
 
 HMR.run();


### PR DESCRIPTION
## Changes

Follow up of #436

Snowpack [already has great handling](https://github.com/snowpackjs/snowpack/blob/680272eb19c43ef88f9d83e436e7131444c53407/snowpack/assets/hmr-client.js#L49-L56) for `HMR_WEBSOCKET_URL`. Only thing we have to do is just setting `HMR_WEBSOCKET_PORT`. AFAIS Snowpack [also does that](https://github.com/snowpackjs/snowpack/blob/a089d86a0095007e0309c0efabfc0a60245a3491/snowpack/src/build/build-import-proxy.ts#L118) at some point.

## Testing

Also test case description wasn't matching with code in `manual.astro`. I fixed it with updated code.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
