### PR TITLE
Removes snowpack warning suppression

### DIFF
--- a/.changeset/silly-bees-flash.md
+++ b/.changeset/silly-bees-flash.md
@@ -1,0 +1,8 @@
+---
+'astro': patch
+'@astrojs/renderer-preact': patch
+'@astrojs/renderer-react': patch
+'@astrojs/renderer-vue': patch
+---
+
+Allows renderers to provide knownEntrypoint config values

--- a/docs/renderers.md
+++ b/docs/renderers.md
@@ -100,6 +100,7 @@ export default {
   server: './server.js', // relative path to the server entrypoint
   snowpackPlugin: '@snowpack/plugin-xxx', // optional, the name of a snowpack plugin to inject
   snowpackPluginOptions: { example: true }, // optional, any options to be forwarded to the snowpack plugin
+  knownEntrypoint: ['framework'] // optional, entrypoint modules that will be used by compiled source
 };
 ```
 

--- a/packages/astro/snowpack-plugin.cjs
+++ b/packages/astro/snowpack-plugin.cjs
@@ -23,7 +23,13 @@ module.exports = (snowpackConfig, options = {}) => {
   let hmrPort = DEFAULT_HMR_PORT;
   return {
     name: 'snowpack-astro',
-    knownEntrypoints: ['astro/dist/internal/h.js', 'astro/components/Prism.astro'],
+    knownEntrypoints: [
+      'astro/dist/internal/h.js',
+      'astro/components/Prism.astro',
+      'shorthash',
+      'estree-util-value-to-estree',
+      'astring'
+    ],
     resolve: {
       input: ['.astro', '.md'],
       output: ['.js', '.css'],

--- a/packages/astro/src/config_manager.ts
+++ b/packages/astro/src/config_manager.ts
@@ -12,6 +12,7 @@ interface RendererInstance {
   snowpackPlugin: RendererSnowpackPlugin;
   client: string;
   server: string;
+  knownEntrypoints: string[] | undefined;
 }
 
 const CONFIG_MODULE_BASE_NAME = '__astro_config.js';
@@ -96,6 +97,7 @@ export class ConfigManager {
         snowpackPlugin,
         client: path.join(name, raw.client),
         server: path.join(name, raw.server),
+        knownEntrypoints: raw.knownEntrypoints
       };
     });
 

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -353,7 +353,13 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
 
   // Make sure that Snowpack builds our renderer plugins
   const rendererInstances = await configManager.buildRendererInstances();
-  const knownEntrypoints = [].concat(...(rendererInstances.map((renderer) => [renderer.server, renderer.client]) as any));
+  const knownEntrypoints: string[] = [];
+  for(const renderer of rendererInstances) {
+    knownEntrypoints.push(renderer.server, renderer.client);
+    if(renderer.knownEntrypoints) {
+      knownEntrypoints.push(...renderer.knownEntrypoints);
+    }
+  }
   const rendererSnowpackPlugins = rendererInstances.filter((renderer) => renderer.snowpackPlugin).map((renderer) => renderer.snowpackPlugin) as string | [string, any];
 
   const snowpackConfig = await loadConfiguration({

--- a/packages/astro/src/snowpack-logger.ts
+++ b/packages/astro/src/snowpack-logger.ts
@@ -1,27 +1,8 @@
 import { logger as snowpackLogger } from 'snowpack';
 import { defaultLogLevel } from './logger.js';
 
-const neverWarn = new RegExp(
-  '(' +
-    /(run "snowpack init" to create a project config file.)|/.source +
-    /(Unscannable package import found.)|/.source +
-    /(Cannot call a namespace \('loadLanguages'\))|/.source +
-    /('default' is imported from external module 'node-fetch' but never used)/.source +
-    ')'
-);
-
 export function configureSnowpackLogger(logger: typeof snowpackLogger) {
-  const messageCache = new Set<string>();
-
   if (defaultLogLevel === 'debug') {
     logger.level = 'debug';
   }
-
-  logger.on('warn', (message) => {
-    // Silence this output message, since it doesn't make sense for Astro.
-    if (neverWarn.test(message)) {
-      return;
-    }
-    console.error(message);
-  });
 }

--- a/packages/renderers/renderer-preact/index.js
+++ b/packages/renderers/renderer-preact/index.js
@@ -2,4 +2,5 @@ export default {
   name: '@astrojs/renderer-preact',
   client: './client',
   server: './server',
+  knownEntrypoints: ['preact', 'preact-render-to-string']
 };

--- a/packages/renderers/renderer-react/index.js
+++ b/packages/renderers/renderer-react/index.js
@@ -2,4 +2,5 @@ export default {
   name: '@astrojs/renderer-react',
   client: './client',
   server: './server',
+  knownEntrypoints: ['react', 'react-dom/server']
 };

--- a/packages/renderers/renderer-vue/index.js
+++ b/packages/renderers/renderer-vue/index.js
@@ -3,4 +3,5 @@ export default {
   snowpackPlugin: '@snowpack/plugin-vue',
   client: './client',
   server: './server',
+  knownEntrypoints: ['vue']
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,6 +1483,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
+"@types/prettier@^2.2.1":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.0.tgz#2e8332cc7363f887d32ec5496b207d26ba8052bb"
+  integrity sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==
+
 "@types/prompts@^2.0.12":
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.0.12.tgz#5cc1557f88e4d69dad93230fff97a583006f858b"


### PR DESCRIPTION
Fixes #356

## Changes

This gets rid of the snowpack warning suppression. The main way this achieves that is by adding a `knownEntrypoints` option to the renderer interface. We use that to add the knownEntrypoints that each renderer needs.

## Testing

Manually as our existing warning unit tests have been flakey and were removed.

## Docs

Doc added for new `knownEntrypoints` option.
