### PR TITLE
Fix astro/jsx comparison table formatting

### DIFF
--- a/docs/core-concepts/astro-components.md
+++ b/docs/core-concepts/astro-components.md
@@ -205,26 +205,23 @@ Inside of an expression, you must wrap multiple elements in a Fragment. Fragment
 
 `.astro` files can end up looking very similar to `.jsx` files, but there are a few key differences. Here's a comparison between the two formats.
 
-| Feature                 | Astro           | JSX              |
-| ----------------------- | --------------- | ---------------- |
-| File extension          | `.astro`        | `.jsx` or `.tsx` |
-| User-Defined Components | `<Capitalized>` | `<Capitalized>`  |
-| Expression Syntax       | `{}`            | `{}`             |
-| Spread Attributes       | `{...props}`    | `{...props}`     |
-
-|
-| Children | `<slot>` (with named slot support) | `children`  
-|
-| Boolean Attributes | `autocomplete` === `autocomplete={true}` | `autocomplete` === `autocomplete={true}` |
-| Inline Functions | `{items.map(item => <li>{item}</li>)}` | `{items.map(item => <li>{item}</li>)}` |
-| IDE Support | WIP - [VS Code][code-ext] | Phenomenal |
-| Requires JS import | No | Yes, `jsxPragma` (`React` or `h`) must be in scope |
-| Fragments | Automatic top-level, `<>` inside functions | Wrap with `<Fragment>` or `<>` |
-| Multiple frameworks per-file | Yes | No |
-| Modifying `<head>` | Just use `<head>` | Per-framework (`<Head>`, `<svelte:head>`, etc) |
-| Comment Style | `<!-- HTML -->` | `{/* JavaScript */}` |
-| Special Characters | `&nbsp;` | `{'\xa0'}` or `{String.fromCharCode(160)}` |
-| Attributes | `dash-case` | `camelCase` |
+| Feature                      | Astro                                      | JSX                                                |
+| ---------------------------- | ------------------------------------------ | -------------------------------------------------- |
+| File extension               | `.astro`                                   | `.jsx` or `.tsx`                                   |
+| User-Defined Components      | `<Capitalized>`                            | `<Capitalized>`                                    |
+| Expression Syntax            | `{}`                                       | `{}`                                               |
+| Spread Attributes            | `{...props}`                               | `{...props}`                                       |
+| Children                     | `<slot>` (with named slot support)         | `children`                                         |
+| Boolean Attributes           | `autocomplete` === `autocomplete={true}`   | `autocomplete` === `autocomplete={true}`           |
+| Inline Functions             | `{items.map(item => <li>{item}</li>)}`     | `{items.map(item => <li>{item}</li>)}`             |
+| IDE Support                  | WIP - [VS Code][code-ext]                  | Phenomenal                                         |
+| Requires JS import           | No                                         | Yes, `jsxPragma` (`React` or `h`) must be in scope |
+| Fragments                    | Automatic top-level, `<>` inside functions | Wrap with `<Fragment>` or `<>`                     |
+| Multiple frameworks per-file | Yes                                        | No                                                 |
+| Modifying `<head>`           | Just use `<head>`                          | Per-framework (`<Head>`, `<svelte:head>`, etc)     |
+| Comment Style                | `<!-- HTML -->`                            | `{/* JavaScript */}`                               |
+| Special Characters           | `&nbsp;`                                   | `{'\xa0'}` or `{String.fromCharCode(160)}`         |
+| Attributes                   | `dash-case`                                | `camelCase`                                        |
 
 ### URL resolution
 


### PR DESCRIPTION
## Changes

This PR fixes formatting of the `.astro`/`.jsx` formats comparison table.

Before:

![image](https://user-images.githubusercontent.com/5723/125406507-34400d80-e3b9-11eb-9816-740f30210761.png)

After:

![image](https://user-images.githubusercontent.com/5723/125406547-3d30df00-e3b9-11eb-854c-32c68097efd2.png)

## Testing

Documentation only

## Docs

Updates the Astro component documentation
