### PR TITLE
Add first take on default layout

### DIFF
--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -59,6 +59,9 @@ export async function convertMdToAstroSource(contents: string, { filename }: { f
   // Break it up here so that the HTML parser won't detect it.
   const stringifiedSetupContext = JSON.stringify(contentData).replace(/\<\/script\>/g, `</scrip" + "t>`);
 
+  // Check to see if the markdown provided a layout, if not use the default layout if it's set.
+  layout = layout ? layout : opts?.defaultLayout 
+
   return `---
 ${layout ? `import {__renderPage as __layout} from '${layout}';` : 'const __layout = undefined;'}
 export const __content = ${stringifiedSetupContext};

--- a/packages/astro/test/fixtures/plain-markdown/astro.config.mjs
+++ b/packages/astro/test/fixtures/plain-markdown/astro.config.mjs
@@ -6,6 +6,6 @@ export default {
     sitemap: false,
   },
   markdownOptions: {
-    defaultLayout: '../layouts/content.astro'
+    defaultLayout: '../layouts/default.astro'
   }
 };

--- a/packages/astro/test/fixtures/plain-markdown/astro.config.mjs
+++ b/packages/astro/test/fixtures/plain-markdown/astro.config.mjs
@@ -5,4 +5,7 @@ export default {
   buildOptions: {
     sitemap: false,
   },
+  markdownOptions: {
+    defaultLayout: '../layouts/content.astro'
+  }
 };

--- a/packages/astro/test/fixtures/plain-markdown/src/layouts/default.astro
+++ b/packages/astro/test/fixtures/plain-markdown/src/layouts/default.astro
@@ -4,7 +4,7 @@
   </head>
   <body>
     <div class="container">
-      <div id="template">content</div>
+      <div id="template">default</div>
       <slot></slot>
     </div>
   </body>

--- a/packages/astro/test/fixtures/plain-markdown/src/pages/no-layout-post.md
+++ b/packages/astro/test/fixtures/plain-markdown/src/pages/no-layout-post.md
@@ -1,0 +1,16 @@
+---
+title: My Blog Post
+description: This is a post about some stuff.
+---
+
+## Interesting Topic
+
+Hello world!
+
+```json
+{ 
+  "key": "value"
+}
+```
+
+<div id="first">Some content</div>

--- a/packages/astro/test/plain-markdown.test.js
+++ b/packages/astro/test/plain-markdown.test.js
@@ -8,6 +8,19 @@ const Markdown = suite('Plain Markdown tests');
 setup(Markdown, './fixtures/plain-markdown');
 setupBuild(Markdown, './fixtures/plain-markdown');
 
+Markdown('Can load a simple markdown page with Astro using the default Layout', async ({ runtime }) => {
+  const result = await runtime.load('/no-layout-post');
+
+  assert.equal(result.statusCode, 200);
+
+  const $ = doc(result.contents);
+  assert.equal($('html').length, 1);
+  assert.equal($('#template').first().text(), "default");
+  assert.equal($('p').first().text(), 'Hello world!');
+  assert.equal($('#first').text(), 'Some content');
+  assert.equal($('#interesting-topic').text(), 'Interesting Topic');
+});
+
 Markdown('Can load a simple markdown page with Astro', async ({ runtime }) => {
   const result = await runtime.load('/post');
 
@@ -16,6 +29,7 @@ Markdown('Can load a simple markdown page with Astro', async ({ runtime }) => {
   const $ = doc(result.contents);
 
   assert.equal($('p').first().text(), 'Hello world!');
+  assert.equal($('#template').first().text(), "content");
   assert.equal($('#first').text(), 'Some content');
   assert.equal($('#interesting-topic').text(), 'Interesting Topic');
 });
@@ -26,7 +40,7 @@ Markdown('Can load a realworld markdown page with Astro', async ({ runtime }) =>
 
   assert.equal(result.statusCode, 200);
   const $ = doc(result.contents);
-
+  assert.equal($('#template').first().text(), "default");
   assert.equal($('pre').length, 7);
 });
 

--- a/packages/markdown-support/src/types.ts
+++ b/packages/markdown-support/src/types.ts
@@ -10,6 +10,7 @@ export interface AstroMarkdownOptions {
   gfm: boolean;
   remarkPlugins: Plugin[];
   rehypePlugins: Plugin[];
+  defaultLayout?: string;
 }
 
 export interface MarkdownRenderingOptions extends Partial<AstroMarkdownOptions> {


### PR DESCRIPTION
## Changes

extends `astro.config.mjs` with a `defaultLayout` in the `markdownOptions`


## Testing

Nope, havn't figure out how to test this

## Docs

Nope, no documentation. It's needed
