### PR TITLE
Remove `prettier-plugin-astro` from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "dev:vscode": "lerna run dev --scope astro-languageserver --scope astro-vscode --scope @astrojs/parser --parallel --stream",
     "format": "prettier -w \"**/*.{js,jsx,ts,tsx,md,json}\"",
     "lint": "eslint \"packages/**/*.ts\"",
-    "test": "lerna run test --scope astro --stream",
-    "test:core": "yarn workspace astro run test",
+    "test": "yarn workspace astro run test",
     "test:templates": "lerna run test --scope create-astro --stream"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev:vscode": "lerna run dev --scope astro-languageserver --scope astro-vscode --scope @astrojs/parser --parallel --stream",
     "format": "prettier -w \"**/*.{js,jsx,ts,tsx,md,json}\"",
     "lint": "eslint \"packages/**/*.ts\"",
-    "test": "lerna run test --scope astro --scope prettier-plugin-astro --stream",
+    "test": "lerna run test --scope astro --stream",
     "test:core": "yarn workspace astro run test",
     "test:templates": "lerna run test --scope create-astro --stream"
   },


### PR DESCRIPTION


## Changes

Updates the root `yarn test` command to not test for the nonexistent `prettier-plugin-astro` package that was moved to https://github.com/snowpackjs/prettier-plugin-astro/ for the moment.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
