### PR TITLE
Do not override snowpack alias

### DIFF
--- a/.changeset/metal-lions-try.md
+++ b/.changeset/metal-lions-try.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Bugfix: do not override user `alias` passed into snowpack config

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -422,8 +422,8 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
   });
 
   const polyfillNode = (snowpackConfig.packageOptions as any).polyfillNode as boolean;
-  if(!polyfillNode) {
-    snowpackConfig.alias = Object.fromEntries(nodeBuiltinsMap);
+  if (!polyfillNode) {
+    snowpackConfig.alias = Object.assign({}, Object.fromEntries(nodeBuiltinsMap), snowpackConfig.alias ?? {});
   }
 
   snowpack = await startSnowpackServer(


### PR DESCRIPTION
## Changes

Previously, we were setting `snowpackConfig.alias = { ... }`, which would override a user's configured `alias`. Now we're merging the two.

## Testing

Bugfix

## Docs

Bugfix
