### PR TITLE
Add support for components defined in frontmatter

### DIFF
--- a/.changeset/twelve-lions-tie.md
+++ b/.changeset/twelve-lions-tie.md
@@ -1,0 +1,14 @@
+---
+'astro': patch
+---
+
+Add support for components defined in Frontmatter. Previously, the following code would throw an error. Now it is officially supported!
+
+```astro
+---
+const { level = 1 } = Astro.props;
+const Element = `h${level}`;
+---
+
+<Element>Hello world!</Element>
+```

--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -688,7 +688,21 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
                 componentInfo = components.get(componentNamespace);
               }
               if (!componentInfo && !isCustomElementTag(componentName)) {
-                throw new Error(`Unknown Component: ${componentName}`);
+                if (hydrationAttributes.method) {
+                  throw new Error(`Unable to hydrate "${componentName}" because it is statically defined in the frontmatter script. Hydration directives may only be used on imported components.`);
+                }
+
+                // Previously we would throw here, but this is valid! 
+                // If the frontmatter script defines `const Element = 'h1'`,
+                // you should be able to statically render `<Element>`
+
+                if (curr === 'markdown') {
+                  await pushMarkdownToBuffer();
+                }
+
+                paren++;
+                buffers[curr] += `h(${componentName}, ${attributes ? generateAttributes(attributes) : 'null'}`;
+                return;
               }
               if (componentName === 'Markdown') {
                 const { $scope } = attributes ?? {};

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -95,4 +95,12 @@ Basics('Allows spread attributes with TypeScript (#521)', async ({ runtime }) =>
   assert.equal($('#spread-ts').attr('c'), '2');
 });
 
+Basics('Allows Components defined in frontmatter', async ({ runtime }) => {
+  const result = await runtime.load('/frontmatter-component');
+  const html = result.contents;
+  const $ = doc(html);
+
+  assert.equal($('h1').length, 1);
+});
+
 Basics.run();

--- a/packages/astro/test/fixtures/astro-basic/src/pages/frontmatter-component.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/frontmatter-component.astro
@@ -1,0 +1,5 @@
+---
+const Element = 'h1';
+---
+
+<Element>Hello world!</Element>

--- a/packages/astro/test/fixtures/astro-basic/src/pages/frontmatter-component.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/frontmatter-component.astro
@@ -1,5 +1,6 @@
 ---
-const Element = 'h1';
+const { level = 1 } = Astro.props;
+const Element = `h${level}`;
 ---
 
 <Element>Hello world!</Element>


### PR DESCRIPTION
## Changes

Previously, components which were not pulled into a file using `import` would throw an Error. This meant you couldn't dynamically define a certain element based on component props. This change allows for components defined in Frontmatter to be rendered statically and throws an error if a user attempts to hydrate them.

This is now valid (and very useful!)

```
---
const { level = 1 } = Astro.props;
const Element = `h${level}`;
---

<Element>Hello world!</Element>
```

## Testing

Added a test under `astro-basic`

## Docs

No docs