### PR TITLE
Removed unused console.warn trap function

### DIFF
--- a/.changeset/lazy-doors-watch.md
+++ b/.changeset/lazy-doors-watch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+#528 Removes unused trapWarn function

--- a/packages/astro/src/build.ts
+++ b/packages/astro/src/build.ts
@@ -18,7 +18,7 @@ import { buildCollectionPage, buildStaticPage, getPageType } from './build/page.
 import { generateSitemap } from './build/sitemap.js';
 import { logURLStats, collectBundleStats, mapBundleStatsToURLStats } from './build/stats.js';
 import { getDistPath, stopTimer } from './build/util.js';
-import { debug, defaultLogDestination, defaultLogLevel, error, info, warn, trapWarn } from './logger.js';
+import { debug, defaultLogDestination, defaultLogLevel, error, info, warn } from './logger.js';
 import { createRuntime } from './runtime.js';
 
 const defaultLogging: LogOptions = {
@@ -71,7 +71,6 @@ export async function build(astroConfig: AstroConfig, logging: LogOptions = defa
     timer.build = performance.now();
     const pages = await allPages(pagesRoot);
     info(logging, 'build', yellow('! building pages...'));
-    const release = trapWarn(); // Vue also console.warns, this silences it.
     await Promise.all(
       pages.map(async (filepath) => {
         const buildPage = getPageType(filepath) === 'collection' ? buildCollectionPage : buildStaticPage;
@@ -88,7 +87,6 @@ export async function build(astroConfig: AstroConfig, logging: LogOptions = defa
       })
     );
     info(logging, 'build', green('✔'), 'pages built.');
-    release();
     debug(logging, 'build', `built pages [${stopTimer(timer.build)}]`);
 
     // after pages are built, build depTree

--- a/packages/astro/src/logger.ts
+++ b/packages/astro/src/logger.ts
@@ -150,16 +150,6 @@ export const logger = {
   error: error.bind(null, defaultLogOptions),
 };
 
-/** For silencing libraries that go directly to console.warn */
-export function trapWarn(cb: (...args: any[]) => void = () => {}) {
-  /* eslint-disable no-console */
-  const consoleWarn = console.warn;
-  console.warn = function (...args: any[]) {
-    cb(...args);
-  };
-  return () => (console.warn = consoleWarn);
-}
-
 function padStr(str: string, len: number) {
   const strLen = stringWidth(str);
   if (strLen > len) {


### PR DESCRIPTION
## Changes

- Removes unused trapWarn() function from loggger and all references to it

## Testing

build passed

## Docs

Bug fix only
