### PR TITLE
update example astro inline docs

### DIFF
--- a/examples/blog-multiple-authors/src/pages/index.astro
+++ b/examples/blog-multiple-authors/src/pages/index.astro
@@ -1,23 +1,25 @@
 ---
+// Component Imports
 import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav.astro';
 import PostPreview from '../components/PostPreview.astro';
 import Pagination from '../components/Pagination.astro';
+import authorData from '../data/authors.json';
 
-// page
+// Component Script:
+// You can write any JavaScript/TypeScript that you'd like here.
+// It will run during the build, but never in the browser.
+// All variables are available to use in the HTML template below.
 let title = 'Don’s Blog';
 let description = 'An example blog on Astro';
 
-// collection
-// note: we want to show first 3 posts here, but we don’t want to paginate at /1, /2, /3, etc.
-// so we show a preview of posts here, but actually paginate from $posts.astro
-import authorData from '../data/authors.json';
-
+// Data Fetching: List all Markdown posts in the repo.
 let allPosts = Astro.fetchContent('./post/*.md');
 allPosts.sort((a, b) => new Date(b.date) - new Date(a.date));
-let firstPage = allPosts.slice(0, 2);
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <title>{title}</title>

--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -1,16 +1,24 @@
 ---
+// Component Imports
 import BaseHead from '../components/BaseHead.astro';
 import BlogHeader from '../components/BlogHeader.astro';
 import BlogPostPreview from '../components/BlogPostPreview.astro';
 
+// Component Script:
+// You can write any JavaScript/TypeScript that you'd like here.
+// It will run during the build, but never in the browser.
+// All variables are available to use in the HTML template below.
 let title = 'Example Blog';
 let description = 'The perfect starter for your perfect blog.';
 let permalink = 'https://example.com/';
 
+// Data Fetching: List all Markdown posts in the repo.
 let allPosts = Astro.fetchContent('./posts/*.md');
 allPosts = allPosts.sort((a, b) => new Date(b.date) - new Date(a.date));
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <BaseHead title={title} description={description} permalink={permalink} />

--- a/examples/docs/src/layouts/Main.astro
+++ b/examples/docs/src/layouts/Main.astro
@@ -1,16 +1,23 @@
 ---
+// Component Imports
 import ArticleFooter from '../components/ArticleFooter.astro';
 import SiteSidebar from '../components/SiteSidebar.astro';
 import ThemeToggle from '../components/ThemeToggle.tsx';
 import DocSidebar from '../components/DocSidebar.tsx';
 
+// Component Script:
+// You can write any JavaScript/TypeScript that you'd like here.
+// It will run during the build, but never in the browser.
+// All variables are available to use in the HTML template below.
 const { content } = Astro.props;
 const headers = content?.astro?.headers;
-let editHref = Astro?.request?.url?.pathname?.slice(1) ?? '';
-if (editHref === '') editHref = `index`;
-editHref = `https://github.com/snowpackjs/astro/tree/main/examples/doc/src/pages/${editHref}.md`
----
+const currentPage = Astro.request.url.pathname;
+const currentFile = currentPage === '/' ? 'src/pages/index.md' : `src/pages${currentPage.replace(/\/$/, "")}.md`;
+const githubEditUrl = `https://github.com/USER/REPO/blob/main/${currentFile}`
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <title>{content.title}</title>

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -1,11 +1,14 @@
 ---
+// Component Imports
 import { A, B as Renamed } from '../components';
 import * as react from '../components/ReactCounter.jsx';
 import { PreactCounter } from '../components/PreactCounter.tsx';
 import VueCounter from '../components/VueCounter.vue';
 import SvelteCounter from '../components/SvelteCounter.svelte';
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <meta charset="utf-8" />

--- a/examples/framework-preact/src/pages/index.astro
+++ b/examples/framework-preact/src/pages/index.astro
@@ -1,7 +1,10 @@
 ---
+// Component Imports
 import Counter from '../components/Counter.jsx'
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <meta charset="utf-8" />

