### PR TITLE
Allow renderers configuration to update

### DIFF
--- a/packages/astro/snowpack-plugin.cjs
+++ b/packages/astro/snowpack-plugin.cjs
@@ -46,6 +46,10 @@ ${contents}`;
         return result;
       }
     },
+    fileChanged(fileLoc) {
+      this.markChanged('astro/runtime/config.js');
+      configChangedCallback();
+    },
     config(snowpackConfig) {
       if(!isNaN(snowpackConfig.devOptions.hmrPort)) {
         hmrPort = snowpackConfig.devOptions.hmrPort;

--- a/packages/astro/snowpack-plugin.cjs
+++ b/packages/astro/snowpack-plugin.cjs
@@ -4,8 +4,22 @@ const transformPromise = import('./dist/compiler/index.js');
 
 const DEFAULT_HMR_PORT = 12321;
 
-/** @type {import('snowpack').SnowpackPluginFactory<any>} */
-module.exports = (snowpackConfig, { resolvePackageUrl, renderers, astroConfig, mode } = {}) => {
+/**
+ * @typedef {Object} PluginOptions - creates a new type named 'SpecialType'
+ * @prop {import('./src/config_manager').ConfigManager} configManager
+ * @prop {'development' | 'production'} mode
+ */
+
+/**
+ * @type {import('snowpack').SnowpackPluginFactory<PluginOptions>}
+ */
+module.exports = (snowpackConfig, options = {}) => {
+  const {
+    resolvePackageUrl,
+    astroConfig,
+    configManager,
+    mode
+  } = options;
   let hmrPort = DEFAULT_HMR_PORT;
   return {
     name: 'snowpack-astro',
@@ -14,41 +28,19 @@ module.exports = (snowpackConfig, { resolvePackageUrl, renderers, astroConfig, m
       input: ['.astro', '.md'],
       output: ['.js', '.css'],
     },
-    /** 
-      * This injects our renderer plugins to the Astro runtime (as a bit of a hack).
-      *
-      * In a world where Snowpack supports virtual files, this won't be necessary and
-      * should be refactored to a virtual file that is imported by the runtime.
-      *
-      * Take a look at `/src/frontend/__astro_component.ts`. It relies on both
-      * `__rendererSources` and `__renderers` being defined, so we're creating those here.
-      *
-      * The output of this is the following (or something very close to it):
-      *
-      * ```js
-      * import * as __renderer_0 from '/_snowpack/link/packages/renderers/vue/index.js';
-      * import * as __renderer_1 from '/_snowpack/link/packages/renderers/svelte/index.js';
-      * import * as __renderer_2 from '/_snowpack/link/packages/renderers/preact/index.js';
-      * import * as __renderer_3 from '/_snowpack/link/packages/renderers/react/index.js';
-      * let __rendererSources = ["/_snowpack/link/packages/renderers/vue/client.js", "/_snowpack/link/packages/renderers/svelte/client.js", "/_snowpack/link/packages/renderers/preact/client.js", "/_snowpack/link/packages/renderers/react/client.js"];
-      * let __renderers = [__renderer_0, __renderer_1, __renderer_2, __renderer_3];
-      * // the original file contents
-      * ```
-      */
     async transform({contents, id, fileExt}) {
-      if (fileExt === '.js' && /__astro_component\.js/g.test(id)) {
-        const rendererServerPackages = renderers.map(({ server }) => server);
-        const rendererClientPackages = await Promise.all(renderers.map(({ client }) => resolvePackageUrl(client)));
-        const result = `${rendererServerPackages.map((pkg, i) => `import __renderer_${i} from "${pkg}";`).join('\n')}
-let __rendererSources = [${rendererClientPackages.map(pkg => `"${pkg}"`).join(', ')}];
-let __renderers = [${rendererServerPackages.map((_, i) => `__renderer_${i}`).join(', ')}];
-${contents}`;
-        return result;
+      if(configManager.isConfigModule(fileExt, id)) {
+        configManager.configModuleId = id;
+        const source = await configManager.buildSource(contents);
+        return source;
       }
     },
-    fileChanged(fileLoc) {
-      this.markChanged('astro/runtime/config.js');
-      configChangedCallback();
+    onChange({ filePath }) {
+      // If the astro.config.mjs file changes, mark the generated config module as changed.
+      if(configManager.isAstroConfig(filePath) && configManager.configModuleId) {
+        this.markChanged(configManager.configModuleId);
+        configManager.markDirty();
+      }
     },
     config(snowpackConfig) {
       if(!isNaN(snowpackConfig.devOptions.hmrPort)) {
@@ -59,12 +51,13 @@ ${contents}`;
       const { compileComponent } = await transformPromise;
       const projectRoot = snowpackConfig.root;
       const contents = await readFile(filePath, 'utf-8');
