### PR TITLE
Add the cli flag `--silent` to astro which sets astro and snowpack l…

### DIFF
--- a/.changeset/pretty-windows-bow.md
+++ b/.changeset/pretty-windows-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add command line flag `--silent` to astro to set no output.

--- a/packages/astro/src/cli.ts
+++ b/packages/astro/src/cli.ts
@@ -78,6 +78,7 @@ function printHelp() {
   --no-sitemap          Disable sitemap generation (build only).
   --reload              Clean the cache, reinstalling dependencies.
   --verbose             Enable verbose logging
+  --silent              Disable logging
   --version             Show the version number and exit.
   --help                Show this help message.
 `);

--- a/packages/astro/src/logger.ts
+++ b/packages/astro/src/logger.ts
@@ -159,4 +159,11 @@ function padStr(str: string, len: number) {
   return str + spaces;
 }
 
-export const defaultLogLevel: LoggerLevel = process.argv.includes('--verbose') ? 'debug' : 'info';
+export let defaultLogLevel: LoggerLevel;
+if (process.argv.includes('--verbose')) {
+  defaultLogLevel = 'debug';
+} else if (process.argv.includes('--silent')) {
+  defaultLogLevel = 'silent';
+} else {
+  defaultLogLevel = 'info';
+}

--- a/packages/astro/src/snowpack-logger.ts
+++ b/packages/astro/src/snowpack-logger.ts
@@ -4,5 +4,7 @@ import { defaultLogLevel } from './logger.js';
 export function configureSnowpackLogger(logger: typeof snowpackLogger) {
   if (defaultLogLevel === 'debug') {
     logger.level = 'debug';
+  } else if (defaultLogLevel === 'silent') {
+    logger.level = 'silent';
   }
 }


### PR DESCRIPTION
…ogging to output nothing

## Changes

Adds the command line flag `--silent` to set the logging to output nothing, for example when you just want the dev server to run in the background for a lint command.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

- [ ] These are not updated, though I did update the `astro help` text.