--- a/examples/framework-react/src/pages/index.astro
+++ b/examples/framework-react/src/pages/index.astro
@@ -1,7 +1,10 @@
 ---
+// Component Imports
 import Counter from '../components/Counter.jsx'
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <meta charset="utf-8" />

--- a/examples/framework-svelte/src/pages/index.astro
+++ b/examples/framework-svelte/src/pages/index.astro
@@ -1,7 +1,10 @@
 ---
+// Component Imports
 import Counter from '../components/Counter.svelte'
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <meta charset="utf-8" />

--- a/examples/framework-vue/src/pages/index.astro
+++ b/examples/framework-vue/src/pages/index.astro
@@ -1,7 +1,10 @@
 ---
+// Component Imports
 import Counter from '../components/Counter.vue'
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <meta charset="utf-8" />

--- a/examples/portfolio/src/pages/index.astro
+++ b/examples/portfolio/src/pages/index.astro
@@ -1,14 +1,18 @@
 ---
+// Component Imports
 import MainHead from '../components/MainHead.astro';
 import Button from '../components/Button/index.jsx';
 import Nav from '../components/Nav/index.jsx';
 import Footer from '../components/Footer/index.jsx';
 import PorfolioPreview from '../components/PortfolioPreview/index.jsx';
 
+// Data Fetching: List all Markdown posts in the repo.
 const projects = Astro.fetchContent('./project/**/*.md');
 const featuredProject = projects[0];
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <MainHead title="Jeanine White: Personal Site" />

--- a/examples/starter/src/pages/index.astro
+++ b/examples/starter/src/pages/index.astro
@@ -1,16 +1,22 @@
 ---
+// Component Imports
 import Tour from '../components/Tour.astro';
----
 
-<!doctype html>
+// Component Script:
+// You can write any JavaScript/TypeScript that you'd like here.
+// It will run during the build, but never in the browser.
+// All variables are available to use in the HTML template below.
+let title = 'My Astro Site';
+
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Astro</title>
-
+    <title>{title}</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-
     <link rel="stylesheet" href="/style/global.css">
     <link rel="stylesheet" href="/style/home.css">
 

--- a/examples/with-markdown/src/pages/index.astro
+++ b/examples/with-markdown/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+// Component Imports
 import { Markdown } from 'astro/components';
 import Layout from '../layouts/main.astro';
 import ReactCounter from '../components/ReactCounter.jsx';
@@ -6,11 +7,17 @@ import PreactCounter from '../components/PreactCounter.tsx';
 import VueCounter from '../components/VueCounter.vue';
 import SvelteCounter from '../components/SvelteCounter.svelte';
 
+// Component Script:
+// You can write any JavaScript/TypeScript that you'd like here.
+// It will run during the build, but never in the browser.
+// All variables are available to use in the HTML template below.
 const title = 'Astro Markdown';
 const variable = 'content';
 const items = ['A', 'B', 'C'];
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <Layout content={{ title }}>
   <Markdown>
     # Introducing {title}

--- a/examples/with-nanostores/src/pages/index.astro
+++ b/examples/with-nanostores/src/pages/index.astro
@@ -1,11 +1,13 @@
 ---
+// Component Imports
 import AdminsReact from '../components/AdminsReact.jsx';
 import AdminsSvelte from '../components/AdminsSvelte.svelte';
 import AdminsVue from '../components/AdminsVue.vue';
 import AdminsPreact from '../components/AdminsPreact.jsx';
----
 
-<!doctype html>
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html lang="en">
 <head>
     <meta charset="UTF-8">

--- a/examples/with-tailwindcss/src/pages/index.astro
+++ b/examples/with-tailwindcss/src/pages/index.astro
@@ -1,7 +1,10 @@
 ---
+// Component Imports
 import Button from '../components/Button.astro';
----
 
+// Full Astro Component Syntax:
+// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+---
 <html>
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
## Changes

- Give more inline support to `npm init astro` users
- adds docs to the main page components in each example project