### PR TITLE
Add eslint config for prettier + run `eslint . --fix`

### DIFF
--- a/.changeset/three-beers-flow.md
+++ b/.changeset/three-beers-flow.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Added eslint-plugin-prettier-doc and removed deprecated uses of `concat`

--- a/tools/prettier-plugin-astro/.eslintrc
+++ b/tools/prettier-plugin-astro/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "plugins": ["prettier-doc"],
+  "extends": ["plugin:prettier-doc/recommended"]
+}

--- a/tools/prettier-plugin-astro/index.js
+++ b/tools/prettier-plugin-astro/index.js
@@ -1,6 +1,6 @@
 const {
   doc: {
-    builders: { concat, hardline },
+    builders: { hardline },
   },
 } = require('prettier');
 const { parse } = require('@astrojs/parser');
@@ -116,15 +116,15 @@ module.exports.printers = {
     print(path, opts, print) {
       const node = path.getValue();
 
-      if (Array.isArray(node)) return concat(path.map(print));
-      if (node.type === 'Fragment') return concat(path.map(print, 'children'));
+      if (Array.isArray(node)) return path.map(print);
+      if (node.type === 'Fragment') return path.map(print, 'children');
 
       return node;
     },
     embed(path, print, textToDoc, options) {
       const node = path.getValue();
       if (node.type === 'Script' && node.context === 'setup') {
-        return concat(['---', hardline, textToDoc(node.content, { ...options, parser: 'typescript' }), '---', hardline, hardline]);
+        return ['---', hardline, textToDoc(node.content, { ...options, parser: 'typescript' }), '---', hardline, hardline];
       }
       if (node.type === 'Fragment' && node.isRoot) {
         const expressions = findExpressionsInAST(node);

--- a/tools/prettier-plugin-astro/package.json
+++ b/tools/prettier-plugin-astro/package.json
@@ -6,13 +6,17 @@
   "private": true,
   "scripts": {
     "test": "uvu test -i fixtures -i package.json",
-    "build": "echo 'build'"
+    "build": "echo 'build'",
+    "lint:eslint": "eslint .",
+    "fix:eslint": "yarn lint:eslint --fix"
   },
   "dependencies": {
     "@astrojs/parser": "^0.15.0",
     "prettier": "^2.2.1"
   },
   "devDependencies": {
-    "@types/prettier": "^2.2.1"
+    "@types/prettier": "^2.2.1",
+    "eslint": "^7.29.0",
+    "eslint-plugin-prettier-doc": "^1.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,6 +396,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@eslint/eslintrc@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.2.tgz#f63d0ef06f5c0c57d76c4ab5f63d3835c51b0179"
+  integrity sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^13.9.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
 "@fullhuman/postcss-purgecss@^3.1.3":
   version "3.1.3"
   resolved "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.1.3.tgz"
@@ -3812,6 +3827,11 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
+eslint-plugin-prettier-doc@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier-doc/-/eslint-plugin-prettier-doc-1.0.1.tgz#3895a8ec4ef99327e7f0349d184cd08476321e35"
+  integrity sha512-co8h9jpIuspOgPXiJW+2IYt2RecB6ivkCv+aaT6mIsBdY7K0VPIksG+MEvyRTCNczqIy63jxXnOUTRNr7bWJ4g==
+
 eslint-plugin-prettier@^3.4.0:
   version "3.4.0"
   resolved "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz"
@@ -3868,6 +3888,51 @@ eslint@^7.25.0:
     file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
+    globals "^13.6.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.9"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+eslint@^7.29.0:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.29.0.tgz#ee2a7648f2e729485e4d0bd6383ec1deabc8b3c0"
+  integrity sha512-82G/JToB9qIy/ArBzIWG9xvvwL3R86AlCjtGw+A29OMZDqhTybz/MByORSukGxeI+YPCR4coYyITKk8BFH9nDA==
+  dependencies:
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.2"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.1.2"
     globals "^13.6.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
@@ -4456,7 +4521,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -4506,6 +4571,13 @@ globals@^13.6.0:
   version "13.8.0"
   resolved "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz"
   integrity sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==
+  dependencies:
+    type-fest "^0.20.2"
+
+globals@^13.9.0:
+  version "13.9.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.9.0.tgz#4bf2bf635b334a173fb1daf7c5e6b218ecdc06cb"
+  integrity sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==
   dependencies:
     type-fest "^0.20.2"
 


### PR DESCRIPTION
https://github.com/fisker/eslint-plugin-prettier-doc#eslint-plugin-prettier-doc-

## Changes

- Adds eslint-plugin-prettier-docs
- Runs`eslint . --fix` to remove uses of deprecated `concat()`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
