### PR TITLE
Add Astro `<Debug/>` component

### DIFF
--- a/.changeset/wet-schools-dream.md
+++ b/.changeset/wet-schools-dream.md
@@ -1,0 +1,14 @@
+---
+'astro': patch
+---
+
+Add `<Debug>` component for JavaScript-free client-side debugging.
+
+```astro
+---
+import Debug from 'astro/debug';
+const obj = { /* ... */ }
+---
+
+<Debug {obj} />
+```

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -18,6 +18,7 @@ export const SIDEBAR = {
     { text: 'Guides', header: true },
     { text: 'Styling & CSS', link: 'guides/styling' },
     { text: 'Markdown', link: 'guides/markdown-content' },
+    { text: 'Debugging', link: 'guides/debugging' },
     { text: 'Data Fetching', link: 'guides/data-fetching' },
     { text: 'Pagination', link: 'guides/pagination' },
     { text: 'RSS', link: 'guides/rss' },

--- a/docs/src/pages/guides/debugging.md
+++ b/docs/src/pages/guides/debugging.md
@@ -1,0 +1,23 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Debugging
+---
+
+Since Astro runs on the server and logs to your terminal, it can be difficult to debug values from Astro. Astro's built-in `<Debug>` component can help you inspect values inside your files on the clientside.
+
+## Usage
+
+```astro
+---
+import Debug from 'astro/debug';
+const serverObject = {
+  a: 0,
+  b: "string",
+  c: {
+    nested: "object"
+  }
+}
+---
+
+<Debug {serverObject} />
+```

--- a/docs/src/pages/guides/debugging.md
+++ b/docs/src/pages/guides/debugging.md
@@ -3,21 +3,4 @@ layout: ~/layouts/MainLayout.astro
 title: Debugging
 ---
 
-Since Astro runs on the server and logs to your terminal, it can be difficult to debug values from Astro. Astro's built-in `<Debug>` component can help you inspect values inside your files on the clientside.
-
-## Usage
-
-```astro
----
-import Debug from 'astro/debug';
-const serverObject = {
-  a: 0,
-  b: "string",
-  c: {
-    nested: "object"
-  }
-}
----
-
-<Debug {serverObject} />
-```
+Astro runs on the server and logs directly to your terminal, so it can be difficult to debug values from Astro. Astro's built-in `<Debug>` component can help you inspect values inside your files on the clientside. Read more about the [built-in Debug Component](/reference/builtin-components#debug-).

--- a/docs/src/pages/reference/builtin-components.md
+++ b/docs/src/pages/reference/builtin-components.md
@@ -30,3 +30,22 @@ import { Prism } from 'astro/components';
 ```
 
 This component provides syntax highlighting for code blocks. Since this never changes in the client it makes sense to use an Astro component (it's equally reasonable to use a framework component for this kind of thing; Astro is server-only by default for all frameworks!).
+
+
+## `<Debug />`
+
+```astro
+---
+import { Debug } from 'astro/debug';
+const serverObject = {
+  a: 0,
+  b: "string",
+  c: {
+    nested: "object"
+  }
+}
+---
+<Debug {serverObject} />
+```
+
+This component provides a way to inspect values on the clientside, without any JavaScript. 

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "astro": "^0.19.2"
+  },
+  "snowpack": {
+    "workspaceRoot": "../.."
   }
 }

--- a/packages/astro/components/Debug.astro
+++ b/packages/astro/components/Debug.astro
@@ -1,20 +1,6 @@
-<style>
-  details {
-    overflow-x: auto;
-    max-width: 100%;
-    position: fixed;
-    top: 2rem;
-    left: 2rem;
-    bottom: 2rem;
-    right: 2rem;
-    z-index: 999;
-    color: white;
-    background-color: black;
-  }
-</style>
+---
+import { Prism } from 'astro/components';
+---
 
-<details>
-  <summary>Debug</summary>
-  <!-- JSON.stringify can pretty print our input: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_argument -->
-  <pre>{JSON.stringify(Astro.props, null, 2)}</pre>
-</details>
+<!-- JSON.stringify can pretty print our input: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_argument -->
+<Prism lang="json" code={JSON.stringify(Astro.props, null, 2)}/>

--- a/packages/astro/components/Debug.astro
+++ b/packages/astro/components/Debug.astro
@@ -141,9 +141,9 @@ const Node = ({ node, key, ...props }) => {
 ---
 
 <div class="debug">
-  <header>
-    <h2><span class="debug-title">Debug</span> <span class="debug-name">"{key}"</span></h2>
-  </header>
+  <div class="debug-header">
+    <h2 class="debug-title"><span class="debug-label">Debug</span> <span class="debug-name">"{key}"</span></h2>
+  </div>
 
   <main>
     <Node node={value} />
@@ -151,18 +151,18 @@ const Node = ({ node, key, ...props }) => {
 </div>
 
 <style lang="scss">
-header {
+.debug-header {
   background: #FF1639;
   margin: -1rem -1.5rem 1rem;
   padding: 0.25rem 0.75rem;
 }
 
-h2 {
+.debug-title {
   font-size: 1em;
   color: #fff;
 }
 
-.debug-title {
+.debug-label {
   font-weight: bold;
   text-transform: uppercase;
   margin-right: 0.75em;

--- a/packages/astro/components/Debug.astro
+++ b/packages/astro/components/Debug.astro
@@ -1,8 +1,4 @@
 ---
-export interface Props {
-  value: any;
-}
-
 const key = Object.keys(Astro.props)[0];
 const value = Astro.props[key];
 

--- a/packages/astro/components/Debug.astro
+++ b/packages/astro/components/Debug.astro
@@ -1,6 +1,308 @@
 ---
-import { Prism } from 'astro/components';
+export interface Props {
+  value: any;
+}
+
+const key = Object.keys(Astro.props)[0];
+const value = Astro.props[key];
+
+const getType = (node: unknown) => {
+  if (Array.isArray(node)) return 'array';
+  if (node === null) return 'null';
+  if (typeof node === 'object') {
+    if ((node as any).then) return 'promise';
+  }
+  return typeof node;
+};
+
+const getSummary = (node: any, key: string) => {
+  const type = getType(node);
+  let value;
+  let open;
+  let close;
+
+  if (type === 'function') {
+    return <>
+      {(key || !key && key === 0) && <><span class="key">{key}</span><span class="sep">:</span></>}
+      <span class="value value-function">{node.name}<span class="punc">()</span></span>
+    </>
+  }
+
+  if (type === 'promise') {
+    return <>
+      {(key || !key && key === 0) && <><span class="key">{key}</span><span class="sep">:</span></>}
+      <span class="value value-promise">Promise</span>
+    </>
+  }
+
+  if (type === 'array') {
+    value = node.length;
+    open = <><span class="none">Array</span>{'['}</>;
+    close = ']';
+  } else if (type === 'object') {
+    const keys = Object.keys(node);
+    if (keys.length === 0) {
+      value = 'Empty';
+    } else if (keys.length > 3) {
+      value = '…';
+    } else {
+      value = keys.slice(0, 3).join(',');
+    }
+    open = '{';
+    close = '}';
+  };
+
+  return <>
+    {key && <><span class="key">{key}</span>: </>}
+    {open && <span class="punc">{open}</span>}
+    <span class="hide">
+      <span class="len">{value}</span>
+      {close && <span class="punc">{close}</span>}
+    </span>
+  </>;
+};
+
+const Details = ({ node, key, children }) => {
+  const type = getType(node);
+  const props = {};
+
+  if (type === 'array' || type === 'object') {
+    props['data-char'] = type === 'array' ? ']' : '}'
+    props.open = !key && type === 'object' ? '' : undefined;
+  }
+  
+  return (
+    <details {...props}>
+        <Summary node={node} key={key} />
+        {children}
+    </details>
+  );
+}
+
+const Summary = ({ node, key }) => {
+  return (
+    <summary>{getSummary(node, key)}</summary>
+  );
+}
+
+const Empty = Symbol('Empty');
+
+const KeyValue = ({ key, value, dim }) => {
+  let type = key === '__proto__' ? 'prototype' : getType(value);
+  if (type === 'null') {
+    value = 'null';
+  } else if (type === 'undefined') {
+    value = 'undefined';
+  } else if (value === Empty) {
+    type = 'empty';
+    value = 'Empty';
+  } else {
+    value = JSON.stringify(value);
+  }
+
+  return (
+    <div class="line">
+      {(key || !key && key === 0) && <><span class={`key ${dim ? 'key-dim' : ''}`.trim()}>{key}</span><span class="sep">:</span></>}
+      <span class={`value value-${type}`}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+const Node = ({ node, key, ...props }) => {
+  const type = getType(node);
+
+  if (type === 'array' || type === 'object') {
+    let children = [];
+    if (type === 'array' && node.length > 0 && Object.entries(node).length === 0) {
+      children = Array.from({ length: node.length }, (_, key) => <Node node={Empty} key={key} />);
+    } else {
+      children = Object.entries(node).map(([key, value]) => <Node node={value} key={key} />);
+    }
+    return (
+      <Details node={node} key={key} children={children} />
+    );
+  } else if (type === 'function') {
+    return (
+      <Details node={node} key={key} children={
+      <>
+        <KeyValue key="name" value={node.name} dim={true} />
+        <KeyValue key="__proto__" value="Function" dim={true} />
+      </>
+      }/>
+    );
+  } else if (type === 'promise') {
+    return (
+      <Details node={node} key={key} children={
+        <KeyValue key="__proto__" value="Promise" dim={true} />
+      } />
+    );
+  }
+
+  return <KeyValue key={key} value={node} />;
+}
 ---
 
-<!-- JSON.stringify can pretty print our input: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_argument -->
-<Prism lang="json" code={JSON.stringify(Astro.props, null, 2)}/>
+<div class="debug">
+  <header>
+    <h2><span class="debug-title">Debug</span> <span class="debug-name">"{key}"</span></h2>
+  </header>
+
+  <main>
+    <Node node={value} />
+  </main>
+</div>
+
+<style lang="scss">
+header {
+  background: #FF1639;
+  margin: -1rem -1.5rem 1rem;
+  padding: 0.25rem 0.75rem;
+}
+
+h2 {
+  font-size: 1em;
+  color: #fff;
+}
+
+.debug-title {
+  font-weight: bold;
+  text-transform: uppercase;
+  margin-right: 0.75em;
+}
+
+.debug {
+  all: initial;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 1.5rem;
+  overflow-y: hidden;
+  overflow-x: auto;
+  border: 1px solid #FFCFD6;
+
+  background: #FFF;
+  font-family: Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace;
+  font-size: 0.8rem;
+  line-height: 1.44;
+  color: #6b7280;
+  white-space: pre;
+
+  :global(details[open] > summary span.hide) {
+    visibility: hidden;
+  }
+
+  :global(details[open] > summary span.none) {
+    display: none;
+  }
+
+  :global(details > details) {
+    padding-left: 1em;
+  }
+
+  :global(.line) {
+    padding-left: 1.125em;
+  }
+
+  :global(details[open]::after) {
+    content: attr(data-char);
+  }
+
+  :global(.sep) {
+    margin-right: 0.25em;
+  }
+
+
+:global(details > summary) {
+  cursor: pointer;
+}
+
+:global(details:hover > summary::before),
+:global(details:focus > summary::before) {
+  transform: translate(0.25em, -0.25em);
+}
+
+:global(details > summary::before) {
+  content: '';
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M13 8L2.60769 14L2.6077 2L13 8Z' fill='%236B7280' /%3E%3C/svg%3E%0A");
+  background-size: 1em;
+
+  display: inline-flex;
+  font-size: 0.5em;
+  width: 1em;
+  height: 1em;
+  margin-right: 1.25em;
+  margin-left: -2em;
+  transform: translate(0, -0.25em);
+  line-height: 1em;
+  transition: transform 120ms ease-in;
+}
+
+:global(details[open] > summary::before) {
+  transform: translate(0.25em, -0.25em) rotate(90deg);
+}
+
+:global(::marker) {
+  content: '';
+  width: 0;
+  visibility: hidden;
+}
+
+:global(.key) {
+  color: #882de7;
+}
+
+:global(.key-dim) {
+  color: #B881F1;
+}
+
+:global(.len) {
+  color: #B881F1;
+}
+
+:global(details:hover > summary),
+:global(details:focus > summary),
+:global(details:hover > summary .punc),
+:global(details:focus > summary .punc),
+:global(details:hover[open]::after),
+:global(details:focus[open]::after) {
+  color: #000012;
+}
+
+:global(details:hover > summary .len),
+:global(details:focus > summary .len) {
+  color: #882DE7;
+}
+
+:global(.punc) {
+  color: #6b7280;
+}
+
+:global(.value-string) {
+  color: #17c083;
+}
+
+:global(.value-function::before) {
+  content: 'ƒ ';
+  color: #3894ff;
+}
+:global(.value-function) {
+  color: #5076f9;
+}
+
+:global(.value-number) {
+  color: #ff5d01;
+}
+
+:global(.value-null),
+:global(.value-undefined) {
+  color: #9ca3af;
+}
+
+:global(main > .line) {
+  margin-left: -0.75em;
+  padding-left: 0;
+}
+  
+}
+</style>

--- a/packages/astro/components/Debug.astro
+++ b/packages/astro/components/Debug.astro
@@ -11,7 +11,7 @@ const getType = (node: unknown) => {
   return typeof node;
 };
 
-const getSummary = (node: any, key: string) => {
+const getSummary = (node: any, key: string, className: string) => {
   const type = getType(node);
   let value;
   let open;
@@ -19,21 +19,21 @@ const getSummary = (node: any, key: string) => {
 
   if (type === 'function') {
     return <>
-      {(key || !key && key === 0) && <><span class="key">{key}</span><span class="sep">:</span></>}
-      <span class="value value-function">{node.name}<span class="punc">()</span></span>
+      {(key || !key && key === 0) && <><span class={`${className} key`}>{key}</span><span class={`${className} sep`}>:</span></>}
+      <span class={`${className} value value-function`}>{node.name}<span class={`${className} punc`}>()</span></span>
     </>
   }
 
   if (type === 'promise') {
     return <>
-      {(key || !key && key === 0) && <><span class="key">{key}</span><span class="sep">:</span></>}
-      <span class="value value-promise">Promise</span>
+      {(key || !key && key === 0) && <><span class={`${className} key`}>{key}</span><span class={`${className} sep`}>:</span></>}
+      <span class={`${className} value value-promise`}>Promise</span>
     </>
   }
 
   if (type === 'array') {
     value = node.length;
-    open = <><span class="none">Array</span>{'['}</>;
+    open = <><span class={`${className} none`}>Array</span>{'['}</>;
     close = ']';
   } else if (type === 'object') {
     const keys = Object.keys(node);
@@ -49,16 +49,16 @@ const getSummary = (node: any, key: string) => {
   };
 
   return <>
-    {key && <><span class="key">{key}</span>: </>}
-    {open && <span class="punc">{open}</span>}
-    <span class="hide">
-      <span class="len">{value}</span>
-      {close && <span class="punc">{close}</span>}
+    {key && <><span class={`${className} key`}>{key}</span>: </>}
+    {open && <span class={`${className} punc`}>{open}</span>}
+    <span class={`${className} hide`}>
+      <span class={`${className} len`}>{value}</span>
+      {close && <span class={`${className} punc`}>{close}</span>}
     </span>
   </>;
 };
 
-const Details = ({ node, key, children }) => {
+const Details = ({ node, key, children, class: className }) => {
   const type = getType(node);
   const props = {};
 
@@ -68,22 +68,22 @@ const Details = ({ node, key, children }) => {
   }
   
   return (
-    <details {...props}>
-        <Summary node={node} key={key} />
+    <details {...props} class={className}>
+        <Summary node={node} key={key} class={className} />
         {children}
     </details>
   );
 }
 
-const Summary = ({ node, key }) => {
+const Summary = ({ node, key, class: className }) => {
   return (
-    <summary>{getSummary(node, key)}</summary>
+    <summary class={className}>{getSummary(node, key, className)}</summary>
   );
 }
 
 const Empty = Symbol('Empty');
 
-const KeyValue = ({ key, value, dim }) => {
+const KeyValue = ({ key, value, dim, class: className }) => {
   let type = key === '__proto__' ? 'prototype' : getType(value);
   if (type === 'null') {
     value = 'null';
@@ -97,46 +97,47 @@ const KeyValue = ({ key, value, dim }) => {
   }
 
   return (
-    <div class="line">
-      {(key || !key && key === 0) && <><span class={`key ${dim ? 'key-dim' : ''}`.trim()}>{key}</span><span class="sep">:</span></>}
-      <span class={`value value-${type}`}>
+    <div class={`${className} line`}>
+      {(key || !key && key === 0) && <><span class={`${className} key ${dim ? 'key-dim' : ''}`.trim()}>{key}</span><span class={`${className} sep`}>:</span></>}
+      <span class={`${className} value value-${type}`}>
         {value}
       </span>
     </div>
   )
 }
 
-const Node = ({ node, key, ...props }) => {
+const Node = ({ node, key, class: className, ...props }) => {
   const type = getType(node);
+  className = className.replace(/debug-value/g, '');
 
   if (type === 'array' || type === 'object') {
     let children = [];
     if (type === 'array' && node.length > 0 && Object.entries(node).length === 0) {
-      children = Array.from({ length: node.length }, (_, key) => <Node node={Empty} key={key} />);
+      children = Array.from({ length: node.length }, (_, key) => <Node node={Empty} key={key} class={className} />);
     } else {
-      children = Object.entries(node).map(([key, value]) => <Node node={value} key={key} />);
+      children = Object.entries(node).map(([key, value]) => <Node node={value} key={key} class={className} />);
     }
     return (
-      <Details node={node} key={key} children={children} />
+      <Details node={node} key={key} children={children} class={className} />
     );
   } else if (type === 'function') {
     return (
-      <Details node={node} key={key} children={
+      <Details node={node} key={key} class={className} children={
       <>
-        <KeyValue key="name" value={node.name} dim={true} />
-        <KeyValue key="__proto__" value="Function" dim={true} />
+        <KeyValue key="name" value={node.name} dim={true} class={className} />
+        <KeyValue key="__proto__" value="Function" dim={true} class={className} />
       </>
       }/>
     );
   } else if (type === 'promise') {
     return (
-      <Details node={node} key={key} children={
+      <Details node={node} key={key} class={className} children={
         <KeyValue key="__proto__" value="Promise" dim={true} />
       } />
     );
   }
 
-  return <KeyValue key={key} value={node} />;
+  return <KeyValue key={key} value={node} class={className} />;
 }
 ---
 
@@ -146,7 +147,7 @@ const Node = ({ node, key, ...props }) => {
   </div>
 
   <main>
-    <Node node={value} />
+    <Node node={value} class="debug-value" />
   </main>
 </div>
 
@@ -184,121 +185,121 @@ const Node = ({ node, key, ...props }) => {
   color: #6b7280;
   white-space: pre;
 
-  :global(details[open] > summary span.hide) {
-    visibility: hidden;
-  }
+}
 
-  :global(details[open] > summary span.none) {
+details[open] > summary span.hide {
+  visibility: hidden;
+}
+
+details[open] > summary span.none {
     display: none;
   }
 
-  :global(details > details) {
+details > details {
     padding-left: 1em;
   }
 
-  :global(.line) {
+.line {
     padding-left: 1.125em;
   }
 
-  :global(details[open]::after) {
+details[open]::after {
     content: attr(data-char);
   }
 
-  :global(.sep) {
+.sep {
     margin-right: 0.25em;
   }
 
 
-  :global(details > summary) {
+details > summary {
     cursor: pointer;
   }
 
-  :global(details:hover > summary::before),
-  :global(details:focus > summary::before) {
-    transform: translate(0.25em, -0.25em);
-  }
+details:hover > summary::before,
+details:focus > summary::before {
+  transform: translate(0.25em, -0.25em);
+}
 
-  :global(details > summary::before) {
-    content: '';
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M13 8L2.60769 14L2.6077 2L13 8Z' fill='%236B7280' /%3E%3C/svg%3E%0A");
-    background-size: 1em;
+details > summary::before {
+  content: '';
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M13 8L2.60769 14L2.6077 2L13 8Z' fill='%236B7280' /%3E%3C/svg%3E%0A");
+  background-size: 1em;
 
-    display: inline-flex;
-    font-size: 0.5em;
-    width: 1em;
-    height: 1em;
-    margin-right: 1.25em;
-    margin-left: -2em;
-    transform: translate(0, -0.25em);
-    line-height: 1em;
-    transition: transform 120ms ease-in;
-  }
+  display: inline-flex;
+  font-size: 0.5em;
+  width: 1em;
+  height: 1em;
+  margin-right: 1.25em;
+  margin-left: -2em;
+  transform: translate(0, -0.25em);
+  line-height: 1em;
+  transition: transform 120ms ease-in;
+}
 
-  :global(details[open] > summary::before) {
-    transform: translate(0.25em, -0.25em) rotate(90deg);
-  }
+details[open] > summary::before {
+  transform: translate(0.25em, -0.25em) rotate(90deg);
+}
 
-  :global(::marker) {
-    content: '';
-    width: 0;
-    visibility: hidden;
-  }
+.debug :global(::marker) {
+  content: '';
+  width: 0;
+  visibility: hidden;
+}
 
-  :global(.key) {
-    color: #882de7;
-  }
+.key {
+  color: #882de7;
+}
 
-  :global(.key-dim) {
-    color: #B881F1;
-  }
+.key-dim {
+  color: #B881F1;
+}
 
-  :global(.len) {
-    color: #B881F1;
-  }
+.len {
+  color: #B881F1;
+}
 
-  :global(details:hover > summary),
-  :global(details:focus > summary),
-  :global(details:hover > summary .punc),
-  :global(details:focus > summary .punc),
-  :global(details:hover[open]::after),
-  :global(details:focus[open]::after) {
-    color: #000012;
-  }
+details:hover > summary,
+details:focus > summary,
+details:hover > summary .punc,
+details:focus > summary .punc,
+details:hover[open]::after,
+details:focus[open]::after {
+  color: #000012;
+}
 
-  :global(details:hover > summary .len),
-  :global(details:focus > summary .len) {
-    color: #882DE7;
-  }
+details:hover > summary .len,
+details:focus > summary .len {
+  color: #882DE7;
+}
 
-  :global(.punc) {
-    color: #6b7280;
-  }
+.punc {
+  color: #6b7280;
+}
 
-  :global(.value-string) {
-    color: #17c083;
-  }
+.value-string {
+  color: #17c083;
+}
 
-  :global(.value-function::before) {
-    content: 'ƒ ';
-    color: #3894ff;
-  }
-  :global(.value-function) {
-    color: #5076f9;
-  }
+.value-function::before {
+  content: 'ƒ ';
+  color: #3894ff;
+}
+.value-function {
+  color: #5076f9;
+}
 
-  :global(.value-number) {
-    color: #ff5d01;
-  }
+.value-number {
+  color: #ff5d01;
+}
 
-  :global(.value-null),
-  :global(.value-undefined) {
-    color: #9ca3af;
-  }
+.value-null,
+.value-undefined {
+  color: #9ca3af;
+}
 
-  :global(main > .line) {
-    margin-left: -0.75em;
-    padding-left: 0;
-  }
-  
+main > .line {
+  margin-left: -0.75em;
+  padding-left: 0;
 }
 </style>

--- a/packages/astro/components/Debug.astro
+++ b/packages/astro/components/Debug.astro
@@ -209,96 +209,96 @@ const Node = ({ node, key, ...props }) => {
   }
 
 
-:global(details > summary) {
-  cursor: pointer;
-}
+  :global(details > summary) {
+    cursor: pointer;
+  }
 
-:global(details:hover > summary::before),
-:global(details:focus > summary::before) {
-  transform: translate(0.25em, -0.25em);
-}
+  :global(details:hover > summary::before),
+  :global(details:focus > summary::before) {
+    transform: translate(0.25em, -0.25em);
+  }
 
-:global(details > summary::before) {
-  content: '';
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M13 8L2.60769 14L2.6077 2L13 8Z' fill='%236B7280' /%3E%3C/svg%3E%0A");
-  background-size: 1em;
+  :global(details > summary::before) {
+    content: '';
+    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M13 8L2.60769 14L2.6077 2L13 8Z' fill='%236B7280' /%3E%3C/svg%3E%0A");
+    background-size: 1em;
 
-  display: inline-flex;
-  font-size: 0.5em;
-  width: 1em;
-  height: 1em;
-  margin-right: 1.25em;
-  margin-left: -2em;
-  transform: translate(0, -0.25em);
-  line-height: 1em;
-  transition: transform 120ms ease-in;
-}
+    display: inline-flex;
+    font-size: 0.5em;
+    width: 1em;
+    height: 1em;
+    margin-right: 1.25em;
+    margin-left: -2em;
+    transform: translate(0, -0.25em);
+    line-height: 1em;
+    transition: transform 120ms ease-in;
+  }
 
-:global(details[open] > summary::before) {
-  transform: translate(0.25em, -0.25em) rotate(90deg);
-}
+  :global(details[open] > summary::before) {
+    transform: translate(0.25em, -0.25em) rotate(90deg);
+  }
 
-:global(::marker) {
-  content: '';
-  width: 0;
-  visibility: hidden;
-}
+  :global(::marker) {
+    content: '';
+    width: 0;
+    visibility: hidden;
+  }
 
-:global(.key) {
-  color: #882de7;
-}
+  :global(.key) {
+    color: #882de7;
+  }
 
-:global(.key-dim) {
-  color: #B881F1;
-}
+  :global(.key-dim) {
+    color: #B881F1;
+  }
 
-:global(.len) {
-  color: #B881F1;
-}
+  :global(.len) {
+    color: #B881F1;
+  }
 
-:global(details:hover > summary),
-:global(details:focus > summary),
-:global(details:hover > summary .punc),
-:global(details:focus > summary .punc),
-:global(details:hover[open]::after),
-:global(details:focus[open]::after) {
-  color: #000012;
-}
+  :global(details:hover > summary),
+  :global(details:focus > summary),
+  :global(details:hover > summary .punc),
+  :global(details:focus > summary .punc),
+  :global(details:hover[open]::after),
+  :global(details:focus[open]::after) {
+    color: #000012;
+  }
 
-:global(details:hover > summary .len),
-:global(details:focus > summary .len) {
-  color: #882DE7;
-}
+  :global(details:hover > summary .len),
+  :global(details:focus > summary .len) {
+    color: #882DE7;
+  }
 
-:global(.punc) {
-  color: #6b7280;
-}
+  :global(.punc) {
+    color: #6b7280;
+  }
 
-:global(.value-string) {
-  color: #17c083;
-}
+  :global(.value-string) {
+    color: #17c083;
+  }
 
-:global(.value-function::before) {
-  content: 'ƒ ';
-  color: #3894ff;
-}
-:global(.value-function) {
-  color: #5076f9;
-}
+  :global(.value-function::before) {
+    content: 'ƒ ';
+    color: #3894ff;
+  }
+  :global(.value-function) {
+    color: #5076f9;
+  }
 
-:global(.value-number) {
-  color: #ff5d01;
-}
+  :global(.value-number) {
+    color: #ff5d01;
+  }
 
-:global(.value-null),
-:global(.value-undefined) {
-  color: #9ca3af;
-}
+  :global(.value-null),
+  :global(.value-undefined) {
+    color: #9ca3af;
+  }
 
-:global(main > .line) {
-  margin-left: -0.75em;
-  padding-left: 0;
-}
+  :global(main > .line) {
+    margin-left: -0.75em;
+    padding-left: 0;
+  }
   
 }
 </style>

--- a/packages/astro/components/Debug.astro
+++ b/packages/astro/components/Debug.astro
@@ -15,5 +15,6 @@
 
 <details>
   <summary>Debug</summary>
+  <!-- JSON.stringify can pretty print our input: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_argument -->
   <pre>{JSON.stringify(Astro.props, null, 2)}</pre>
 </details>

--- a/packages/astro/components/Debug.astro
+++ b/packages/astro/components/Debug.astro
@@ -161,6 +161,7 @@ const Node = ({ node, key, class: className, ...props }) => {
 .debug-title {
   font-size: 1em;
   color: #fff;
+  margin: 0.5em 0;
 }
 
 .debug-label {

--- a/packages/astro/components/Debug.astro
+++ b/packages/astro/components/Debug.astro
@@ -1,0 +1,19 @@
+<style>
+  details {
+    overflow-x: auto;
+    max-width: 100%;
+    position: fixed;
+    top: 2rem;
+    left: 2rem;
+    bottom: 2rem;
+    right: 2rem;
+    z-index: 999;
+    color: white;
+    background-color: black;
+  }
+</style>
+
+<details>
+  <summary>Debug</summary>
+  <pre>{JSON.stringify(Astro.props, null, 2)}</pre>
+</details>

--- a/packages/astro/components/index.js
+++ b/packages/astro/components/index.js
@@ -1,2 +1,3 @@
 export { default as Markdown } from './Markdown.astro';
 export { default as Prism } from './Prism.astro';
+export { default as Debug } from './Debug.astro';

--- a/packages/astro/components/index.js
+++ b/packages/astro/components/index.js
@@ -1,3 +1,17 @@
-export { default as Markdown } from './Markdown.astro';
-export { default as Prism } from './Prism.astro';
-export { default as Debug } from './Debug.astro';
+// `lazy` is a wrapper that creates async Astro components
+const lazy = (_import) => {
+  return {
+    isAstroComponent: true,
+    __render: async (...args) =>
+      _import().then(({ default: Component }) => {
+        return Component.__render(...args);
+      }),
+  };
+};
+
+// We use `lazy` to avoid the Astro Snowpack plugin from eagerly evaluating these components
+// because `__renderPage` is stateful and will inject any linked styles to `state`
+// for any consumers using `import { SingleComponent } from 'astro/component'`
+export const Markdown = lazy(() => import('./Markdown.astro'));
+export const Prism = lazy(() => import('./Prism.astro'));
+export const Debug = lazy(() => import('./Debug.astro'));

--- a/packages/astro/components/index.js
+++ b/packages/astro/components/index.js
@@ -1,17 +1,2 @@
-// `lazy` is a wrapper that creates async Astro components
-const lazy = (_import) => {
-  return {
-    isAstroComponent: true,
-    __render: async (...args) =>
-      _import().then(({ default: Component }) => {
-        return Component.__render(...args);
-      }),
-  };
-};
-
-// We use `lazy` to avoid the Astro Snowpack plugin from eagerly evaluating these components
-// because `__renderPage` is stateful and will inject any linked styles to `state`
-// for any consumers using `import { SingleComponent } from 'astro/component'`
-export const Markdown = lazy(() => import('./Markdown.astro'));
-export const Prism = lazy(() => import('./Prism.astro'));
-export const Debug = lazy(() => import('./Debug.astro'));
+export { default as Markdown } from './Markdown.astro';
+export { default as Prism } from './Prism.astro';

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -16,6 +16,7 @@
     "./snowpack-plugin": "./snowpack-plugin.cjs",
     "./snowpack-plugin-jsx": "./snowpack-plugin-jsx.cjs",
     "./components": "./components/index.js",
+    "./debug": "./components/Debug.astro",
     "./components/*": "./components/*",
     "./runtime/svelte": "./dist/frontend/runtime/svelte.js",
     "./internal/*": "./dist/internal/*",


### PR DESCRIPTION
## Changes

- Adds a `<Debug/>` component to Astro, closing #411 

## Testing

- [ ] TODO but probably doesn't need to be in this PR.

## Docs

- [ ] TODO

You can use this with Astro's shorthand syntax by passing in any value surrounded by curly braces. You can also do something like `<Debug value={someValue} />`. The component supports any named prop, so it doesn't matter what you call it.

```astro
---
import { Debug } from 'astro/components';
const object = { /* ... */ };
---

<Debug {object} />
```