### PR TITLE
Implements templates from external repos

### DIFF
--- a/.changeset/tame-cheetahs-yawn.md
+++ b/.changeset/tame-cheetahs-yawn.md
@@ -1,0 +1,11 @@
+---
+'create-astro': patch
+---
+
+Allows using an external repo as a template
+
+You can do this with the `--template` flag:
+
+```bash
+npm init astro my-shopify --template cassidoo/shopify-react-astro
+```

--- a/packages/create-astro/README.md
+++ b/packages/create-astro/README.md
@@ -28,6 +28,12 @@ yarn create astro my-astro-project --template starter
 ```
 [Check out the full list][examples] of example starter templates, available on GitHub.
 
+You can also use any GitHub repo as a template:
+
+```bash
+npm init astro my-astro-project -- --template cassidoo/shopify-react-astro
+```
+
 ### CLI Flags
 
 May be provided in place of prompts

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -55,7 +55,12 @@ export async function main() {
   ]);
 
   const hash = args.commit ? `#${args.commit}` : '';
-  const emitter = degit(`snowpackjs/astro/examples/${options.template}${hash}`, {
+
+  const templateTarget = options.template.includes('/') ?
+    options.template :
+    `snowpackjs/astro/examples/${options.template}`;
+
+  const emitter = degit(`${templateTarget}${hash}`, {
     cache: false,
     force: true,
     verbose: false,

--- a/packages/create-astro/test/create-astro.test.js
+++ b/packages/create-astro/test/create-astro.test.js
@@ -1,15 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import http from 'http';
 import { green, red } from 'kleur/colors';
 import execa from 'execa';
 import glob from 'tiny-glob';
 import { TEMPLATES } from '../dist/templates.js';
-
-// config
-const GITHUB_SHA = process.env.GITHUB_SHA || execa.sync('git', ['rev-parse', 'HEAD']).stdout; // process.env.GITHUB_SHA will be set in CI; if testing locally execa() will gather this
-const FIXTURES_DIR = path.join(fileURLToPath(path.dirname(import.meta.url)), 'fixtures');
+import { GITHUB_SHA, FIXTURES_DIR } from './helpers.js';
 
 // helpers
 async function fetch(url) {

--- a/packages/create-astro/test/external.test.js
+++ b/packages/create-astro/test/external.test.js
@@ -1,0 +1,29 @@
+import assert from 'assert';
+import execa from 'execa';
+import { FIXTURES_URL } from './helpers.js';
+import { existsSync } from 'fs';
+
+async function run(outdir, template) {
+  //--template cassidoo/shopify-react-astro
+  await execa('../../create-astro.mjs', [outdir, '--template', template, '--force-overwrite'], {
+    cwd: FIXTURES_URL.pathname,
+  });
+}
+
+const testCases = [
+  ['shopify', 'cassidoo/shopify-react-astro']
+];
+
+async function tests() {
+  for(let [dir, tmpl] of testCases) {
+    await run(dir, tmpl);
+
+    const outPath = new URL('' + dir, FIXTURES_URL);
+    assert.ok(existsSync(outPath));
+  }
+}
+
+tests().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/create-astro/test/helpers.js
+++ b/packages/create-astro/test/helpers.js
@@ -1,0 +1,13 @@
+import execa from 'execa';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const GITHUB_SHA = process.env.GITHUB_SHA || execa.sync('git', ['rev-parse', 'HEAD']).stdout; // process.env.GITHUB_SHA will be set in CI; if testing locally execa() will gather this
+const FIXTURES_DIR = path.join(fileURLToPath(path.dirname(import.meta.url)), 'fixtures');
+const FIXTURES_URL = pathToFileURL(FIXTURES_DIR + '/');
+
+export {
+  GITHUB_SHA,
+  FIXTURES_DIR,
+  FIXTURES_URL
+};


### PR DESCRIPTION
Closes #558

## Changes

This allows you to clone from an external repo like so:

```bash
npm init astro my-shopify --template cassidoo/shopify-react-astro
```

This will work with any string that degit supports, so you get simplified user/repo like shown above or https urls, from gitlab, etc.

## Testing

Test added.

## Docs

Docs updated
