### PR TITLE
docs: fixed ascii based folder strucure in dev.md

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -29,8 +29,11 @@ For any URL you visit that doesn't have a corresponding page, the `400.astro` fi
 
 This is a custom **500** status code page. You can add this route by adding a page component to your `src/pages` folder:
 
-```astro
-├── src/ │ ├── components/ │ └── pages/ │ └── 500.astro
+```
+├── src/ 
+│   ├── components/ 
+│   └── pages/ 
+│       └── 500.astro
 ```
 
 This page is used any time an error occurs in the dev server.


### PR DESCRIPTION
## Changes

- Fixed docs (docs/dev.md)
- Before
    ![image](https://user-images.githubusercontent.com/6815560/122184547-f202d980-cea9-11eb-99c4-888a5a9a47e1.png)
- After
   <img width="281" alt="Screenshot 2021-06-16 at 1 52 19 PM" src="https://user-images.githubusercontent.com/6815560/122184675-1363c580-ceaa-11eb-843f-6503eac2a9fe.png">


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
NA 

## Docs
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
