### PR TITLE
Always add the HMR script in dev

### DIFF
--- a/.changeset/old-buses-tell.md
+++ b/.changeset/old-buses-tell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes livereload on static pages

--- a/packages/astro/src/compiler/transform/head.ts
+++ b/packages/astro/src/compiler/transform/head.ts
@@ -123,7 +123,7 @@ export default function (opts: TransformOptions): Transformer {
         });
       }
 
-      if (isHmrEnabled && hasComponents) {
+      if (isHmrEnabled) {
         const { hmrPort } = opts.compileOptions;
         children.push(
           {

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -27,12 +27,6 @@ Basics('Sets the HMR port when dynamic components used', async ({ runtime }) => 
   assert.ok(/HMR_WEBSOCKET_PORT/.test(html), 'Sets the websocket port');
 });
 
-Basics('Does not set the HMR port when no dynamic component used', async ({ runtime }) => {
-  const result = await runtime.load('/');
-  const html = result.contents;
-  assert.ok(!/HMR_WEBSOCKET_PORT/.test(html), 'Does not set the websocket port');
-});
-
 Basics('Correctly serializes boolean attributes', async ({ runtime }) => {
   const result = await runtime.load('/');
   const html = result.contents;

--- a/packages/astro/test/astro-hmr.test.js
+++ b/packages/astro/test/astro-hmr.test.js
@@ -21,12 +21,22 @@ HMR('Honors the user provided port', async ({ runtime }) => {
 
 HMR('Does not override script added by the user', async ({ runtime }) => {
   const result = await runtime.load('/manual');
-  console.log(result.error);
+  if (result.error) throw new Error(result.error);
 
   const html = result.contents;
 
   assert.ok(/window\.HMR_WEBSOCKET_URL = 'wss:\/\/example.com:3333'/.test(html), "User's script included");
   assert.ok(/window\.HMR_WEBSOCKET_PORT = 5555/.test(html), 'Ignored when window.HMR_WEBSOCKET_URL set');
+});
+
+HMR('Adds script to static pages too', async ({ runtime }) => {
+  const result = await runtime.load('/static');
+  if (result.error) throw new Error(result.error);
+
+  const html = result.contents;
+  const $ = doc(html);
+  assert.equal($('[src="/_snowpack/hmr-client.js"]').length, 1);
+  assert.ok(/window\.HMR_WEBSOCKET_PORT/.test(html), 'websocket port added');
 });
 
 HMR.run();

--- a/packages/astro/test/fixtures/astro-hmr/src/pages/static.astro
+++ b/packages/astro/test/fixtures/astro-hmr/src/pages/static.astro
@@ -1,0 +1,12 @@
+---
+import Tour from '../components/Tour.jsx';
+---
+<html>
+<head>
+  <title>My Test</title>
+</head>
+<body>
+  <div>Hello world</div>
+  <Tour />
+</body>
+</html>


### PR DESCRIPTION
Fixes #527

## Changes

Previously we only added the HMR script on pages with dynamic components. This now adds it all the time in dev, so livereload works with astro components.

## Testing

Test added

## Docs

N/A, bug fix.
