### PR TITLE
fix issues uncovered by snowpack warnings

### DIFF
--- a/.changeset/wise-eels-help.md
+++ b/.changeset/wise-eels-help.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix snowpack issues uncovered by no longer hiding warnings

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -3,6 +3,7 @@ import type { ImportSpecifier, ImportDefaultSpecifier, ImportNamespaceSpecifier 
 export interface AstroConfigRaw {
   dist: string;
   projectRoot: string;
+  srcRoot: string;
   pages: string;
   public: string;
   jsx?: string;
@@ -19,6 +20,7 @@ export interface AstroConfig {
   projectRoot: URL;
   pages: URL;
   public: URL;
+  srcRoot: URL;
   renderers?: string[];
   /** Options for rendering markdown content */
   markdownOptions?: Partial<AstroMarkdownOptions>;

--- a/packages/astro/src/config.ts
+++ b/packages/astro/src/config.ts
@@ -54,6 +54,7 @@ function configDefaults(userConfig?: any): any {
   const config: any = { ...(userConfig || {}) };
 
   if (!config.projectRoot) config.projectRoot = '.';
+  if (!config.srcRoot) config.srcRoot = './src';
   if (!config.pages) config.pages = './src/pages';
   if (!config.dist) config.dist = './dist';
   if (!config.public) config.public = './public';
@@ -72,6 +73,7 @@ function normalizeConfig(userConfig: any, root: string): AstroConfig {
 
   const fileProtocolRoot = `file://${root}/`;
   config.projectRoot = new URL(config.projectRoot + '/', fileProtocolRoot);
+  config.srcRoot = new URL(config.srcRoot + '/', fileProtocolRoot);
   config.pages = new URL(config.pages + '/', fileProtocolRoot);
   config.public = new URL(config.public + '/', fileProtocolRoot);
 

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -250,6 +250,7 @@ async function load(config: RuntimeConfig, rawPathname: string | undefined): Pro
     }
 
     if (err instanceof NotFoundError && rawPathname) {
+      console.log('ERR', err);
       const fileMatch = err.toString().match(/\(([^\)]+)\)/);
       const missingFile: string | undefined = (fileMatch && fileMatch[1].replace(/^\/_astro/, '').replace(/\.proxy\.js$/, '')) || undefined;
       const distPath = path.extname(rawPathname) ? rawPathname : rawPathname.replace(/\/?$/, '/index.html');
@@ -308,7 +309,7 @@ interface CreateSnowpackOptions {
 
 /** Create a new Snowpack instance to power Astro */
 async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackOptions) {
-  const { projectRoot } = astroConfig;
+  const { projectRoot, srcRoot } = astroConfig;
   const { mode, resolvePackageUrl } = options;
 
   const frontendPath = new URL('./frontend/', import.meta.url);
@@ -335,7 +336,7 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
   const mountOptions = {
     ...(existsSync(astroConfig.public) ? { [fileURLToPath(astroConfig.public)]: '/' } : {}),
     [fileURLToPath(frontendPath)]: '/_astro_frontend',
-    [fileURLToPath(projectRoot)]: '/_astro', // must be last (greediest)
+    [fileURLToPath(srcRoot)]: '/_astro/src', // must be last (greediest)
   };
 
   // Tailwind: IDK what this does but it makes JIT work 🤷‍♂️
@@ -345,7 +346,7 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
 
   // Make sure that Snowpack builds our renderer plugins
   const rendererInstances = await configManager.buildRendererInstances();
-  const knownEntrypoints: string[] = [];
+  const knownEntrypoints: string[] = ['astro/dist/internal/__astro_component.js'];
   for (const renderer of rendererInstances) {
     knownEntrypoints.push(renderer.server, renderer.client);
     if (renderer.knownEntrypoints) {


### PR DESCRIPTION
## Changes

- In #329 we removed warnings that were being hidden from Snowpack
- this uncovered a larger issue in how Astro is using Snowpack: your entire project is mounted as a part of your website. This causes a few issues for Snowpack, most notably (noticed immediately in Discord) that Snowpack watches your `.git` directory for changes (since its mounted) and logs them to the console on every change. It also means that files like `.git/*` outside of the src directory are loadable as a part of your site.
- The intention (as I understood it) is that only `public/` and `src/` are a part of your site. Anything else is not built by Astro.
- This changes Astro to only mount the `src/` folder to the web.
**Partial change:** this is a partially implemented PR. There are some open questions below.

## Open questions

- Is `pagesRoot` a helpful config option here? I feel like `pages/` is a meaningful term that we document everywhere, so then making it configurable feels like a nit in such an opinionated tool as Astro. Instead, can we make `srcRoot` configurable and then make `${srcRoot}/pages` hardcoded? That better matches the fact that `publicRoot` is already a thing.


## Testing

- Not yet updated.

## Docs

- Not yet updated.