### PR TITLE
Fix: 🐛 ThemeToggle should initialize from localstorage immediately

### DIFF
--- a/docs/src/components/ThemeToggle.tsx
+++ b/docs/src/components/ThemeToggle.tsx
@@ -43,13 +43,13 @@ const icons = [
 ];
 
 const ThemeToggle: FunctionalComponent = () => {
-  const [theme, setTheme] = useState(themes[0]);
+  const [theme, setTheme] = useState(() => {
+    if (typeof localStorage === 'undefined') {
+      return themes[0];
+    }
 
-  useEffect(() => {
-    const user = localStorage.getItem('theme');
-    if (!user) return;
-    setTheme(user);
-  }, []);
+    return localStorage.getItem('theme') || themes[0];
+  });
 
   useEffect(() => {
     const root = document.documentElement;


### PR DESCRIPTION
## Changes

- fixes a flash when navigating between docs pages in the light theme

## Testing

Tested manually since there's no straightforward way to catch a flash like this in automation

## Docs

Only a visual fix for the docs site, no docs were changed or added
