### PR TITLE
Fix injection behavior for pages which contain no elements

### DIFF
--- a/.changeset/twelve-lions-tie.md
+++ b/.changeset/twelve-lions-tie.md
@@ -1,0 +1,14 @@
+---
+'astro': patch
+---
+
+Add support for components defined in Frontmatter. Previously, the following code would throw an error. Now it is officially supported!
+
+```astro
+---
+const { level = 1 } = Astro.props;
+const Element = `h${level}`;
+---
+
+<Element>Hello world!</Element>
+```

--- a/packages/astro/src/compiler/transform/head.ts
+++ b/packages/astro/src/compiler/transform/head.ts
@@ -24,7 +24,8 @@ export default function (opts: TransformOptions): Transformer {
             if (hasComponents) {
               return;
             }
-
+            // Initialize eoh if there are no elements
+            eoh.enter(node);
             if (node.attributes && node.attributes.some(({ name }: any) => name.startsWith('client:'))) {
               hasComponents = true;
               return;
@@ -35,6 +36,9 @@ export default function (opts: TransformOptions): Transformer {
             if (kind) {
               hasComponents = true;
             }
+          },
+          leave(node) {
+            eoh.leave(node);
           },
         },
         Element: {

--- a/packages/astro/test/astro-hmr.test.js
+++ b/packages/astro/test/astro-hmr.test.js
@@ -39,4 +39,14 @@ HMR('Adds script to static pages too', async ({ runtime }) => {
   assert.ok(/window\.HMR_WEBSOCKET_PORT/.test(html), 'websocket port added');
 });
 
+HMR('Adds script to pages even if there aren\'t any elements in the template', async ({ runtime }) => {
+  const result = await runtime.load('/no-elements');
+  if (result.error) throw new Error(result.error);
+
+  const html = result.contents;
+  const $ = doc(html);
+  assert.equal($('[src="/_snowpack/hmr-client.js"]').length, 1);
+  assert.ok(/window\.HMR_WEBSOCKET_PORT/.test(html), 'websocket port added');
+});
+
 HMR.run();

--- a/packages/astro/test/fixtures/astro-hmr/src/components/Demo.astro
+++ b/packages/astro/test/fixtures/astro-hmr/src/components/Demo.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+  <title>My Test</title>
+</head>
+<body>
+  <div>Hello world</div>
+</body>
+</html>

--- a/packages/astro/test/fixtures/astro-hmr/src/pages/no-elements.astro
+++ b/packages/astro/test/fixtures/astro-hmr/src/pages/no-elements.astro
@@ -1,0 +1,4 @@
+---
+import Demo from '../components/Demo.astro';
+---
+<Demo />

--- a/packages/astro/test/fixtures/no-head-el/src/pages/no-elements.astro
+++ b/packages/astro/test/fixtures/no-head-el/src/pages/no-elements.astro
@@ -1,0 +1,6 @@
+---
+import Something from '../components/Something.jsx';
+import Child from '../components/Child.astro';
+---
+<Something client:load />
+<Child />

--- a/packages/astro/test/no-head-el.test.js
+++ b/packages/astro/test/no-head-el.test.js
@@ -25,4 +25,14 @@ NoHeadEl('Places style and scripts before the first non-head element', async ({ 
   assert.equal($('script[src="/_snowpack/hmr-client.js"]').length, 1, 'Only the hmr client for the page');
 });
 
+NoHeadEl('Places style and scripts before the first non-head element even when there are no elements on the page', async ({ runtime }) => {
+  const result = await runtime.load('/no-elements');
+  if (result.error) throw new Error(result.error);
+
+  const html = result.contents;
+  const $ = doc(html);
+  
+  assert.equal($('script[src="/_snowpack/hmr-client.js"]').length, 1, 'Only the hmr client for the page');
+});
+
 NoHeadEl.run();

--- a/packages/astro/test/no-head-el.test.js
+++ b/packages/astro/test/no-head-el.test.js
@@ -25,7 +25,7 @@ NoHeadEl('Places style and scripts before the first non-head element', async ({ 
   assert.equal($('script[src="/_snowpack/hmr-client.js"]').length, 1, 'Only the hmr client for the page');
 });
 
-NoHeadEl('Places style and scripts before the first non-head element even when there are no elements on the page', async ({ runtime }) => {
+NoHeadEl('Injects HMR script even when there are no elements on the page', async ({ runtime }) => {
   const result = await runtime.load('/no-elements');
   if (result.error) throw new Error(result.error);
 


### PR DESCRIPTION
## Changes

Closes #605. Previously our `EndOfHead` implementation was ignoring pages which had no Element nodes (only InlineComponent) nodes. This change ensures that HMR and styles are _always_ injected.

## Testing

Added two test cases

## Docs

Bug fix only
