### PR TITLE
Update collections.md

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -162,7 +162,7 @@ const { collection } = Astro.props;
 export async function createCollection() {
   const allPokemonResponse = await fetch(`https://pokeapi.co/api/v2/pokemon?limit=150`);
   const allPokemonResult = await allPokemonResponse.json();
-  const allPokemon = allPokemonResult.result;
+  const allPokemon = allPokemonResult.results;
   return {
     // `routes` defines the total collection of routes as data objects.
     routes: allPokemon.map((pokemon, i) => {
@@ -175,8 +175,9 @@ export async function createCollection() {
     // Luckily we had already loaded all of the data at the top of the function,
     // so we just filter the data here to group pages by first letter.
     // If you needed to fetch more data for each page, you can do that here as well.
+    // Note: data() is expected to return an array!
     async data({ params }) {
-      return allPokemon[params.index];
+      return [allPokemon[params.index]];
     },
     // Note: The default pageSize is fine because technically only one data object
     // is ever returned per route. We set it to Infinity in this example for completeness.
@@ -188,7 +189,7 @@ export async function createCollection() {
   <head>
     <title>Pokemon: {collection.params.name}</head>
   <body>
-    Who's that pokemon? It's {collection.data.name}!
+    Who's that pokemon? It's {collection.data[0].name}!
   </body>
 </html>
 ```


### PR DESCRIPTION
Updating the Individual Pages from a Collection example to fix a few typos.

- The pokemon API returns an object with an array named `results` (plural)
- `data()` needs to wrap the object in an Array
- accessing item data needs to use `collection.data[0]` to grab data from the `data()` Array

## Changes

Updates an example in the docs to match the current collections AI

## Testing

Tested locally, based on the basic `astro` starter

## Docs

Yes - the `collections.md` docs were updated
