### PR TITLE
Improve lighthouse score : Add lang attribute to `example/` sites

### DIFF
--- a/.changeset/lovely-kids-sniff.md
+++ b/.changeset/lovely-kids-sniff.md
@@ -1,0 +1,17 @@
+---
+'@example/blog': minor
+'@example/blog-multiple-authors': minor
+'@example/docs': minor
+'@example/framework-multiple': minor
+'@example/framework-preact': minor
+'@example/framework-react': minor
+'@example/framework-svelte': minor
+'@example/framework-vue': minor
+'@example/portfolio': minor
+'@example/snowpack': minor
+'@example/with-markdown': minor
+'@example/with-markdown-plugins': minor
+'@example/with-tailwindcss': minor
+---
+
+Add lang attribute to html tags

--- a/examples/blog-multiple-authors/src/layouts/post.astro
+++ b/examples/blog-multiple-authors/src/layouts/post.astro
@@ -6,7 +6,7 @@ import authorData from '../data/authors.json';
 const { content } = Astro.props;
 ---
 
-<html>
+<html lang={ content.lang ?? 'en' }>
   <head>
     <title>{content.title}</title>
     <MainHead title={content.title} description={content.description} image={content.image} canonicalURL={Astro.request.canonicalURL} />

--- a/examples/blog-multiple-authors/src/pages/$author.astro
+++ b/examples/blog-multiple-authors/src/pages/$author.astro
@@ -8,6 +8,7 @@ import Pagination from '../components/Pagination.astro';
 let title = 'Don’s Blog';
 let description = 'An example blog on Astro';
 let canonicalURL = Astro.request.canonicalURL;
+let lang = 'en';
 
 // collection
 import authorData from '../data/authors.json';
