### PR TITLE
Fix keyboard untargetable on theme switcher

### DIFF
--- a/examples/docs/public/index.css
+++ b/examples/docs/public/index.css
@@ -224,7 +224,8 @@ button:hover {
   border-radius: 99em;
   background-color: var(--theme-bg);
 }
-#theme-toggle:focus-within {
+
+#theme-toggle > label:focus-within {
   outline: 2px solid transparent;
   box-shadow: 0 0 0 0.08em var(--theme-accent), 0 0 0 0.12em white;
 }


### PR DESCRIPTION
## Changes

Currently the theme switcher in the `example/docs` starter isn't tab targetable, made a small change so that keyboard users can navigate to theme switching.

Before:
![toggle](https://user-images.githubusercontent.com/12174733/122451758-8175be80-cf76-11eb-9e36-b1fb5acae21f.gif)
Previously, you could only tab to the containing div of the radio group, but not into it.

After:
![newtoggle](https://user-images.githubusercontent.com/12174733/122451780-876b9f80-cf76-11eb-84e0-ee92a79ca6d0.gif)
After the change, you able to tab target into the radio group and arrow key navigate between theme choices

## Docs

N/A
