### PR TITLE
fix: sorting key for example blog posts

### DIFF
--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -14,7 +14,7 @@ let permalink = 'https://example.com/';
 
 // Data Fetching: List all Markdown posts in the repo.
 let allPosts = Astro.fetchContent('./posts/*.md');
-allPosts = allPosts.sort((a, b) => new Date(b.date) - new Date(a.date));
+allPosts = allPosts.sort((a, b) => new Date(b.publishDate) - new Date(a.publishDate));
 
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md


### PR DESCRIPTION
## Changes

I started a new blog project and found that, once I added more than one blog post, my posts weren't sorting by date.

Once I looked at the code, I realized it's because it was sorting on the `date` key which doesn't exist. The example blog posts use the `publishDate` key. So no sorting was occurring.

## Testing

No tests written because idk how to write a test for this. AFAIK there wasn't one previously.

## Docs

Bug fix in example only.
