### PR TITLE
add svelte extension to purge list

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -96,7 +96,7 @@ And also create a `tailwind.config.js` in your project root:
 // tailwind.config.js
 module.exports = {
   mode: 'jit',
-  purge: ['./public/**/*.html', './src/**/*.{astro,js,jsx,ts,tsx,vue}'],
+  purge: ['./public/**/*.html', './src/**/*.{astro,js,jsx,ts,tsx,vue,svelte}'],
   // more options here
 };
 ```


### PR DESCRIPTION
## Changes

This just adds `svelte` in the purged list under tailwind config

```js
// tailwind.config.js
module.exports = {
  mode: 'jit',
  purge: ['./public/**/*.html', './src/**/*.{astro,js,jsx,ts,tsx,vue,svelte}']
};

## Testing

Only docs

## Docs

Docs updated
