### PR TITLE
test ignoring examples directory from workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "workspaces": [
     "packages/renderers/*",
     "packages/*",
-    "examples/*",
     "tools/*",
     "scripts",
     "www",


### PR DESCRIPTION
## Changes

- Mentioned in https://github.com/snowpackjs/astro/pull/671 - its confusing that changeset wants to manage our `examples` directory, when those are intentionally unversioned, never published
- The more examples we add, the slower `yarn install` is getting
- Are we okay to remove these from the workspace? will anything break? my only concern was if tests were written expecting this, but we've already talked about moving away from testing things that rely on workspace installation behavior.