### PR TITLE
update example readmes

### DIFF
--- a/examples/blog-multiple-authors/README.md
+++ b/examples/blog-multiple-authors/README.md
@@ -1,4 +1,8 @@
-# Astro Blog Example
+# Astro Starter Kit: Blog with Multiple Authors
+
+```
+npm init astro --template blog-multiple-authors
+```
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -1,4 +1,8 @@
-# Astro Blog Example
+# Astro Starter Kit: Blog
+
+```
+npm init astro --template blog
+```
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -1,10 +1,17 @@
-# Astro Starter Kit: Portfolio
+# Astro Starter Kit: Docs Site
 
 ```
-npm init astro --template portfolio
+npm init astro --template docs
 ```
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+
+Features:
+
+- ✅ CSS Grid Layout
+- ✅ Full Markdown support
+- ✅ Automatic header navigation sidebar
+- ✅ Dark mode enabled by default
 
 ## 🧞 Commands
 

--- a/examples/framework-multiple/README.md
+++ b/examples/framework-multiple/README.md
@@ -1,4 +1,4 @@
-- # Kitchen Sink: Microfrontends with Astro
+# Kitchen Sink: Microfrontends with Astro
 
 ```
 npm init astro --template framework-multiple

--- a/examples/framework-multiple/README.md
+++ b/examples/framework-multiple/README.md
@@ -1,4 +1,8 @@
-# Using Preact with Astro
+- # Kitchen Sink: Microfrontends with Astro
+
+```
+npm init astro --template framework-multiple
+```
 
 This example showcases Astro's built-in support for multiple frameworks ([React](https://reactjs.org), [Preact](https://preactjs.com), [Svelte](https://svelte.dev), and [Vue (`v3.x`)](https://v3.vuejs.org/)).
 

--- a/examples/framework-preact/README.md
+++ b/examples/framework-preact/README.md
@@ -1,5 +1,9 @@
 # Using Preact with Astro
 
+```
+npm init astro --template framework-preact
+```
+
 This example showcases Astro's built-in support for [Preact](https://preactjs.com/).
 
 No configuration is needed to enable Preact support—just start writing Preact components in `src/components`.

--- a/examples/framework-react/README.md
+++ b/examples/framework-react/README.md
@@ -1,5 +1,9 @@
 # Using React with Astro
 
+```
+npm init astro --template framework-react
+```
+
 This example showcases Astro's built-in support for [React](https://reactjs.org/).
 
 No configuration is needed to enable React support—just start writing React components in `src/components`.

--- a/examples/framework-svelte/README.md
+++ b/examples/framework-svelte/README.md
@@ -1,5 +1,9 @@
 # Using Svelte with Astro
 
+```
+npm init astro --template framework-svelte
+```
+
 This example showcases Astro's built-in support for [Svelte](https://svelte.dev/).
 
 No configuration is needed to enable Svelte support—just start writing Svelte components in `src/components`.

--- a/examples/framework-vue/README.md
+++ b/examples/framework-vue/README.md
@@ -1,5 +1,9 @@
 # Using Vue with Astro
 
+```
+npm init astro --template framework-vue
+```
+
 This example showcases Astro's built-in support for [Vue (`v3.x`)](https://v3.vuejs.org/).
 
 No configuration is needed to enable Vue support—just start writing Vue components in `src/components`.

--- a/examples/with-markdown/README.md
+++ b/examples/with-markdown/README.md
@@ -1,4 +1,8 @@
-# Astro with Markdown
+# Astro Example: Markdown
+
+```
+npm init astro --template with-markdown
+```
 
 This example showcases Astro's [built-in Markdown support](../../docs/markdown.md).
 

--- a/examples/with-nanostores/README.md
+++ b/examples/with-nanostores/README.md
@@ -1,3 +1,7 @@
-# Astro with [`nanostores`](https://github.com/nanostores/nanostores)
+# Astro Example: Nanostores
+
+```
+npm init astro --template with-nanostores
+```
 
 This example showcases using [`nanostores`](https://github.com/nanostores/nanostores) to provide shared state between components from different frameworks.

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -1,5 +1,9 @@
-# Astro with [Tailwind](https://tailwindcss.com)
+# Astro with Tailwind
 
-Astro comes with Tailwind support out of the box. This example showcases how to style your Astro project with [Tailwind](https://tailwindcss.com).
+```
+npm init astro --template with-tailwind
+```
 
-For complete setup instructions, please see our [Styling Guide](https://github.com/snowpackjs/astro/blob/main/docs/styling.md#-tailwind).
+Astro comes with [Tailwind](https://tailwindcss.com) support out of the box. This example showcases how to style your Astro project with Tailwind.
+
+For complete setup instructions, please see our [Styling Guide](/docs/guides/styling.md#-tailwind).


### PR DESCRIPTION
## Changes

- When you open an example in our repo, it's hard to know how to clone it
- The change adds `npm init astro` instructions for every example template README