### PR TITLE
Allow Preact components to return an empty Fragment

### DIFF
--- a/packages/astro/test/fixtures/preact-component/src/components/EmptyFrag.jsx
+++ b/packages/astro/test/fixtures/preact-component/src/components/EmptyFrag.jsx
@@ -1,0 +1,5 @@
+import { h, Fragment } from 'preact';
+
+export default function() {
+  return <Fragment></Fragment>
+}

--- a/packages/astro/test/fixtures/preact-component/src/pages/frag.astro
+++ b/packages/astro/test/fixtures/preact-component/src/pages/frag.astro
@@ -1,0 +1,10 @@
+---
+import FragComponent from '../components/EmptyFrag.jsx';
+---
+
+<html>
+<head>
+  <title>Preact component returns fragment</title>
+</head>
+<body><FragComponent /></body>
+</html>

--- a/packages/astro/test/preact-component.test.js
+++ b/packages/astro/test/preact-component.test.js
@@ -32,4 +32,12 @@ PreactComponent('Can use hooks', async ({ runtime }) => {
   assert.equal($('#world').length, 1);
 });
 
+PreactComponent('Can export a Fragment', async ({ runtime }) => {
+  const result = await runtime.load('/frag');
+  if (result.error) throw new Error(result.error);
+
+  const $ = doc(result.contents);
+  assert.equal($('body').children().length, 0, 'nothing rendered but it didn\'t throw.');
+});
+
 PreactComponent.run();

--- a/packages/renderers/renderer-preact/server.js
+++ b/packages/renderers/renderer-preact/server.js
@@ -10,7 +10,7 @@ function check(Component, props, children) {
   }
 
   const { html } = renderToStaticMarkup(Component, props, children);
-  return Boolean(html);
+  return typeof html === 'string';
 }
 
 function renderToStaticMarkup(Component, props, children) {


### PR DESCRIPTION
## Changes

This is a bug fix. When a Preact component returns only an empty fragment like so `return <Fragment />` this should be treated as a valid Preact component.

Use-case I had was that I wanted nothing to rendered in a certain state. An `Alert` component that only shows something when there is a message.

## Testing

Test added

## Docs

N/A bug fix