### PR TITLE
Adds hydrationPolyfills config for renderers

### DIFF
--- a/docs/core-concepts/ui-renderers.md
+++ b/docs/core-concepts/ui-renderers.md
@@ -106,6 +106,7 @@ export default {
   knownEntrypoint: ['framework'], // optional, entrypoint modules that will be used by compiled source
   external: ['dep'] // optional, dependencies that should not be built by snowpack
   polyfills: ['./shadow-dom-polyfill.js'] // optional, module scripts that should be loaded before client hydration.
+  hydrationPolyfills: ['./hydrate-framework.js'] // optional, polyfills that need to run before hydration ever occurs.
 };
 ```
 

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -364,7 +364,7 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
 
   // Make sure that Snowpack builds our renderer plugins
   const rendererInstances = await configManager.buildRendererInstances();
-  const knownEntrypoints: string[] = ['astro/dist/internal/__astro_component.js'];
+  const knownEntrypoints: string[] = ['astro/dist/internal/__astro_component.js', 'astro/dist/internal/element-registry.js'];
   for (const renderer of rendererInstances) {
     knownEntrypoints.push(renderer.server);
     if(renderer.client) {
@@ -373,6 +373,8 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
     if (renderer.knownEntrypoints) {
       knownEntrypoints.push(...renderer.knownEntrypoints);
     }
+    knownEntrypoints.push(...renderer.polyfills);
+    knownEntrypoints.push(...renderer.hydrationPolyfills);
   }
   const external = snowpackExternals.concat([]);
   for(const renderer of rendererInstances) {

--- a/packages/astro/test/custom-elements.test.js
+++ b/packages/astro/test/custom-elements.test.js
@@ -49,6 +49,7 @@ CustomElements('Polyfills are added before the hydration script', async ({ runti
 
   assert.equal($('script[type=module]').length, 2);
   assert.equal($('script[type=module]').attr('src'), '/_snowpack/link/packages/astro/test/fixtures/custom-elements/my-component-lib/polyfill.js');
+  assert.match($($('script[type=module]').get(1)).html(), new RegExp('/_snowpack/link/packages/astro/test/fixtures/custom-elements/my-component-lib/hydration-polyfill.js'));
 });
 
 CustomElements('Polyfills are added even if not hydrating', async ({ runtime }) => {
@@ -60,6 +61,7 @@ CustomElements('Polyfills are added even if not hydrating', async ({ runtime }) 
 
   assert.equal($('script[type=module]').length, 1);
   assert.equal($('script[type=module]').attr('src'), '/_snowpack/link/packages/astro/test/fixtures/custom-elements/my-component-lib/polyfill.js');
+  assert.not.match($($('script[type=module]').get(1)).html(), new RegExp('/_snowpack/link/packages/astro/test/fixtures/custom-elements/my-component-lib/hydration-polyfill.js'));
 });
 
 CustomElements('Custom elements not claimed by renderer are rendered as regular HTML', async ({ runtime }) => {

--- a/packages/astro/test/fixtures/custom-elements/my-component-lib/hydration-polyfill.js
+++ b/packages/astro/test/fixtures/custom-elements/my-component-lib/hydration-polyfill.js
@@ -1,0 +1,2 @@
+
+globalThis.somePolyfillHere = '';

--- a/packages/astro/test/fixtures/custom-elements/my-component-lib/index.js
+++ b/packages/astro/test/fixtures/custom-elements/my-component-lib/index.js
@@ -4,5 +4,8 @@ export default {
   server: './server',
   polyfills: [
     './polyfill.js'
+  ],
+  hydrationPolyfills: [
+    './hydration-polyfill.js'
   ]
 };


### PR DESCRIPTION
## Changes

Some renderers, such as Lit, need special polyfills only for hydration. We have the `polyfills` array, but that is intended for polyfills that always need to run. This adds a second type hydrationPolyfills that only run on elements that are `:load`, `:idle`, etc.

## Testing

Tests added

## Docs

Documented
