### PR TITLE
Clarify `src` and `pages` options

### DIFF
--- a/examples/blog-multiple-authors/astro.config.mjs
+++ b/examples/blog-multiple-authors/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',           // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/blog/astro.config.mjs
+++ b/examples/blog/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',           // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/docs/astro.config.mjs
+++ b/examples/docs/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',           // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/framework-lit/astro.config.mjs
+++ b/examples/framework-lit/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages',   // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',           // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/framework-multiple/astro.config.mjs
+++ b/examples/framework-multiple/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',  // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/framework-preact/astro.config.mjs
+++ b/examples/framework-preact/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',  // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/framework-react/astro.config.mjs
+++ b/examples/framework-react/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',  // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/framework-svelte/astro.config.mjs
+++ b/examples/framework-svelte/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',  // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/framework-vue/astro.config.mjs
+++ b/examples/framework-vue/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',  // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/portfolio/astro.config.mjs
+++ b/examples/portfolio/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',  // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/starter/astro.config.mjs
+++ b/examples/starter/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',  // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/with-markdown-plugins/astro.config.mjs
+++ b/examples/with-markdown-plugins/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages',   // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     site: 'http://example.com',           // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/with-nanostores/astro.config.mjs
+++ b/examples/with-nanostores/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',  // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.

--- a/examples/with-tailwindcss/astro.config.mjs
+++ b/examples/with-tailwindcss/astro.config.mjs
@@ -1,7 +1,8 @@
 export default {
   // projectRoot: '.',     // Where to resolve all URLs relative to. Useful if you have a monorepo project.
-  // pages: './src/pages', // Path to Astro components, pages, and data
-  // dist: './dist',       // When running `astro build`, path to final static output
+  // src: './src',         // Path to website source files.
+  // pages: './src/pages', // Path to Astro pages and data. Must start with the value of `src` above.
+  // dist: './dist',       // When running `astro build`, path to final static output.
   // public: './public',   // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don’t need processing.
   buildOptions: {
     // site: 'http://example.com',           // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.


### PR DESCRIPTION
- Resolve #674

## Changes

- Adds `src` option to `starter` config file and adds further explanation to `pages` config option.
  `src` is not given by default and `pages` must begin with the value of `src`.
- Also, copyedit other comments.

## Testing

N/A

## Docs

N/A, selfdocumenting
