### PR TITLE
Fix README header aspect ratio

### DIFF
--- a/.changeset/eight-garlics-rescue.md
+++ b/.changeset/eight-garlics-rescue.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed README header aspect ratio

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/snowpackjs/astro/blob/main/assets/social/banner.png?raw=true" width="100%" height="50%" />
+<img src="https://github.com/snowpackjs/astro/blob/main/assets/social/banner.png?raw=true" />
 
 **Astro** is a _fresh but familiar_ approach to building websites. Astro combines decades of proven performance best practices with the DX improvements of the component-oriented era. Use your favorite JavaScript framework and automatically ship the bare-minimum amount of JavaScript—by default. 
 

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/snowpackjs/astro/blob/main/assets/social/banner.png?raw=true" alt="Astro" width="838" height="420" >
+![Astro](/assets/social/banner.png?raw=true)
 
 **Astro** is a _fresh but familiar_ approach to building websites. Astro combines decades of proven performance best practices with the DX improvements of the component-oriented era. Use your favorite JavaScript framework and automatically ship the bare-minimum amount of JavaScript—by default. 
 

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -1,4 +1,4 @@
-![Astro](/assets/social/banner.png?raw=true)
+<img src="https://github.com/snowpackjs/astro/blob/main/assets/social/banner.png?raw=true" width="100%" height="50%" />
 
 **Astro** is a _fresh but familiar_ approach to building websites. Astro combines decades of proven performance best practices with the DX improvements of the component-oriented era. Use your favorite JavaScript framework and automatically ship the bare-minimum amount of JavaScript—by default. 
 


### PR DESCRIPTION
## Changes

Just fixing the README header:

1. Preserves aspect ratio on mobile.
2. Header is served from same branch. If image gets changed in a branch, the header in that branch gets updated, too.

## Testing

| Before | After |
| --- | --- |
| ![IMG_A04ADB39D28C-1](https://user-images.githubusercontent.com/31006608/122431240-919c9680-cf94-11eb-8a50-1f3aeb479543.jpeg) | ![IMG_5A2E805D6A76-1](https://user-images.githubusercontent.com/31006608/122431297-9eb98580-cf94-11eb-9050-7f1c389e0b91.jpeg) |

## Docs

No docs changed
