### PR TITLE
Skip scoped `astro-*` class if Astro component has no `<style>`

### DIFF
--- a/.changeset/happy-cougars-scream.md
+++ b/.changeset/happy-cougars-scream.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+#472 Do not inject `astro-*` scoped class unless it is actually used

--- a/.changeset/happy-cougars-scream.md
+++ b/.changeset/happy-cougars-scream.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-#472 Do not inject `astro-*` scoped class unless it is actually used
+Fix [472](https://github.com/snowpackjs/astro/issues/472) by not injecting `astro-*` scoped class unless it is actually used

--- a/packages/astro/test/astro-styles-ssr.test.js
+++ b/packages/astro/test/astro-styles-ssr.test.js
@@ -126,4 +126,11 @@ StylesSSR('Astro scoped styles', async ({ runtime }) => {
   assert.match(cssMinify(css.toString()), `.blue.${scopedClass}{color:powderblue}.color\\:blue.${scopedClass}{color:powderblue}.visible.${scopedClass}{display:block}`);
 });
 
+StylesSSR('Astro scoped styles skipped without <style>', async ({ runtime }) => {
+  const result = await runtime.load('/');
+  const $ = doc(result.contents);
+
+  assert.type($('#no-scope').attr('class'), 'undefined', `Astro component without <style> should not include scoped class`)
+});
+
 StylesSSR.run();

--- a/packages/astro/test/fixtures/astro-styles-ssr/src/components/AstroNone.astro
+++ b/packages/astro/test/fixtures/astro-styles-ssr/src/components/AstroNone.astro
@@ -1,0 +1,1 @@
+<div id="no-scope">360</div>

--- a/packages/astro/test/fixtures/astro-styles-ssr/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-styles-ssr/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import AstroComponent from '../components/Astro.astro';
+import AstroComponentNone from '../components/AstroNone.astro';
 import ReactCSS from '../components/ReactCSS.jsx';
 import ReactModules from '../components/ReactModules.jsx';
 import VueCSS from '../components/VueCSS.vue';
@@ -22,6 +23,7 @@ import SvelteScoped from '../components/SvelteScoped.svelte';
   <body>
     <div class="wrapper">
       <AstroComponent />
+      <AstroComponentNone />
       <ReactCSS />
       <ReactModules />
       <VueCSS />


### PR DESCRIPTION
## Changes

This is a partial solution for #472. Instead of injecting the `astro-*` class into every Astro component, this only injects it for components that use `<style>`.

## Testing

Added a test in `astro-styles-ssr`. Maybe not the best place? It seemed like the most relevant area.

## Docs

Nope, optimization only.