### PR TITLE
feat(#455): improve error logging inside of expressions

### DIFF
--- a/packages/astro/src/compiler/utils.ts
+++ b/packages/astro/src/compiler/utils.ts
@@ -2,3 +2,87 @@
 export function isComponentTag(tag: string) {
   return /^[A-Z]/.test(tag) || /^[a-z]+\./.test(tag);
 }
+
+export interface Position {
+  line: number;
+  character: number;
+}
+
+/** Clamps a number between min and max */
+export function clamp(num: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, num));
+}
+
+/**
+ * Get the line and character based on the offset
+ * @param offset The index of the position
+ * @param text The text for which the position should be retrived
+ */
+export function positionAt(offset: number, text: string): Position {
+  offset = clamp(offset, 0, text.length);
+
+  const lineOffsets = getLineOffsets(text);
+  let low = 0;
+  let high = lineOffsets.length;
+  if (high === 0) {
+    return { line: 0, character: offset };
+  }
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (lineOffsets[mid] > offset) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  // low is the least x for which the line offset is larger than the current offset
+  // or array.length if no line offset is larger than the current offset
+  const line = low - 1;
+  return { line, character: offset - lineOffsets[line] };
+}
+
+/**
+ * Get the offset of the line and character position
+ * @param position Line and character position
+ * @param text The text for which the offset should be retrived
+ */
+export function offsetAt(position: Position, text: string): number {
+  const lineOffsets = getLineOffsets(text);
+
+  if (position.line >= lineOffsets.length) {
+    return text.length;
+  } else if (position.line < 0) {
+    return 0;
+  }
+
+  const lineOffset = lineOffsets[position.line];
+  const nextLineOffset = position.line + 1 < lineOffsets.length ? lineOffsets[position.line + 1] : text.length;
+
+  return clamp(nextLineOffset, lineOffset, lineOffset + position.character);
+}
+
+/** Get the offset of all lines */
+function getLineOffsets(text: string) {
+  const lineOffsets = [];
+  let isLineStart = true;
+
+  for (let i = 0; i < text.length; i++) {
+    if (isLineStart) {
+      lineOffsets.push(i);
+      isLineStart = false;
+    }
+    const ch = text.charAt(i);
+    isLineStart = ch === '\r' || ch === '\n';
+    if (ch === '\r' && i + 1 < text.length && text.charAt(i + 1) === '\n') {
+      i++;
+    }
+  }
+
+  if (isLineStart && text.length > 0) {
+    lineOffsets.push(text.length);
+  }
+
+  return lineOffsets;
+}


### PR DESCRIPTION
## Changes

Closes #455. Previously, errors inside of expressions would fail cryptically. This adds much better error handling and a code frame.

**Before**
<img width="1176" alt="Screen Shot 2021-06-16 at 4 01 33 PM" src="https://user-images.githubusercontent.com/7118177/122293099-4a42d700-cebc-11eb-9e65-f12065e8af01.png">

**After**
<img width="1174" alt="Screen Shot 2021-06-16 at 4 00 38 PM" src="https://user-images.githubusercontent.com/7118177/122293120-4fa02180-cebc-11eb-857e-c99ffe0d2f07.png">


## Testing

Tested manually since we aren't really testing the logger output.

## Docs

DX enhancement, no docs needed
