### PR TITLE
Improve error handling in unsupported node versions

### DIFF
--- a/.changeset/smart-forks-search.md
+++ b/.changeset/smart-forks-search.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve error handling for unsupported Node versions

--- a/packages/astro/astro.cjs
+++ b/packages/astro/astro.cjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict';
+const pkg = require('./package.json');
+const semver = require('semver');
+const ci = require('ci-info');
+const CI_INTRUCTIONS = {
+  NETLIFY: 'https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript',
+  GITHUB_ACTIONS: 'https://docs.github.com/en/actions/guides/building-and-testing-nodejs#specifying-the-nodejs-version',
+  VERCEL: 'https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version'
+}
+
+/** Dynamically import the CLI after checking if this version of Node is supported */
+async function main() {
+  const engines = pkg.engines.node;
+  const version = process.versions.node;
+  const isSupported = semver.satisfies(version, engines)
+
+  if (!isSupported) {
+    console.error(`\nNode.js v${version} is not supported by Astro!
+Please upgrade to one of Node.js ${engines}.\n`);
+    if (ci.isCI) {
+      let platform;
+      for (const [key, value] of Object.entries(ci)) {
+        if (value === true) {
+          platform = key;
+          break;
+        }
+      }
+      console.log(`To set the Node.js version for ${ci.name}, reference the official documentation`)
+      if (CI_INTRUCTIONS[platform]) console.log(CI_INTRUCTIONS[platform]);
+    }
+    process.exit(1);
+  }
+
+  await import('./dist/cli.js').then(({cli}) => cli(process.argv));
+}
+
+main();

--- a/packages/astro/astro.mjs
+++ b/packages/astro/astro.mjs
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-import { cli } from './dist/cli.js';
-
-cli(process.argv);

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/astro"
   },
   "exports": {
-    ".": "./astro.mjs",
+    ".": "./astro.cjs",
     "./package.json": "./package.json",
     "./snowpack-plugin": "./snowpack-plugin.cjs",
     "./components": "./components/index.js",
@@ -25,7 +25,7 @@
     "#astro/*": "./dist/*.js"
   },
   "bin": {
-    "astro": "astro.mjs"
+    "astro": "astro.cjs"
   },
   "files": [
     "components",
@@ -58,6 +58,7 @@
     "astring": "^1.7.4",
     "autoprefixer": "^10.2.5",
     "cheerio": "^1.0.0-rc.6",
+    "ci-info": "^3.2.0",
     "del": "^6.0.0",
     "es-module-lexer": "^0.4.1",
     "esbuild": "^0.10.1",
@@ -66,7 +67,6 @@
     "fast-xml-parser": "^3.19.0",
     "fdir": "^5.0.0",
     "find-up": "^5.0.0",
-    "unified": "^9.2.1",
     "gzip-size": "^6.0.0",
     "hast-to-hyperscript": "~9.0.0",
     "kleur": "^4.1.4",
@@ -83,12 +83,14 @@
     "rollup": "^2.43.1",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.32.13",
+    "semver": "^7.3.5",
     "shorthash": "^0.0.2",
     "slash": "^4.0.0",
     "snowpack": "3.7.1",
     "source-map-support": "^0.5.19",
     "string-width": "^5.0.0",
     "tiny-glob": "^0.2.8",
+    "unified": "^9.2.1",
     "yargs-parser": "^20.2.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2679,6 +2679,11 @@ ci-info@^2.0.0:
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
+ci-info@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
+  integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
+
 clean-css@^4.1.11:
   version "4.2.3"
   resolved "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz"
@@ -8970,7 +8975,7 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
 
 semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"


### PR DESCRIPTION
## Changes

Previously, `astro.mjs` was statically using `import { cli } from './dist/cli.js'` which would execute the CLI code and throw on unsupported Node versions.

This adds a simple `engines` check before _dynamically_ running `import('./dist/cli.js').then({ cli }) => cli())`, so any invalid code in `cli.js` won't be run until the version is verified.

I also added some handy links to Netlify, Vercel, and GitHub Actions documentation because why not!

**BEFORE**
<img width="729" alt="Screen Shot 2021-07-09 at 12 47 10 PM" src="https://user-images.githubusercontent.com/7118177/125117808-5b929400-e0b4-11eb-8a42-c8fcc605b64b.png">

**AFTER**
<img width="735" alt="Screen Shot 2021-07-09 at 12 46 19 PM" src="https://user-images.githubusercontent.com/7118177/125117833-664d2900-e0b4-11eb-9b30-ffa7afa011b3.png">


## Testing

Manually, hard to test automatically

## Docs

QOL Improvement