### PR TITLE
Fixes blog-multiple-authors example by updating variable name

### DIFF
--- a/examples/blog-multiple-authors/src/pages/index.astro
+++ b/examples/blog-multiple-authors/src/pages/index.astro
@@ -26,7 +26,7 @@ allPosts.sort((a, b) => new Date(b.date) - new Date(a.date));
     <MainHead
       title={title}
       description={description}
-      image={firstPage[0].image}
+      image={allPosts[0].image}
       canonicalURL={Astro.request.canonicalURL.href}
     />
   </head>
@@ -35,7 +35,7 @@ allPosts.sort((a, b) => new Date(b.date) - new Date(a.date));
     <Nav />
 
     <main class="wrapper">
-      {firstPage.map((post) => <PostPreview post={post} author={authorData[post.author]} />)}
+      {allPosts.map((post) => <PostPreview post={post} author={authorData[post.author]} />)}
     </main>
 
     <footer>


### PR DESCRIPTION
## Changes

Currently, running the multiple authors blog post example https://github.com/snowpackjs/astro/tree/main/examples/blog-multiple-authors results in an error:

```
[executing astro] ReferenceError: firstPage is not defined
    at Object.__render (/_astro/src/pages/index.astro.js:38:662)
    at Object.__renderPage (/_astro/src/pages/index.astro.js:64:46)
    at load (file:///Users/tyler/workspace/astro-example-multiple-authors/node_modules/astro/src/runtime.ts:229:35)
    at Server.<anonymous> (file:///Users/tyler/workspace/astro-example-multiple-authors/node_modules/astro/src/dev.ts:33:20
```

- This is because `index.astro` is using an undefined `firstPage` variable
- It should use the `allPosts` variable

## Testing

No unit tests. The best way to reproduce this bug is to create a new project an initialize it with:

```
npm init astro --template blog-multiple-authors
```

Then run the project with `npm run start` which will result in the above error and the 500 screen.

## Docs

No documentation changes, bug fix in an example only.
