### PR TITLE
Only display notice if needed

### DIFF
--- a/.changeset/pink-buttons-destroy.md
+++ b/.changeset/pink-buttons-destroy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Only show the buildOptions.site notice if not already set

--- a/packages/astro/src/build.ts
+++ b/packages/astro/src/build.ts
@@ -53,7 +53,9 @@ export async function build(astroConfig: AstroConfig, logging: LogOptions = defa
   };
 
   // warn users if missing config item in build that may result in broken SEO (can’t disable, as they should provide this)
-  warn(logging, 'config', `Set "buildOptions.site" to generate correct canonical URLs and sitemap`);
+  if (!astroConfig.buildOptions.site) {
+    warn(logging, 'config', `Set "buildOptions.site" to generate correct canonical URLs and sitemap`);
+  }
 
   const mode: RuntimeMode = 'production';
   const runtime = await createRuntime(astroConfig, { mode, logging: runtimeLogging });


### PR DESCRIPTION
## Changes

- Added a check to see if site is already set

## Testing

Didn't add any extra test, couldn't find any specific test for the build output.
Ran all tests and they passed in the same way as in the main branch.

## Docs

This does not actually change any functionality.
