### PR TITLE
Don't alias builtins if polyfillNode is used

### DIFF
--- a/.changeset/bright-cherries-juggle.md
+++ b/.changeset/bright-cherries-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for using the snowpack polyfillNode option

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "www",
     "docs-www",
     "packages/astro/test/fixtures/builtins/packages/*",
+    "packages/astro/test/fixtures/builtins-polyfillnode",
     "packages/astro/test/fixtures/custom-elements/my-component-lib"
   ],
   "volta": {

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -418,11 +418,13 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
     packageOptions: {
       knownEntrypoints,
       external,
-    },
-    alias: {
-      ...Object.fromEntries(nodeBuiltinsMap),
-    },
+    }
   });
+
+  const polyfillNode = (snowpackConfig.packageOptions as any).polyfillNode as boolean;
+  if(!polyfillNode) {
+    snowpackConfig.alias = Object.fromEntries(nodeBuiltinsMap);
+  }
 
   snowpack = await startSnowpackServer(
     {

--- a/packages/astro/test/builtins-polyfillnode.test.js
+++ b/packages/astro/test/builtins-polyfillnode.test.js
@@ -13,7 +13,7 @@ Builtins('Doesnt alias to node: prefix', async ({ runtime }) => {
 
   const $ = doc(result.contents);
 
-  assert.equal($('#url').text(), 'file:///unicorn.jpg');
+  assert.match($('#url').text(), new RegExp('unicorn.jpg'));
 });
 
 Builtins.run();

--- a/packages/astro/test/builtins-polyfillnode.test.js
+++ b/packages/astro/test/builtins-polyfillnode.test.js
@@ -1,0 +1,19 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import { doc } from './test-utils.js';
+import { setup } from './helpers.js';
+
+const Builtins = suite('Node builtins with polyfillNode option');
+
+setup(Builtins, './fixtures/builtins-polyfillnode');
+
+Builtins('Doesnt alias to node: prefix', async ({ runtime }) => {
+  const result = await runtime.load('/');
+  if (result.error) throw new Error(result.error);
+
+  const $ = doc(result.contents);
+
+  assert.equal($('#url').text(), 'file:///unicorn.jpg');
+});
+
+Builtins.run();

--- a/packages/astro/test/fixtures/builtins-polyfillnode/package.json
+++ b/packages/astro/test/fixtures/builtins-polyfillnode/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@astrojs/astro-test-builtins-polyfillnode",
+  "version": "1.2.0",
+  "dependencies": {
+    "file-url": "4.0.0"
+  }
+}

--- a/packages/astro/test/fixtures/builtins-polyfillnode/snowpack.config.json
+++ b/packages/astro/test/fixtures/builtins-polyfillnode/snowpack.config.json
@@ -1,0 +1,6 @@
+{
+  "workspaceRoot": "../../../../../",
+  "packageOptions": {
+    "polyfillNode": false 
+  }
+}

--- a/packages/astro/test/fixtures/builtins-polyfillnode/src/pages/index.astro
+++ b/packages/astro/test/fixtures/builtins-polyfillnode/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import fileUrl from 'file-url';
+
+const r = fileUrl('unicorn.jpg');
+---
+
+<html>
+<head><title>Testing</title></head>
+<body>
+  <div id="url">{r}</div>
+</body>
+</html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,9 @@
     time-require "^0.1.2"
     valid-url "^1.0.9"
 
+"@astrojs/astro-test-builtins-dep2@file:./packages/astro/test/fixtures/builtins-polyfillnode/packages/dep":
+  version "0.0.1"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz"
@@ -4142,6 +4145,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-url@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/file-url/-/file-url-4.0.0.tgz#6fe05262d3187da70bc69889091932b6bc7df270"
+  integrity sha512-vRCdScQ6j3Ku6Kd7W1kZk9c++5SqD6Xz5Jotrjr/nkY714M14RFHy/AAVA2WQvpsqVAVgTbDrYyBpU205F0cLw==
 
 fill-range@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
## Changes

Fixes #569 by avoiding setting `node:` aliases when polyfillNode is being used.

## Testing

Yep

## Docs

N/A, bug fix.
