### PR TITLE
Add ability to name code blocks

### DIFF
--- a/packages/astro/components/Prism.astro
+++ b/packages/astro/components/Prism.astro
@@ -3,7 +3,7 @@ import Prism from 'prismjs';
 import { addAstro } from '@astrojs/prism';
 import loadLanguages from 'prismjs/components/index.js';
 
-const { lang, code } = Astro.props;
+const { lang, code, filename } = Astro.props;
 
 const languageMap = new Map([
   ['ts', 'typescript']
@@ -42,4 +42,5 @@ if (grammar) {
 let className = lang ? `language-${lang}` : '';
 ---
 
-<pre class={className}><code class={className}>{html}</code></pre>
+{filename && <div class="code-filename">{filename}</div>}
+<pre class={className} data-filename={filename}><code class={className}>{html}</code></pre>

--- a/packages/astro/src/compiler/transform/prism.ts
+++ b/packages/astro/src/compiler/transform/prism.ts
@@ -57,6 +57,11 @@ export default function (module: Script): Transformer {
             if (!codeData) return;
             let code = codeData.data as string;
 
+            let filename;
+            if (lang.includes(':')) {
+              [lang, filename] = lang.split(':');
+            }
+            
             const repl = {
               start: 0,
               end: 0,
@@ -91,6 +96,20 @@ export default function (module: Script): Transformer {
               ],
               children: [],
             };
+
+            if (filename){
+              repl.attributes.push({
+                type: 'Attribute',
+                name: 'filename',
+                value: [
+                  {
+                    type: 'Text',
+                    raw: filename,
+                    data: filename,
+                  },
+                ],
+              })
+            }
 
             this.replace(repl);
             usesPrism = true;


### PR DESCRIPTION
Resolves #560

## Changes

- parses `lang` and get filename from it
- adds filename to attributes of a code block
- adds filename to the markup of Prism component

## Testing

- [ ] add tests

## Docs

- [ ] write docs
