### PR TITLE
changed init example to correct template name

### DIFF
--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -1,7 +1,7 @@
 # Astro with Tailwind
 
 ```
-npm init astro --template with-tailwind
+npm init astro --template with-tailwindcss
 ```
 
 Astro comes with [Tailwind](https://tailwindcss.com) support out of the box. This example showcases how to style your Astro project with Tailwind.


### PR DESCRIPTION

## Changes

Changes the example init command template name from "with-tailwind" to "with-tailwindcss"

## Testing

ran in the example init command locally.

## Docs

typo fix only
