### PR TITLE
Update the shape of data provided by `Astro.fetchContent("./*.md")`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,12 +27,22 @@ const data = Astro.fetchContent('../pages/post/*.md'); // returns an array of po
 
 `.fetchContent()` only takes one parameter: a relative URL glob of which local files you’d like to import. Currently only `*.md` files are supported. It’s synchronous, and returns an array of items of type:
 
-```
+```js
 {
-  url: string;     // the URL of this item (if it’s in pages/)
-  content: string; // the HTML of this item
-  // frontmatter data expanded here
-}[];
+   /** frontmatter from the post.. example frontmatter:
+    title: '',
+    tag: '',
+    date: '',
+    image: '',
+    author: '',
+    description: '',
+   **/
+    astro: {
+      headers: [], // TODO: document what this means
+      source: '' // raw source of the markdown file
+    },
+    url: '' // the rendered path
+  }[]
 ```
 
 #### `request`


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.
- Docs change

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Docs only change.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
- Documents the shape of data returned by Astro.fetchContent when used with markdown, closes #367 
- `{ astro.headers[]f }` still needs explanation since I haven't figured out what it will return, since it's been empty when I've printed it out.