### PR TITLE
Update createCollection() to handle `pageSize: Infinity`

### DIFF
--- a/.changeset/shy-houses-do.md
+++ b/.changeset/shy-houses-do.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow `pageSize: Infinity` when creating a collection

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -137,7 +137,7 @@ export async function createCollection() {
     // Finally, `pageSize` and `pagination` is still on by default. Because
     // we don't want to paginate the already-grouped pages a second time, we'll
     // disable pagination.
-    pageSize: 1,
+    pageSize: Infinity,
   };
 }
 ---
@@ -179,8 +179,8 @@ export async function createCollection() {
       return allPokemon[params.index];
     },
     // Note: The default pageSize is fine because technically only one data object
-    // is ever returned per route. We can set it to "1" in this example for completeness.
-    pageSize: 1,
+    // is ever returned per route. We set it to Infinity in this example for completeness.
+    pageSize: Infinity,
   };
 }
 ---

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -153,7 +153,7 @@ async function load(config: RuntimeConfig, rawPathname: string | undefined): Pro
 
       // paginate
       if (searchResult.currentPage) {
-        const start = (searchResult.currentPage - 1) * pageSize; // currentPage is 1-indexed
+        const start = pageSize === Infinity ? 0 : (searchResult.currentPage - 1) * pageSize; // currentPage is 1-indexed
         const end = Math.min(start + pageSize, data.length);
 
         collection.start = start;

--- a/packages/astro/test/astro-collection.test.js
+++ b/packages/astro/test/astro-collection.test.js
@@ -54,4 +54,33 @@ Collections('can load remote data', async ({ runtime }) => {
   }
 });
 
+Collections('generates pages grouped by author', async ({ runtime }) => {
+  const AUTHORS_TO_TEST = [
+    {
+      id: 'author-one',
+      posts: ['one', 'three'],
+    },
+    {
+      id: 'author-two',
+      posts: ['two'],
+    },
+    {
+      id: 'author-three',
+      posts: ['nested/a'],
+    },
+  ];
+
+  for (const { id, posts } of AUTHORS_TO_TEST) {
+    const result = await runtime.load(`/grouped/${id}`);
+    if (result.error) throw new Error(result.error);
+    const $ = doc(result.contents);
+
+    assert.ok($(`#${id}`).length);
+
+    for (const post of posts) {
+      assert.ok($(`a[href="/post/${post}"]`).length);
+    }
+  }
+});
+
 Collections.run();

--- a/packages/astro/test/astro-collection.test.js
+++ b/packages/astro/test/astro-collection.test.js
@@ -83,4 +83,30 @@ Collections('generates pages grouped by author', async ({ runtime }) => {
   }
 });
 
+Collections('generates individual pages from a collection', async ({ runtime }) => {
+  const PAGES_TO_TEST = [
+    {
+      slug: 'one',
+      title: 'Post One',
+    },
+    {
+      slug: 'two',
+      title: 'Post Two',
+    },
+    {
+      slug: 'three',
+      title: 'Post Three',
+    },
+  ];
+
+  for (const { slug, title } of PAGES_TO_TEST) {
+    const result = await runtime.load(`/individual/${slug}`);
+    if (result.error) throw new Error(result.error);
+    const $ = doc(result.contents);
+
+    assert.ok($(`#${slug}`).length);
+    assert.equal($(`h1`).text(), title);
+  }
+});
+
 Collections.run();

--- a/packages/astro/test/fixtures/astro-collection/src/pages/$grouped.astro
+++ b/packages/astro/test/fixtures/astro-collection/src/pages/$grouped.astro
@@ -1,0 +1,30 @@
+---
+export let collection: any;
+
+export async function createCollection() {
+  const allPosts = Astro.fetchContent('./post/**/*.md');
+  const allAuthors = allPosts.map(p => p.author);
+  const uniqueAuthors = [...new Set(allAuthors)];
+
+  return {
+    routes: uniqueAuthors.map(author => {
+        const params = { name: author };
+        return params;
+    }),
+
+    permalink: ({ params }) => `/grouped/${params.name}`,
+
+    async data({ params }) {
+        return allPosts.filter(p => p.author === params.name)
+    },
+
+    pageSize: Infinity
+  };
+}
+---
+
+<div id={collection.params.name}>
+  {collection.data.map((post) => (
+    <a href={post.url}>{post.title}</a>
+   ))}
+</div>

--- a/packages/astro/test/fixtures/astro-collection/src/pages/$individual.astro
+++ b/packages/astro/test/fixtures/astro-collection/src/pages/$individual.astro
@@ -1,0 +1,29 @@
+---
+export let collection: any;
+
+export async function createCollection() {
+  const allPosts = Astro.fetchContent('./post/*.md');
+
+  return {
+    routes: allPosts.map((post, i) => {
+        const params = {
+          slug: post.url.replace('/post/', ''),
+          index: i
+        };
+        return params;
+    }),
+
+    permalink: ({ params }) => `/individual/${params.slug}`,
+
+    async data({ params }) {
+      return [allPosts[params.index]];
+    },
+
+    pageSize: Infinity
+  };
+}
+---
+
+<div id={collection.params.slug}>
+  <h1>{collection.data[0].title}</h1>
+</div>

--- a/packages/astro/test/fixtures/astro-collection/src/pages/post/nested/a.md
+++ b/packages/astro/test/fixtures/astro-collection/src/pages/post/nested/a.md
@@ -1,6 +1,7 @@
 ---
 title: Post A
 date: 2021-04-16 00:00:00
+author: author-three
 ---
 
 # Post A

--- a/packages/astro/test/fixtures/astro-collection/src/pages/post/one.md
+++ b/packages/astro/test/fixtures/astro-collection/src/pages/post/one.md
@@ -1,6 +1,7 @@
 ---
 title: Post One
 date: 2021-04-13 00:00:00
+author: author-one
 ---
 
 # Post One

--- a/packages/astro/test/fixtures/astro-collection/src/pages/post/three.md
+++ b/packages/astro/test/fixtures/astro-collection/src/pages/post/three.md
@@ -1,6 +1,7 @@
 ---
 title: Post Three
 date: 2021-04-15 00:00:00
+author: author-one
 ---
 
 # Post Three

--- a/packages/astro/test/fixtures/astro-collection/src/pages/post/two.md
+++ b/packages/astro/test/fixtures/astro-collection/src/pages/post/two.md
@@ -1,6 +1,7 @@
 ---
 title: Post Two
 date: 2021-04-14 00:00:00
+author: author-two
 ---
 
 # Post Two


### PR DESCRIPTION
## Changes

- Adds support for `pageSize: Infinity` when creating a collection
- Fixes #483 

## Testing

- Adds test coverage for grouping a collection by item metadata (author, tag, etc)
- Adds test coverage for creating individual pages for each item in a collection

## Docs

- Reverts the docs change that removed the references to Infinity
