### PR TITLE
Prevent HMR client from being part of build output

### DIFF
--- a/packages/astro/snowpack-plugin.cjs
+++ b/packages/astro/snowpack-plugin.cjs
@@ -5,7 +5,7 @@ const transformPromise = import('./dist/compiler/index.js');
 const DEFAULT_HMR_PORT = 12321;
 
 /** @type {import('snowpack').SnowpackPluginFactory<any>} */
-module.exports = (snowpackConfig, { resolvePackageUrl, renderers, astroConfig } = {}) => {
+module.exports = (snowpackConfig, { resolvePackageUrl, renderers, astroConfig, mode } = {}) => {
   let hmrPort = DEFAULT_HMR_PORT;
   return {
     name: 'snowpack-astro',
@@ -58,6 +58,7 @@ ${contents}`;
       const compileOptions = {
         astroConfig,
         hmrPort,
+        mode,
         resolvePackageUrl,
         renderers,
       };

--- a/packages/astro/src/compiler/transform/head.ts
+++ b/packages/astro/src/compiler/transform/head.ts
@@ -5,7 +5,8 @@ import type { TemplateNode } from '@astrojs/parser';
 export default function (opts: TransformOptions): Transformer {
   let head: TemplateNode;
   let hasComponents = false;
-  let isHmrEnabled = typeof opts.compileOptions.hmrPort !== 'undefined';
+  let isHmrEnabled = typeof opts.compileOptions.hmrPort !== 'undefined' &&
+    opts.compileOptions.mode === 'development';
 
   return {
     visitors: {

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -313,7 +313,7 @@ const DEFAULT_RENDERERS = ['@astrojs/renderer-vue', '@astrojs/renderer-svelte', 
 
 /** Create a new Snowpack instance to power Astro */
 async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackOptions) {
-  const { projectRoot, pages: pagesRoot, renderers = DEFAULT_RENDERERS } = astroConfig;
+  const { projectRoot, renderers = DEFAULT_RENDERERS } = astroConfig;
   const { mode, resolvePackageUrl } = options;
 
   const frontendPath = new URL('./frontend/', import.meta.url);
@@ -326,9 +326,11 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
     renderers?: { name: string; client: string; server: string }[];
     astroConfig: AstroConfig;
     hmrPort?: number;
+    mode: RuntimeMode;
   } = {
     astroConfig,
     resolvePackageUrl,
+    mode,
   };
 
   const mountOptions = {


### PR DESCRIPTION
Fixes #463

## Changes

Passes `mode` through, and only attaches HMR client in development mode.

## Testing

Added a test.

## Docs

N/A