+
+      /** @type {import('./src/@types/compiler').CompileOptions} */
       const compileOptions = {
         astroConfig,
         hmrPort,
         mode,
         resolvePackageUrl,
-        renderers,
       };
       const result = await compileComponent(contents, { compileOptions, filename: filePath, projectRoot });
       const output = {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -176,3 +176,16 @@ export interface ComponentInfo {
 }
 
 export type Components = Map<string, ComponentInfo>;
+
+type AsyncRendererComponentFn<U> = (
+  Component: any,
+  props: any,
+  children: string | undefined
+) => Promise<U>;
+
+export interface Renderer {
+  check: AsyncRendererComponentFn<boolean>;
+  renderToStaticMarkup: AsyncRendererComponentFn<{
+    html: string;
+  }>;
+}

--- a/packages/astro/src/config_manager.ts
+++ b/packages/astro/src/config_manager.ts
@@ -1,0 +1,140 @@
+import type { ServerRuntime as SnowpackServerRuntime } from 'snowpack';
+import type { AstroConfig } from './@types/astro';
+import { posix as path } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import resolve from 'resolve';
+import { loadConfig } from './config.js';
+
+type RendererSnowpackPlugin = string | [string, any] | undefined;
+
+interface RendererInstance {
+  name: string;
+  snowpackPlugin: RendererSnowpackPlugin;
+  client: string;
+  server: string;
+}
+
+const CONFIG_MODULE_BASE_NAME = '__astro_config.js';
+const CONFIG_MODULE_URL = `/_astro_frontend/${CONFIG_MODULE_BASE_NAME}`;
+
+const DEFAULT_RENDERERS = [
+  '@astrojs/renderer-vue',
+  '@astrojs/renderer-svelte',
+  '@astrojs/renderer-react',
+  '@astrojs/renderer-preact'
+];
+
+export class ConfigManager {
+  private state: 'initial' | 'dirty' | 'clean' = 'initial';
+  public snowpackRuntime: SnowpackServerRuntime | null = null;
+  public configModuleId: string | null = null;
+  private rendererNames!: string[];
+  private version = 1;
+
+  constructor(
+    private astroConfig: AstroConfig,
+    private resolvePackageUrl: (pkgName: string) => Promise<string>,
+  ) {
+    this.setRendererNames(this.astroConfig);
+  }
+
+  markDirty() {
+    this.state = 'dirty';
+  }
+
+  async update() {
+    if(this.needsUpdate() && this.snowpackRuntime) {
+      // astro.config.mjs has changed, reload it.
+      if(this.state === 'dirty') {
+        const version = this.version++;
+        const astroConfig = await loadConfig(this.astroConfig.projectRoot.pathname, `astro.config.mjs?version=${version}`);
+        this.setRendererNames(astroConfig);
+      }
+
+      await this.importModule(this.snowpackRuntime);
+      this.state = 'clean';
+    }
+  }
+
+  isConfigModule(fileExt: string, filename: string) {
+    return fileExt === '.js' && filename.endsWith(CONFIG_MODULE_BASE_NAME);
+  }
+
+  isAstroConfig(filename: string) {
+    const { projectRoot } = this.astroConfig;
+    return new URL('./astro.config.mjs', projectRoot).pathname === filename;
+  }
+
+  async buildRendererInstances(): Promise<RendererInstance[]> {
+    const { projectRoot } = this.astroConfig;
+    const rendererNames = this.rendererNames;
+    const resolveDependency = (dep: string) => resolve.sync(dep, { basedir: fileURLToPath(projectRoot) });
+
+    const rendererInstances = (
+      await Promise.all(
+        rendererNames.map((rendererName) => {
+          const entrypoint = pathToFileURL(resolveDependency(rendererName)).toString();
+          return import(entrypoint);
+        })
+      )
+    ).map(({ default: raw }, i) => {
+      const { name = rendererNames[i], client, server, snowpackPlugin: snowpackPluginName, snowpackPluginOptions } = raw;
+  
+      if (typeof client !== 'string') {
+        throw new Error(`Expected "client" from ${name} to be a relative path to the client-side renderer!`);
+      }
+  
+      if (typeof server !== 'string') {
+        throw new Error(`Expected "server" from ${name} to be a relative path to the server-side renderer!`);
+      }
+  
+      let snowpackPlugin: RendererSnowpackPlugin;
+      if (typeof snowpackPluginName === 'string') {
+        if (snowpackPluginOptions) {
+          snowpackPlugin = [resolveDependency(snowpackPluginName), snowpackPluginOptions];
+        } else {
+          snowpackPlugin = resolveDependency(snowpackPluginName);
+        }
+      } else if (snowpackPluginName) {
+        throw new Error(`Expected the snowpackPlugin from ${name} to be a "string" but encountered "${typeof snowpackPluginName}"!`);
+      }
+  
+      return {
+        name,
+        snowpackPlugin,
+        client: path.join(name, raw.client),
+        server: path.join(name, raw.server),
+      };
+    });
+
+    return rendererInstances;
+  }
+
+  async buildSource(contents: string): Promise<string> {
+    const renderers = await this.buildRendererInstances();
+    const rendererServerPackages = renderers.map(({ server }) => server);
+    const rendererClientPackages = await Promise.all(renderers.map(({ client }) => this.resolvePackageUrl(client)));
+    const result = /* js */ `${rendererServerPackages.map((pkg, i) => `import __renderer_${i} from "${pkg}";`).join('\n')}
+
+import { setRenderers } from 'astro/dist/internal/__astro_component.js';
+
+let rendererSources = [${rendererClientPackages.map(pkg => `"${pkg}"`).join(', ')}];
+let renderers = [${rendererServerPackages.map((_, i) => `__renderer_${i}`).join(', ')}];
+
+${contents}
+`;
+    return result;
+  }
+
+  needsUpdate(): boolean {
+    return this.state === 'initial' || this.state === 'dirty';
+  }
+
+  private setRendererNames(astroConfig: AstroConfig) {
+    this.rendererNames = astroConfig.renderers || DEFAULT_RENDERERS;
+  }
+
+  private async importModule(snowpackRuntime: SnowpackServerRuntime): Promise<void> {
+    await snowpackRuntime!.importModule(CONFIG_MODULE_URL);
+  }
+}

--- a/packages/astro/src/frontend/__astro_config.ts
+++ b/packages/astro/src/frontend/__astro_config.ts
@@ -1,4 +1,4 @@
-import { setRenderers } from 'astro/dist/internal/__astro_component.js';
+declare function setRenderers(sources: string[], renderers: any[]): void;
 
 declare let rendererSources: string[];
 declare let renderers: any[];

--- a/packages/astro/src/internal/__astro_component.ts
+++ b/packages/astro/src/internal/__astro_component.ts
@@ -7,22 +7,13 @@ import * as astro from './renderer-astro';
 // see https://github.com/remcohaszing/estree-util-value-to-estree#readme
 const serialize = (value: Value) => generate(valueToEstree(value));
 
-/**
- * These values are dynamically injected by Snowpack.
- * See comment in `snowpack-plugin.cjs`!
- *
- * In a world where Snowpack supports virtual files, this won't be necessary.
- * It would ideally look something like:
- *
- * ```ts
- * import { __rendererSources, __renderers } from "virtual:astro/runtime"
- * ```
- */
-declare let __rendererSources: string[];
-declare let __renderers: any[];
+let rendererSources = [];
+let renderers = [];
 
-__rendererSources = ['', ...__rendererSources];
-__renderers = [astro, ...__renderers];
+export function setRenderers(_rendererSources: string[], _renderers: any) {
+  rendererSources = [''].concat(_rendererSources);
+  renderers = [astro].concat(_renderers);
+}
 
 const rendererCache = new WeakMap();
 

--- a/packages/astro/src/runtime/config.ts
+++ b/packages/astro/src/runtime/config.ts
@@ -1,0 +1,6 @@
+import { setRenderers } from 'astro/dist/internal/__astro_component.js';
+
+declare let rendererSources: string[];
+declare let renderers: any[];
+
+setRenderers(rendererSources, renderers);


### PR DESCRIPTION
Fixes #414

## Changes

This moves the logic that handles renders to the `config_manager.ts`. This file exists to handle any configuration changes.

How it works is, the ConfigManager creates the dynamically generated `__astro_config.js` module. When the astro.config.mjs file changes it makes itself as dirty, and the next time a page load occurs it grabs a new version of the astro config and creates that __astro_config.js module.

It's a coordination between this ConfigManager and the snowpack plugin that makes this all work.

## Testing

This was tested manually by loading up a dev server and changing the renderers in an example app. We don't currently have a way to unit test file changes in Astro.

## Docs

N/A, this is expected user behavior.