### PR TITLE
Add default layout look up using findUp

### DIFF
--- a/packages/astro/snowpack-plugin.cjs
+++ b/packages/astro/snowpack-plugin.cjs
@@ -35,6 +35,7 @@ module.exports = (snowpackConfig, options = {}) => {
       input: ['.astro', '.md'],
       output: ['.js', '.css'],
     },
+    exclude: ["**/default.astro"],
     async transform({contents, id, fileExt}) {
       if(configManager.isConfigModule(fileExt, id)) {
         configManager.configModuleId = id;

--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -1,5 +1,6 @@
 import type { CompileResult, TransformResult } from '../@types/astro';
 import type { CompileOptions } from '../@types/compiler.js';
+import  findUp from 'find-up';
 
 import path from 'path';
 import { MarkdownRenderingOptions, renderMarkdownWithFrontmatter } from '@astrojs/markdown-support';
@@ -58,6 +59,13 @@ export async function convertMdToAstroSource(contents: string, { filename }: { f
   // </script> can't be anywhere inside of a JS string, otherwise the HTML parser fails.
   // Break it up here so that the HTML parser won't detect it.
   const stringifiedSetupContext = JSON.stringify(contentData).replace(/\<\/script\>/g, `</scrip" + "t>`);
+
+  if (!layout) {
+    const defaultTemplate = await findUp('default.astro', { cwd: filename });
+    if(defaultTemplate) {
+      layout = "./" + path.relative(path.dirname(filename), defaultTemplate)
+    }
+  }
 
   return `---
 ${layout ? `import {__renderPage as __layout} from '${layout}';` : 'const __layout = undefined;'}

--- a/packages/astro/test/fixtures/plain-markdown/src/pages/default.astro
+++ b/packages/astro/test/fixtures/plain-markdown/src/pages/default.astro
@@ -3,7 +3,7 @@
     <!-- Head Stuff -->
   </head>
   <body>
-    <div id="layout">content</div>
+    <div id="layout">default</div>
     <div class="container">
       <slot></slot>
     </div>

--- a/packages/astro/test/plain-markdown.test.js
+++ b/packages/astro/test/plain-markdown.test.js
@@ -15,6 +15,7 @@ Markdown('Can load a simple markdown page with Astro', async ({ runtime }) => {
 
   const $ = doc(result.contents);
 
+  assert.equal($('#layout').text(), "content");
   assert.equal($('p').first().text(), 'Hello world!');
   assert.equal($('#first').text(), 'Some content');
   assert.equal($('#interesting-topic').text(), 'Interesting Topic');
@@ -27,6 +28,7 @@ Markdown('Can load a realworld markdown page with Astro', async ({ runtime }) =>
   assert.equal(result.statusCode, 200);
   const $ = doc(result.contents);
 
+  assert.equal($('#layout').text(), "default");
   assert.equal($('pre').length, 7);
 });
 


### PR DESCRIPTION
## Changes

Add support for a default layout (default.astro) file in the folder or a parent directory.

The `exclude` in snowpack-plugin.cjs doesn't actually work and I'm getting an error.

```
   FAIL  Plain Markdown tests  "Builds markdown pages for prod"
    The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Object
```

If the default.astro file is moved one folder up it starts to work tho.

## Testing

Added a test to check if this is loaded in the `plain-markdown.test.js` test.

## Docs

Docs needs to be added for this.