### PR TITLE
Use `assert.fixture` rather than `assert.equal` 

### DIFF
--- a/tools/prettier-plugin-astro/test/astro-prettier.test.js
+++ b/tools/prettier-plugin-astro/test/astro-prettier.test.js
@@ -19,26 +19,26 @@ const getFiles = async (name) => {
 
 Prettier('can format a basic Astro file', async () => {
   const [src, out] = await getFiles('basic');
-  assert.not.equal(src, out);
+  assert.not.fixture(src, out);
 
   const formatted = format(src);
-  assert.equal(formatted, out);
+  assert.fixture(formatted, out);
 });
 
 Prettier('can format an Astro file with frontmatter', async () => {
   const [src, out] = await getFiles('frontmatter');
-  assert.not.equal(src, out);
+  assert.not.fixture(src, out);
 
   const formatted = format(src);
-  assert.equal(formatted, out);
+  assert.fixture(formatted, out);
 });
 
 Prettier('can format an Astro file with embedded JSX expressions', async () => {
   const [src, out] = await getFiles('embedded-expr');
-  assert.not.equal(src, out);
+  assert.not.fixture(src, out);
 
   const formatted = format(src);
-  assert.equal(formatted, out);
+  assert.fixture(formatted, out);
 });
 
 Prettier.run();


### PR DESCRIPTION


## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
- Change usage of `assert.equal` to `assert.fixture` so that error output is more readable, as it expects to compare two multiline strings, and formats errors with line numbers. 
- https://github.com/lukeed/uvu/blob/master/docs/api.assert.md#fixtureactual-string-expects-string-msg-message
- https://github.com/lukeed/uvu/blob/master/docs/api.assert.md#notfixtureactual-string-expects-string-msg-message

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
