### PR TITLE
select random ports if defaults are taken

### DIFF
--- a/.changeset/empty-otters-smell.md
+++ b/.changeset/empty-otters-smell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow multiple Astro servers to be running simultaneously by choosing random ports if the defaults are taken.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -68,6 +68,7 @@
     "fast-xml-parser": "^3.19.0",
     "fdir": "^5.0.0",
     "find-up": "^5.0.0",
+    "get-port": "^5.1.1",
     "gzip-size": "^6.0.0",
     "hast-to-hyperscript": "~9.0.0",
     "kleur": "^4.1.4",

--- a/packages/astro/snowpack-plugin.cjs
+++ b/packages/astro/snowpack-plugin.cjs
@@ -1,4 +1,5 @@
 const { readFile } = require('fs').promises;
+const getPort = require('get-port');
 // Snowpack plugins must be CommonJS :(
 const transformPromise = import('./dist/compiler/index.js');
 
@@ -48,9 +49,12 @@ module.exports = (snowpackConfig, options = {}) => {
         configManager.markDirty();
       }
     },
-    config(snowpackConfig) {
+    async config(snowpackConfig) {
       if(!isNaN(snowpackConfig.devOptions.hmrPort)) {
         hmrPort = snowpackConfig.devOptions.hmrPort;
+      } else {
+        hmrPort = await getPort({ port: DEFAULT_HMR_PORT, host: snowpackConfig.devOptions.hostname });
+        snowpackConfig.devOptions.hmrPort = hmrPort;
       }
     },
     async load({ filePath }) {

--- a/packages/astro/src/config.ts
+++ b/packages/astro/src/config.ts
@@ -1,6 +1,7 @@
 import type { AstroConfig } from './@types/astro';
 import path from 'path';
 import { existsSync } from 'fs';
+import getPort from 'get-port';
 
 /** Type util */
 const type = (thing: any): string => (Array.isArray(thing) ? 'Array' : typeof thing);
@@ -48,7 +49,7 @@ function validateConfig(config: any): void {
 }
 
 /** Set default config values */
-function configDefaults(userConfig?: any): any {
+async function configDefaults(userConfig?: any): Promise<any> {
   const config: any = { ...(userConfig || {}) };
 
   if (!config.projectRoot) config.projectRoot = '.';
@@ -57,7 +58,7 @@ function configDefaults(userConfig?: any): any {
   if (!config.dist) config.dist = './dist';
   if (!config.public) config.public = './public';
   if (!config.devOptions) config.devOptions = {};
-  if (!config.devOptions.port) config.devOptions.port = 3000;
+  if (!config.devOptions.port) config.devOptions.port = await getPort({ port: getPort.makeRange(3000, 3050) });
   if (!config.buildOptions) config.buildOptions = {};
   if (!config.markdownOptions) config.markdownOptions = {};
   if (typeof config.buildOptions.sitemap === 'undefined') config.buildOptions.sitemap = true;
@@ -86,9 +87,9 @@ export async function loadConfig(rawRoot: string | undefined, configFileName = '
   // load
   let config: any;
   if (existsSync(astroConfigPath)) {
-    config = configDefaults((await import(astroConfigPath.href)).default);
+    config = await configDefaults((await import(astroConfigPath.href)).default);
   } else {
-    config = configDefaults();
+    config = await configDefaults();
   }
 
   // validate

--- a/yarn.lock
+++ b/yarn.lock
@@ -4988,7 +4988,7 @@ get-pkg-repo@^1.0.0:
 
 get-port@^5.1.1:
   version "5.1.1"
-  resolved "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
 get-stdin@^4.0.1:


### PR DESCRIPTION
Closes #429.

## Changes

This adds support for multiple Astro dev servers running simultaneously. Previously, trying to start a second server errored out because the fixed default ports were already in use. Now, when the default ports are in use, a random port is chosen.

## Testing

I've tested this manually by running two of the examples in the repo at the same time. Not sure if this can be automatically tested against, but if it needs to be, I would like some pointers.

## Docs

Bug fix only.