### PR TITLE
Protect again no metadata being passed

### DIFF
--- a/packages/renderers/renderer-react/server.js
+++ b/packages/renderers/renderer-react/server.js
@@ -37,7 +37,7 @@ function check(Component, props, children) {
 function renderToStaticMarkup(Component, props, children, metadata) {
   const vnode = h(Component, { ...props, children: h(StaticHtml, { value: children }), innerHTML: children });
   let html;
-  if (metadata.hydrate) {
+  if(metadata && metadata.hydrate) {
     html = renderToString(vnode);
   } else {
     html = reactRenderToStaticMarkup(vnode);


### PR DESCRIPTION
If using Astro <= 0.17.0 there is no `metadata` being passed. Even though no one should be using that version with this, adding some extra protection just in case.
