### PR TITLE
Expose `content.astro.html` to `Astro.fetchContent`

### DIFF
--- a/.changeset/good-beers-worry.md
+++ b/.changeset/good-beers-worry.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-support': patch
+---
+
+Expose `html` to `Astro.fetchContent` (#571)

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -41,8 +41,9 @@ const data = Astro.fetchContent('../pages/post/*.md'); // returns an array of po
     description: '',
    **/
     astro: {
-      headers: [], // TODO: document what this means
-      source: '' // raw source of the markdown file
+      headers: [],  // an array of h1...h6 elements in the markdown file
+      source: ''    // raw source of the markdown file
+      html: ''      // rendered HTML of the markdown file
     },
     url: '' // the rendered path
   }[]

--- a/packages/markdown-support/src/index.ts
+++ b/packages/markdown-support/src/index.ts
@@ -63,7 +63,7 @@ export async function renderMarkdown(content: string, opts?: MarkdownRenderingOp
   }
 
   return {
-    astro: { headers, source: content },
+    astro: { headers, source: content, html: result.toString() },
     content: result.toString(),
   };
 }


### PR DESCRIPTION
## Changes

Adds `astro.html` to results returned by `Astro.fetchContent`. Closes #571.

> **Note** there was a performance concern to rendering all `.md` files fetched with `Astro.fetchContent`, but it turns out we were already rendering them completely! This just exposes the result under the `astro.html` key.

## Testing

No tests, just exposing another prop.

## Docs

- [x] TODO: add docs
