### PR TITLE
Fixes #251 closing the parent tag if the component rendering led to an error

### DIFF
--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -609,6 +609,7 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
               paren++;
               buffers[curr] += `h(${wrapper}, ${attributes ? generateAttributes(attributes) : 'null'}`;
             } catch (err) {
+              paren--;
               // handle errors in scope with filename
               const rel = filename.replace(astroConfig.projectRoot.pathname, '');
               // TODO: return actual codeframe here


### PR DESCRIPTION
If a component is not rendered because it doesn't exist the codegen still adds a closing parenthesis to the render function and therefore closes the last parent Element.

## Changes

Adds additional marker for the code generator to know if a component was rendered and therefore isn't accidently closing the parent tag if not.

## Testing

<!-- How can a reviewer test your code themselves? -->

- [x] Tests are passing
- [x] should fix the test of issue #251 

