### PR TITLE
Add @types/prettier to astro-prettier-plugin

### DIFF
--- a/.changeset/late-badgers-accept.md
+++ b/.changeset/late-badgers-accept.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Add @types/prettier for type support

--- a/tools/prettier-plugin-astro/package.json
+++ b/tools/prettier-plugin-astro/package.json
@@ -9,7 +9,10 @@
     "build": "echo 'build'"
   },
   "dependencies": {
-    "prettier": "^2.2.1",
-    "@astrojs/parser": "^0.13.3"
+    "@astrojs/parser": "^0.13.3",
+    "prettier": "^2.2.1"
+  },
+  "devDependencies": {
+    "@types/prettier": "^2.2.1"
   }
 }


### PR DESCRIPTION
## Changes

- Adds `@types/prettier` to the `devDependencies` so that typescript can find the correct types.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
- package added only