@@ -45,7 +46,7 @@ export async function createCollection() {
 const author = authorData[collection.params.author];
 ---
 
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <title>{title}</title>
     <MainHead

--- a/examples/blog-multiple-authors/src/pages/$posts.astro
+++ b/examples/blog-multiple-authors/src/pages/$posts.astro
@@ -8,6 +8,7 @@ import Pagination from '../components/Pagination.astro';
 let title = 'Don’s Blog';
 let description = 'An example blog on Astro';
 let canonicalURL = Astro.request.canonicalURL;
+let lang = 'en';
 
 // collection
 import authorData from '../data/authors.json';
@@ -38,7 +39,7 @@ export async function createCollection() {
 }
 ---
 
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <title>{title}</title>
     <MainHead

--- a/examples/blog-multiple-authors/src/pages/about.astro
+++ b/examples/blog-multiple-authors/src/pages/about.astro
@@ -3,8 +3,9 @@ import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav.astro';
 
 let title = "About";
+let lang = 'en';
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <MainHead
       title={title}

--- a/examples/blog-multiple-authors/src/pages/index.astro
+++ b/examples/blog-multiple-authors/src/pages/index.astro
@@ -12,6 +12,7 @@ import authorData from '../data/authors.json';
 // All variables are available to use in the HTML template below.
 let title = 'Don’s Blog';
 let description = 'An example blog on Astro';
+let lang = 'en';
 
 // Data Fetching: List all Markdown posts in the repo.
 let allPosts = Astro.fetchContent('./post/*.md');
@@ -21,7 +22,7 @@ let firstPage = allPosts.slice(0, 2);
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <title>{title}</title>
     <MainHead

--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -7,7 +7,7 @@ import BlogPost from '../components/BlogPost.astro';
 const {content} = Astro.props;
 const {title, description, publishDate, author, heroImage, permalink} = content;
 ---
-<html>
+<html lang={ content.lang ?? 'en' }>
   <head>
     <BaseHead title={title} description={description} permalink={permalink} />
     <link rel="stylesheet" href="/blog.css" />

--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -11,6 +11,7 @@ import BlogPostPreview from '../components/BlogPostPreview.astro';
 let title = 'Example Blog';
 let description = 'The perfect starter for your perfect blog.';
 let permalink = 'https://example.com/';
+let lang = 'en';
 
 // Data Fetching: List all Markdown posts in the repo.
 let allPosts = Astro.fetchContent('./posts/*.md');
@@ -19,7 +20,7 @@ allPosts = allPosts.sort((a, b) => new Date(b.publishDate) - new Date(a.publishD
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <BaseHead title={title} description={description} permalink={permalink} />
     <link rel="stylesheet" href="/blog.css" />

--- a/examples/docs/src/layouts/Main.astro
+++ b/examples/docs/src/layouts/Main.astro
@@ -18,7 +18,7 @@ const githubEditUrl = `https://github.com/USER/REPO/blob/main/${currentFile}`
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ content.lang ?? 'en' }>
   <head>
     <title>{content.title}</title>
     

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -6,10 +6,12 @@ import { PreactCounter } from '../components/PreactCounter.tsx';
 import VueCounter from '../components/VueCounter.vue';
 import SvelteCounter from '../components/SvelteCounter.svelte';
 
+let lang = 'en';
+
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />

--- a/examples/framework-preact/src/pages/index.astro
+++ b/examples/framework-preact/src/pages/index.astro
@@ -2,10 +2,12 @@
 // Component Imports
 import Counter from '../components/Counter.jsx'
 
+let lang = 'en';
+
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <meta charset="utf-8" />
     <meta

--- a/examples/framework-react/src/pages/index.astro
+++ b/examples/framework-react/src/pages/index.astro
@@ -2,10 +2,12 @@
 // Component Imports
 import Counter from '../components/Counter.jsx'
 
+let lang = 'en';
+
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <meta charset="utf-8" />
     <meta

--- a/examples/framework-svelte/src/pages/index.astro
+++ b/examples/framework-svelte/src/pages/index.astro
@@ -2,10 +2,12 @@
 // Component Imports
 import Counter from '../components/Counter.svelte'
 
+let lang = 'en';
+
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <meta charset="utf-8" />
     <meta

--- a/examples/framework-vue/src/pages/index.astro
+++ b/examples/framework-vue/src/pages/index.astro
@@ -2,10 +2,12 @@
 // Component Imports
 import Counter from '../components/Counter.vue'
 
+let lang = 'en';
+
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <meta charset="utf-8" />
     <meta

--- a/examples/portfolio/src/layouts/project.astro
+++ b/examples/portfolio/src/layouts/project.astro
@@ -6,7 +6,7 @@ import Nav from '../components/Nav/index.jsx';
 
 const { content } = Astro.props;
 ---
-<html>
+<html lang={ content.lang ?? 'en' }>
   <head>
     <MainHead title={content.title} />
     <style lang="scss">

--- a/examples/portfolio/src/pages/$projects.astro
+++ b/examples/portfolio/src/pages/$projects.astro
@@ -5,6 +5,7 @@ import Nav from '../components/Nav/index.jsx';
 import PortfolioPreview from '../components/PortfolioPreview/index.jsx';
 
 let { collection } = Astro.props;
+let lang = 'en';
 export async function createCollection() {
   return {
     async data() {
@@ -16,7 +17,7 @@ export async function createCollection() {
 }
 ---
 
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <MainHead title="All Projects | Jeanine White" />
     <style lang="scss">

--- a/examples/portfolio/src/pages/404.astro
+++ b/examples/portfolio/src/pages/404.astro
@@ -2,9 +2,11 @@
 import MainHead from '../components/MainHead.astro';
 import Footer from '../components/Footer/index.jsx';
 import Nav from '../components/Nav/index.jsx';
+
+let lang = 'en';
 ---
 
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <MainHead title="Not Found" />
   </head>

--- a/examples/portfolio/src/pages/about.astro
+++ b/examples/portfolio/src/pages/about.astro
@@ -2,9 +2,11 @@
 import MainHead from '../components/MainHead.astro';
 import Footer from '../components/Footer/index.jsx';
 import Nav from '../components/Nav/index.jsx';
+
+let lang = 'en';
 ---
 
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <MainHead title="About | Jeanine White" />
     <style lang="scss">

--- a/examples/portfolio/src/pages/index.astro
+++ b/examples/portfolio/src/pages/index.astro
@@ -9,11 +9,12 @@ import PorfolioPreview from '../components/PortfolioPreview/index.jsx';
 // Data Fetching: List all Markdown posts in the repo.
 const projects = Astro.fetchContent('./project/**/*.md');
 const featuredProject = projects[0];
+let lang = 'en';
 
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <MainHead title="Jeanine White: Personal Site" />
     <style lang="scss">

--- a/examples/snowpack/src/layouts/content-with-cover.astro
+++ b/examples/snowpack/src/layouts/content-with-cover.astro
@@ -8,7 +8,7 @@ const { content } = Astro.props;
 ---
 
 <!doctype html>
-<html>
+<html lang={ content.lang ?? 'en' }>
 
 <head>
   <style>

--- a/examples/snowpack/src/layouts/content.astro
+++ b/examples/snowpack/src/layouts/content.astro
@@ -8,7 +8,7 @@ const { content } = Astro.props;
 ---
 
 <!doctype html>
-<html>
+<html lang={ content.lang ?? 'en' }>
 
 <head>
   <BaseHead title={content.title} description={content.description} permalink="TODO" />

--- a/examples/snowpack/src/layouts/post.astro
+++ b/examples/snowpack/src/layouts/post.astro
@@ -7,7 +7,7 @@ const { content } = Astro.props;
 ---
 
 <!doctype html>
-<html>
+<html lang={ content.lang ?? 'en' }>
 
 <head>
   <style lang="scss">

--- a/examples/snowpack/src/pages/404.astro
+++ b/examples/snowpack/src/pages/404.astro
@@ -4,10 +4,11 @@ import MainLayout from '../components/MainLayout.astro';
 
 let title = 'Not Found';
 let description = 'Snowpack is a lightning-fast frontend build tool, designed for the modern web.';
+let lang = 'en';
 ---
 
 <!doctype html>
-<html>
+<html lang={ lang ?? 'en' }>
 
 <head>
   <BaseHead title={title} description={description} permalink="TODO" />

--- a/examples/snowpack/src/pages/guides.astro
+++ b/examples/snowpack/src/pages/guides.astro
@@ -23,7 +23,7 @@ let title = 'Guides';
 let description = 'Snowpack\'s usage and integration guides.';
 let guides;
 let communityGuides;
-
+let lang = 'en';
 
   guides = paginate({
     files: '/posts/guides/*.md',
@@ -41,7 +41,7 @@ let communityGuides;
 ---
 
 <!doctype html>
-<html>
+<html lang={ lang ?? 'en' }>
 
 <head>
   <BaseHead title={title} description={description} permalink="TODO" />

--- a/examples/snowpack/src/pages/index.astro
+++ b/examples/snowpack/src/pages/index.astro
@@ -7,10 +7,11 @@ import BaseLayout from '../components/BaseLayout.astro';
 
 let title = 'Snowpack';
 let description = 'Snowpack is a lightning-fast frontend build tool, designed for the modern web.';
+let lang = 'en';
 ---
 
 <!doctype html>
-<html>
+<html lang={ lang ?? 'en' }>
 <head>
   <style lang="scss">
     @use '../../public/styles/var' as *;

--- a/examples/snowpack/src/pages/news.astro
+++ b/examples/snowpack/src/pages/news.astro
@@ -14,10 +14,11 @@ import users from '../data/users.json';
 
 const title = 'Community & News';
 const description = 'Snowpack community news and companies that use Snowpack.';
+let lang = 'en';
 ---
 
 <!doctype html>
-<html>
+<html lang={ lang ?? 'en' }>
 
 <head>
   <BaseHead title={title} description={description} permalink="TODO" />

--- a/examples/snowpack/src/pages/plugins.astro
+++ b/examples/snowpack/src/pages/plugins.astro
@@ -5,10 +5,11 @@ import MainLayout from '../components/MainLayout.astro';
 
 let title = 'The Snowpack Plugin Catalog';
 let description = 'Snowpack plugins allow for configuration-minimal tooling integration.';
+let lang = 'en';
 ---
 
 <!doctype html>
-<html>
+<html lang={ lang ?? 'en' }>
 
 <head>
   <BaseHead title={title} description={description} permalink="TODO" />

--- a/examples/snowpack/src/pages/proof-of-concept-dynamic/[slug].astro.ignore
+++ b/examples/snowpack/src/pages/proof-of-concept-dynamic/[slug].astro.ignore
@@ -8,6 +8,7 @@ import BaseLayout from '../components/BaseLayout.astro';
 let title = 'Community & News';
 let description = 'Snowpack community news and companies that use Snowpack.';
 let entry;
+let lang = 'en';
 
 export default async function ({ params }) {
     entry = await contentful.getEntry(params.slug);
@@ -15,7 +16,7 @@ export default async function ({ params }) {
 }
 ---
 
-<html>
+<html lang={ lang ?? 'en' }>
 
 <head>
   <BaseHead title={title} description={description} permalink="TODO" />

--- a/examples/starter/src/pages/index.astro
+++ b/examples/starter/src/pages/index.astro
@@ -9,11 +9,12 @@ import Tour from '../components/Tour.astro';
 // It will run during the build, but never in the browser.
 // All variables are available to use in the HTML template below.
 let title = 'My Astro Site';
+let lang = 'en';
 
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html lang="en">
+<html lang={ lang ?? 'en' }>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-markdown-plugins/src/layouts/main.astro
+++ b/examples/with-markdown-plugins/src/layouts/main.astro
@@ -2,7 +2,7 @@
 const { content } = Astro.props;
 ---
 
-<html>
+<html lang={ content.lang ?? 'en' }>
   <head>
     <meta charset="utf-8" />
     <title>{content.title}</title>

--- a/examples/with-markdown/src/layouts/main.astro
+++ b/examples/with-markdown/src/layouts/main.astro
@@ -2,7 +2,7 @@
 const { content } = Astro.props;
 ---
 
-<html>
+<html lang={ content.lang ?? 'en' }>
   <head>
     <meta charset="utf-8">
     <title>{content.title}</title>

--- a/examples/with-nanostores/src/pages/index.astro
+++ b/examples/with-nanostores/src/pages/index.astro
@@ -5,10 +5,11 @@ import AdminsSvelte from '../components/AdminsSvelte.svelte';
 import AdminsVue from '../components/AdminsVue.vue';
 import AdminsPreact from '../components/AdminsPreact.jsx';
 
+let lang = 'en';
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html lang="en">
+<html lang={ lang ?? 'en' }>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-tailwindcss/src/pages/index.astro
+++ b/examples/with-tailwindcss/src/pages/index.astro
@@ -2,10 +2,11 @@
 // Component Imports
 import Button from '../components/Button.astro';
 
+let lang = 'en';
 // Full Astro Component Syntax:
 // https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
 ---
-<html>
+<html lang={ lang ?? 'en' }>
   <head>
     <meta charset="UTF-8" />
     <title>Astro + TailwindCSS</title>


### PR DESCRIPTION
## Changes

- Adds missing lang attribute to html tags in examples/ folder

## Testing

I found this issue in my blog starter template after running lighthouse in my browser.

## Docs

Haven't seen any documentation around this to update.
