### PR TITLE
DOCS: Update collections.md

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -115,7 +115,7 @@ export let collection: any;
 export async function createCollection() {
   const allPokemonResponse = await fetch(`https://pokeapi.co/api/v2/pokemon?limit=150`);
   const allPokemonResult = await allPokemonResponse.json();
-  const allPokemon = allPokemonResult.result;
+  const allPokemon = allPokemonResult.results;
   const allLetters = ['a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'];
   return {
     // `routes` defines the total collection of routes as `params` data objects.


### PR DESCRIPTION
Very minor typo in the example code pulling results out of the `pokeapi` response

## Changes

Docs change only, noticed when I tried running the exact code locally that `pokeapi.co` returns the data in an array named `results` rather than `result` 

## Testing

Hit the same [pokeapi endpoint](https://pokeapi.co/api/v2/pokemon?limit=150) in a browser to confirm the prop is named `results`

## Docs

Yes!  Only public docs were updated
