### PR TITLE
fix: add force to rm script in create-astro

### DIFF
--- a/.changeset/odd-cameras-wave.md
+++ b/.changeset/odd-cameras-wave.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+create-astro does not fail when removing subdirectories

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -37,7 +37,7 @@ export async function main() {
       const response = await prompts({
         type: 'confirm',
         name: 'forceOverwrite',
-        message: 'Directory not empty. Continue?',
+        message: `Directory not empty. Delete ${cwd} to continue?`,
         initial: false,
       });
       if (!response.forceOverwrite) {

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -22,8 +22,13 @@ export function mkdirp(dir: string) {
 
 export async function emptyDir(dir: string) {
   const items = await fs.promises.readdir(dir);
-  return Promise.all(items.map((item) =>
-    fs.promises.rm(item, { recursive: true, force: true })));
+  return Promise.all(items.map(async (item) => {
+    const itemPath = path.join(dir, item);
+    const stat = await fs.promises.stat(itemPath);
+    return stat.isDirectory()
+      ? fs.promises.rm(itemPath, { recursive: true, force: true })
+      : fs.promises.unlink(itemPath);
+  }));
 }
 
 const { version } = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -20,14 +20,21 @@ export function mkdirp(dir: string) {
   }
 }
 
+/**
+ * Delete all files, subdirectories, and symlinks in a given 
+ * directory. 
+ *
+ * @param dir the directory to empty
+ * @returns a promise for emptying a given directory
+ */
 export async function emptyDir(dir: string) {
   const items = await fs.promises.readdir(dir);
   return Promise.all(items.map(async (item) => {
     const itemPath = path.join(dir, item);
     const stat = await fs.promises.stat(itemPath);
     return stat.isDirectory()
-      ? fs.promises.rm(itemPath, { recursive: true, force: true })
-      : fs.promises.unlink(itemPath);
+      ? fs.promises.rm(itemPath, { recursive: true, force: true }) // To remove directories
+      : fs.promises.unlink(itemPath); // Remove files and symlinks
   }));
 }
 

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -44,7 +44,7 @@ export async function main() {
         process.exit(1);
       }
 
-      await fs.promises.rm(cwd, { recursive: true });
+      await fs.promises.rm(cwd, { recursive: true, force: true });
       mkdirp(cwd);
     }
   } else {

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -20,6 +20,12 @@ export function mkdirp(dir: string) {
   }
 }
 
+export async function emptyDir(dir: string) {
+  const items = await fs.promises.readdir(dir);
+  return Promise.all(items.map((item) =>
+    fs.promises.rm(item, { recursive: true, force: true })));
+}
+
 const { version } = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
 
 const POSTPROCESS_FILES = ['package.json', 'astro.config.mjs', 'CHANGELOG.md']; // some files need processing after copying.
@@ -44,8 +50,7 @@ export async function main() {
         process.exit(1);
       }
 
-      await fs.promises.rm(cwd, { recursive: true, force: true });
-      mkdirp(cwd);
+      await emptyDir(cwd);
     }
   } else {
     mkdirp(cwd);


### PR DESCRIPTION
## Changes

Fix the remove script to use `--force` to emulate a `rm -rf` to clear subdirectories during `create-astro`. I think this is a valid solution because the create script asks if it can override the files, but fails on subdirectories. 

What **would** be nice would be to save the `.git` directory and such. But not sure if that should be included in this PR.

## Testing

Not sure how to perform testing because all the current testing is on templates. I also don't mind adding a section later in the test that is run under the fixtures directory.

## Docs

Bug fix?

Fixes: #
