### PR TITLE
bug: changed initialization order of the author

### DIFF
--- a/examples/blog/src/pages/$author.astro
+++ b/examples/blog/src/pages/$author.astro
@@ -8,7 +8,6 @@ import Pagination from '../components/Pagination.astro';
 let title = 'Don’s Blog';
 let description = 'An example blog on Astro';
 let canonicalURL = Astro.request.canonicalURL;
-const author = authorData[collection.params.author];
 
 // collection
 import authorData from '../data/authors.json';
@@ -42,6 +41,8 @@ export async function createCollection() {
     routes,
   };
 }
+
+const author = authorData[collection.params.author];
 ---
 
 <html>


### PR DESCRIPTION
## Changes
Updates the order author is initialized until after the collection

`const author = authorData[collection.params.author];
`

Now is assigned after the createCollection() function.

Before
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/2288431/123554517-5c3f3800-d74e-11eb-9b32-bfb6d8e6bef0.png">

## Testing

- Made the change
- Added a new author
- Opened each author page to confirm they loaded

## Docs

No docs needed

