### PR TITLE
Add repository remotes for all astro packages

### DIFF
--- a/.changeset/eleven-cats-tan.md
+++ b/.changeset/eleven-cats-tan.md
@@ -1,0 +1,8 @@
+---
+'astro': patch
+'@astrojs/parser': patch
+'@astrojs/prism': patch
+'@astrojs/markdown-support': patch
+---
+
+Add repository key to all package.json

--- a/.changeset/rare-weeks-explode.md
+++ b/.changeset/rare-weeks-explode.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Add repository key to package.json for create-astro

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "root",
   "version": "0.0.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowpackjs/astro.git"
+  },
   "scripts": {
     "release": "yarn build && yarn changeset publish",
     "benchmark": "yarn workspace astro run benchmark",

--- a/packages/astro-parser/package.json
+++ b/packages/astro-parser/package.json
@@ -8,7 +8,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snowpackjs/astro/tree/main/packages/astro-parser"
+    "url": "https://github.com/snowpackjs/astro.git",
+    "directory": "packages/astro-parser"
   },
   "files": [
     "dist"

--- a/packages/astro-parser/package.json
+++ b/packages/astro-parser/package.json
@@ -6,6 +6,10 @@
   "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowpackjs/astro/tree/main/packages/astro-parser"
+  },
   "files": [
     "dist"
   ],

--- a/packages/astro-prism/package.json
+++ b/packages/astro-prism/package.json
@@ -5,7 +5,8 @@
   "main": "index.mjs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snowpackjs/astro/tree/main/packages/astro-prism"
+    "url": "https://github.com/snowpackjs/astro.git",
+    "directory": "packages/astro-prism"
   },
   "scripts": {
     "build": "echo 'build'",

--- a/packages/astro-prism/package.json
+++ b/packages/astro-prism/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.1",
   "description": "IYKYK",
   "main": "index.mjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowpackjs/astro/tree/main/packages/astro-prism"
+  },
   "scripts": {
     "build": "echo 'build'",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "type": "module",
   "types": "./dist/types",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowpackjs/astro/tree/main/packages/astro"
+  },
   "exports": {
     ".": "./astro.mjs",
     "./package.json": "./package.json",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -7,7 +7,8 @@
   "types": "./dist/types",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snowpackjs/astro/tree/main/packages/astro"
+    "url": "https://github.com/snowpackjs/astro.git",
+    "directory": "packages/astro"
   },
   "exports": {
     ".": "./astro.mjs",

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -2,6 +2,11 @@
   "name": "create-astro",
   "version": "0.3.2",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowpackjs/astro.git",
+    "directory": "packages/create-astro"
+  },
   "exports": {
     ".": "./create-astro.js"
   },

--- a/packages/markdown-support/package.json
+++ b/packages/markdown-support/package.json
@@ -5,7 +5,8 @@
   "type": "commonjs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snowpackjs/astro/tree/main/packages/markdown-support"
+    "url": "https://github.com/snowpackjs/astro.git",
+    "directory": "packages/markdown-support"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/markdown-support/package.json
+++ b/packages/markdown-support/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.1",
   "main": "./dist/index.js",
   "type": "commonjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowpackjs/astro/tree/main/packages/markdown-support"
+  },
   "exports": {
     ".": "./dist/index.js"
   },


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

Adds the git remote URL for each package to their respective package.json's so that services like renovatebot and dependabot can find them.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
