### PR TITLE
Fix collections regex

### DIFF
--- a/.changeset/orange-grapes-divide.md
+++ b/.changeset/orange-grapes-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates collections to match URLs by exact template filename

--- a/packages/astro/src/search.ts
+++ b/packages/astro/src/search.ts
@@ -115,7 +115,7 @@ export function searchForPage(url: URL, astroConfig: AstroConfig): SearchResult 
 function loadCollection(url: string, astroConfig: AstroConfig): { currentPage?: number; location: PageLocation } | undefined {
   const pages = glob('**/$*.astro', { cwd: fileURLToPath(astroConfig.pages), filesOnly: true });
   for (const pageURL of pages) {
-    const reqURL = new RegExp('^/' + pageURL.replace(/\$([^/]+)\.astro/, '$1') + '/?(.*)');
+    const reqURL = new RegExp('^/' + pageURL.replace(/\$([^/]+)\.astro/, '$1') + '(?:\/(.*)|\/?$)');
     const match = url.match(reqURL);
     if (match) {
       let currentPage: number | undefined;

--- a/packages/astro/test/astro-collection.test.js
+++ b/packages/astro/test/astro-collection.test.js
@@ -109,4 +109,18 @@ Collections('generates individual pages from a collection', async ({ runtime }) 
   }
 });
 
+Collections('matches collection filename exactly', async ({ runtime }) => {
+  const result = await runtime.load('/individuals');
+  if (result.error) throw new Error(result.error);
+  const $ = doc(result.contents);
+
+  assert.ok($('#posts').length);
+  const urls = [
+    ...$('#posts a').map(function () {
+      return $(this).attr('href');
+    }),
+  ];
+  assert.equal(urls, ['/post/nested/a', '/post/three', '/post/two', '/post/one']);
+});
+
 Collections.run();

--- a/packages/astro/test/fixtures/astro-collection/src/pages/$individuals.astro
+++ b/packages/astro/test/fixtures/astro-collection/src/pages/$individuals.astro
@@ -1,0 +1,24 @@
+---
+const { collection } = Astro.props;
+
+export async function createCollection() {
+  return {
+    async data() {
+      let data = Astro.fetchContent('./post/**/*.md');
+      data.sort((a, b) => new Date(b.date) - new Date(a.date));
+      return data;
+    },
+
+    pageSize: 10
+  };
+}
+---
+
+<div id="posts">
+{collection.data.map((post) => (
+  <article>
+    <h1>{post.title}</h1>
+    <a href={post.url}>Read more</a>
+  </article>
+))}
+</div>


### PR DESCRIPTION
## Changes

This updates the RegExp used to match collection URLs to the Astro template file.

## Testing

Added test coverage to make sure URLs for `$individual.astro` and `$individuals.astro` are mapped back to the correct template file

## Docs

bug fix only
