### PR TITLE
[docs] Changed URLs to match the release

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,6 @@
 export default {
   buildOptions: {
-    site: 'https://astro-docs-preview.vercel.app/',
+    site: 'https://docs.astro.build/',
   },
   renderers: ['@astrojs/renderer-preact'],
 };

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "lint": "run-p --aggregate-output lint:linkcheck",
     "lint:linkcheck": "start-test 'yarn start --silent' 3000  'yarn lint:linkcheck:local'",
     "lint:linkcheck:local": "blc -ro --user-agent 'broken-link-checker/0.7.8' 'http://localhost:3000'",
-    "lint:linkcheck:remote": "blc -ro --user-agent 'broken-link-checker/0.7.8' 'https://astro-docs-preview.vercel.app/'"
+    "lint:linkcheck:remote": "blc -ro --user-agent 'broken-link-checker/0.7.8' 'https://docs.astro.build/'"
   },
   "devDependencies": {
     "@snowpack/plugin-dotenv": "^2.1.0",

--- a/docs/src/components/AvatarList.astro
+++ b/docs/src/components/AvatarList.astro
@@ -1,8 +1,8 @@
 ---
 // fetch all commits for just this page's path
-const { path } = Astro.props;
-const url = `https://api.github.com/repos/snowpackjs/astro-docs/commits?path=${path}`;
-const commitsURL = `https://github.com/snowpackjs/astro-docs/commits/main/${path}`;
+const path = "docs/" + Astro.props.path;
+const url = `https://api.github.com/repos/snowpackjs/astro/commits?path=${path}`;
+const commitsURL = `https://github.com/snowpackjs/astro/commits/main/${path}`;
 
 async function getCommits(url) {
   try {

--- a/docs/src/layouts/Main.astro
+++ b/docs/src/layouts/Main.astro
@@ -9,7 +9,7 @@ const { content } = Astro.props;
 const headers = content?.astro?.headers;
 const currentPage = Astro.request.url.pathname;
 const currentFile = currentPage === '/' ? 'src/pages/index.md' : `src/pages${currentPage.replace(/\/$/, "")}.md`;
-const githubEditUrl = `https://github.com/snowpackjs/astro-docs/blob/main/${currentFile}`;
+const githubEditUrl = `https://github.com/snowpackjs/astro/blob/main/docs/${currentFile}`;
 ---
 
 <html lang="{content.lang ?? 'en-us'}">


### PR DESCRIPTION
## Changes

After the release of the Astro Docs to docs.astro.build and the migration to this repo, I changed some URLs

## Testing

Tests were updated

## Docs

bug fix only
