### PR TITLE
Update README.md relative docs links

### DIFF
--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -229,17 +229,17 @@ Astro is able to render [React](https://npm.im/@astrojs/renderer-react), [Svelte
 
 👉 [**Dev Server Docs**][docs-dev]
 
-[docs-config]: ./docs/config.md
+[docs-config]: /docs/config.md
 [docs-snowpack-config]: https://www.snowpack.dev/reference/configuration
-[docs-syntax]: ./docs/syntax.md
-[docs-api]: ./docs/api.md
-[docs-renderer]: ./docs/renderers.md
-[docs-collections]: ./docs/collections.md
-[docs-markdown]: ./docs/markdown.md
-[docs-dev]: ./docs/dev.md
-[docs-styling]: ./docs/styling.md
-[example-blog]: ./examples/blog
-[fetch-content]: ./docs/api.md#fetchcontent
+[docs-syntax]: /docs/syntax.md
+[docs-api]: /docs/api.md
+[docs-renderer]: /docs/renderers.md
+[docs-collections]: /docs/collections.md
+[docs-markdown]: /docs/markdown.md
+[docs-dev]: /docs/dev.md
+[docs-styling]: /docs/styling.md
+[example-blog]: /examples/blog
+[fetch-content]: /docs/api.md#fetchcontent
 [fetch-js]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
 [remark]: https://github.com/remarkjs/remark
 [mdx]: https://mdxjs.com/
@@ -247,5 +247,5 @@ Astro is able to render [React](https://npm.im/@astrojs/renderer-react), [Svelte
 [mdn-ric]: https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
 [partial-hydration]: #-partial-hydration
 [routing]: #-routing
-[docs-cli]: ./docs/cli.md
-[docs-publishing]: ./docs/publishing.md
+[docs-cli]: /docs/cli.md
+[docs-publishing]: /docs/publishing.md


### PR DESCRIPTION
## Changes

- previously, links were broken from https://github.com/snowpackjs/astro/blob/main/packages/astro/README.md
- now they are not