### PR TITLE
Fix pokemon results typo in collections docs

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -162,7 +162,7 @@ const { collection } = Astro.props;
 export async function createCollection() {
   const allPokemonResponse = await fetch(`https://pokeapi.co/api/v2/pokemon?limit=150`);
   const allPokemonResult = await allPokemonResponse.json();
-  const allPokemon = allPokemonResult.result;
+  const allPokemon = allPokemonResult.results;
   return {
     // `routes` defines the total collection of routes as data objects.
     routes: allPokemon.map((pokemon, i) => {


### PR DESCRIPTION
## Changes

Fixes a typo in the collection docs. allPokemonResult.result should be allPokemonResult.results.

## Testing

1. Add $pokemon.astro to pages.
2. Paste code from Example: Individual Pages from a Collection section in collections docs
3. Log allPokemonResult.result to show that it's undefined
4. Log allPokemonResult.results to show that it is correct

## Docs

Public documentation was updated
