### PR TITLE
test cleanup: move if-check-then-throws to assertions

### DIFF
--- a/packages/astro/test/astro-attrs.test.js
+++ b/packages/astro/test/astro-attrs.test.js
@@ -9,7 +9,7 @@ setup(Attributes, './fixtures/astro-attrs');
 
 Attributes('Passes attributes to elements as expected', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -27,7 +27,7 @@ Attributes('Passes attributes to elements as expected', async ({ runtime }) => {
 
 Attributes('Passes boolean attributes to components as expected', async ({ runtime }) => {
   const result = await runtime.load('/component');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#true').attr('attr'), 'attr-true');

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -14,7 +14,7 @@ setupBuild(Basics, './fixtures/astro-basic');
 
 Basics('Can load page', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 

--- a/packages/astro/test/astro-children.test.js
+++ b/packages/astro/test/astro-children.test.js
@@ -10,7 +10,7 @@ setupBuild(ComponentChildren, './fixtures/astro-children');
 
 ComponentChildren('Passes string children to framework components', async ({ runtime }) => {
   let result = await runtime.load('/strings');
-  if (result.error) throw new Error(result);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -26,7 +26,7 @@ ComponentChildren('Passes string children to framework components', async ({ run
 
 ComponentChildren('Passes markup children to framework components', async ({ runtime }) => {
   let result = await runtime.load('/markup');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -42,10 +42,7 @@ ComponentChildren('Passes markup children to framework components', async ({ run
 
 ComponentChildren('Passes multiple children to framework components', async ({ runtime }) => {
   let result = await runtime.load('/multiple');
-  if (result.error) {
-    console.log(result);
-    throw new Error(result.error);
-  }
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 

--- a/packages/astro/test/astro-collection.test.js
+++ b/packages/astro/test/astro-collection.test.js
@@ -9,7 +9,7 @@ setup(Collections, './fixtures/astro-collection');
 
 Collections('shallow selector (*.md)', async ({ runtime }) => {
   const result = await runtime.load('/shallow');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
   const $ = doc(result.contents);
   const urls = [
     ...$('#posts a').map(function () {
@@ -22,7 +22,7 @@ Collections('shallow selector (*.md)', async ({ runtime }) => {
 
 Collections('deep selector (**/*.md)', async ({ runtime }) => {
   const result = await runtime.load('/nested');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
   const $ = doc(result.contents);
   const urls = [
     ...$('#posts a').map(function () {
@@ -34,7 +34,7 @@ Collections('deep selector (**/*.md)', async ({ runtime }) => {
 
 Collections('generates pagination successfully', async ({ runtime }) => {
   const result = await runtime.load('/paginated');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
   const $ = doc(result.contents);
   const prev = $('#prev-page');
   const next = $('#next-page');
@@ -44,7 +44,7 @@ Collections('generates pagination successfully', async ({ runtime }) => {
 
 Collections('can load remote data', async ({ runtime }) => {
   const result = await runtime.load('/remote');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
   const $ = doc(result.contents);
 
   const PACKAGES_TO_TEST = ['canvas-confetti', 'preact', 'svelte'];
@@ -72,7 +72,7 @@ Collections('generates pages grouped by author', async ({ runtime }) => {
 
   for (const { id, posts } of AUTHORS_TO_TEST) {
     const result = await runtime.load(`/grouped/${id}`);
-    if (result.error) throw new Error(result.error);
+    assert.ok(!result.error, `build error: ${result.error}`);
     const $ = doc(result.contents);
 
     assert.ok($(`#${id}`).length);
@@ -101,7 +101,7 @@ Collections('generates individual pages from a collection', async ({ runtime }) 
 
   for (const { slug, title } of PAGES_TO_TEST) {
     const result = await runtime.load(`/individual/${slug}`);
-    if (result.error) throw new Error(result.error);
+    assert.ok(!result.error, `build error: ${result.error}`);
     const $ = doc(result.contents);
 
     assert.ok($(`#${slug}`).length);
@@ -111,7 +111,7 @@ Collections('generates individual pages from a collection', async ({ runtime }) 
 
 Collections('matches collection filename exactly', async ({ runtime }) => {
   const result = await runtime.load('/individuals');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
   const $ = doc(result.contents);
 
   assert.ok($('#posts').length);

--- a/packages/astro/test/astro-components.test.js
+++ b/packages/astro/test/astro-components.test.js
@@ -9,7 +9,7 @@ setup(Components, './fixtures/astro-components');
 
 Components('Astro components are able to render framework components', async ({ runtime }) => {
   let result = await runtime.load('/');
-  if (result.error) throw new Error(result);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 

--- a/packages/astro/test/astro-doctype.test.js
+++ b/packages/astro/test/astro-doctype.test.js
@@ -34,7 +34,7 @@ DType('No errors creating a runtime', () => {
 
 DType('Automatically prepends the standards mode doctype', async () => {
   const result = await runtime.load('/prepend');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents.toString('utf-8');
   assert.ok(html.startsWith('<!doctype html>'), 'Doctype always included');
@@ -42,7 +42,7 @@ DType('Automatically prepends the standards mode doctype', async () => {
 
 DType('No attributes added when doctype is provided by user', async () => {
   const result = await runtime.load('/provided');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents.toString('utf-8');
   assert.ok(html.startsWith('<!doctype html>'), 'Doctype always included');
@@ -50,7 +50,7 @@ DType('No attributes added when doctype is provided by user', async () => {
 
 DType.skip('Preserves user provided doctype', async () => {
   const result = await runtime.load('/preserve');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents.toString('utf-8');
   assert.ok(html.startsWith('<!doctype HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">'), 'Doctype included was preserved');
@@ -58,7 +58,7 @@ DType.skip('Preserves user provided doctype', async () => {
 
 DType('User provided doctype is case insensitive', async () => {
   const result = await runtime.load('/capital');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents.toString('utf-8');
   assert.ok(html.startsWith('<!DOCTYPE html>'), 'Doctype left alone');

--- a/packages/astro/test/astro-dynamic.test.js
+++ b/packages/astro/test/astro-dynamic.test.js
@@ -9,7 +9,7 @@ setupBuild(DynamicComponents, './fixtures/astro-dynamic');
 
 DynamicComponents('Loads client-only packages', async ({ runtime }) => {
   let result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   // Grab the react-dom import
   const exp = /import\("(.+?)"\)/g;
@@ -28,7 +28,7 @@ DynamicComponents('Loads client-only packages', async ({ runtime }) => {
 
 DynamicComponents('Loads pages using client:media hydrator', async ({ runtime }) => {
   let result = await runtime.load('/media');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   let html = result.contents;
   assert.ok(html.includes(`value: "(max-width: 700px)"`), 'static value rendered');

--- a/packages/astro/test/astro-expr.test.js
+++ b/packages/astro/test/astro-expr.test.js
@@ -9,7 +9,7 @@ setup(Expressions, './fixtures/astro-expr');
 
 Expressions('Can load page', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -20,7 +20,7 @@ Expressions('Can load page', async ({ runtime }) => {
 
 Expressions('Ignores characters inside of strings', async ({ runtime }) => {
   const result = await runtime.load('/strings');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -31,7 +31,7 @@ Expressions('Ignores characters inside of strings', async ({ runtime }) => {
 
 Expressions('Ignores characters inside of line comments', async ({ runtime }) => {
   const result = await runtime.load('/line-comments');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -42,7 +42,7 @@ Expressions('Ignores characters inside of line comments', async ({ runtime }) =>
 
 Expressions('Ignores characters inside of multiline comments', async ({ runtime }) => {
   const result = await runtime.load('/multiline-comments');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -53,14 +53,14 @@ Expressions('Ignores characters inside of multiline comments', async ({ runtime 
 
 Expressions('Allows multiple JSX children in mustache', async ({ runtime }) => {
   const result = await runtime.load('/multiple-children');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   assert.ok(result.contents.includes('#f') && !result.contents.includes('#t'));
 });
 
 Expressions('Allows <> Fragments in expressions', async ({ runtime }) => {
   const result = await runtime.load('/multiple-children');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
   const $ = doc(result.contents);
 
   assert.equal($('#fragment').children().length, 3);
@@ -71,7 +71,7 @@ Expressions('Allows <> Fragments in expressions', async ({ runtime }) => {
 
 Expressions('Does not render falsy values using &&', async ({ runtime }) => {
   const result = await runtime.load('/falsy');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 

--- a/packages/astro/test/astro-fallback.test.js
+++ b/packages/astro/test/astro-fallback.test.js
@@ -9,7 +9,7 @@ setup(Fallback, './fixtures/astro-fallback');
 
 Fallback('Shows static content', async (context) => {
   const result = await context.runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#fallback').text(), 'static');

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -9,7 +9,7 @@ setup(Global, './fixtures/astro-global');
 
 Global('Astro.request.url', async (context) => {
   const result = await context.runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#pathname').text(), '/');
@@ -34,7 +34,7 @@ Global('Astro.request.canonicalURL', async (context) => {
 
 Global('Astro.site', async (context) => {
   const result = await context.runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#site').attr('href'), 'https://mysite.dev');

--- a/packages/astro/test/astro-hmr.test.js
+++ b/packages/astro/test/astro-hmr.test.js
@@ -13,7 +13,7 @@ setup(HMR, './fixtures/astro-hmr', {
 
 HMR('Honors the user provided port', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents;
   assert.ok(/window\.HMR_WEBSOCKET_PORT = 5555/.test(html), "Uses the user's websocket port");
@@ -21,7 +21,7 @@ HMR('Honors the user provided port', async ({ runtime }) => {
 
 HMR('Does not override script added by the user', async ({ runtime }) => {
   const result = await runtime.load('/manual');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents;
 
@@ -31,7 +31,7 @@ HMR('Does not override script added by the user', async ({ runtime }) => {
 
 HMR('Adds script to static pages too', async ({ runtime }) => {
   const result = await runtime.load('/static');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents;
   const $ = doc(html);
@@ -41,7 +41,7 @@ HMR('Adds script to static pages too', async ({ runtime }) => {
 
 HMR("Adds script to pages even if there aren't any elements in the template", async ({ runtime }) => {
   const result = await runtime.load('/no-elements');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents;
   const $ = doc(html);

--- a/packages/astro/test/astro-markdown-plugins.test.js
+++ b/packages/astro/test/astro-markdown-plugins.test.js
@@ -10,7 +10,7 @@ setupBuild(MarkdownPlugin, './fixtures/astro-markdown-plugins');
 
 MarkdownPlugin('Can render markdown with plugins', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('.toc').length, 1, 'Added a TOC');
@@ -19,7 +19,7 @@ MarkdownPlugin('Can render markdown with plugins', async ({ runtime }) => {
 
 MarkdownPlugin('Can render Astro <Markdown> with plugins', async ({ runtime }) => {
   const result = await runtime.load('/astro');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('.toc').length, 1, 'Added a TOC');

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -10,7 +10,7 @@ setupBuild(Markdown, './fixtures/astro-markdown');
 
 Markdown('Can load markdown pages with Astro', async ({ runtime }) => {
   const result = await runtime.load('/post');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.ok($('#first').length, 'There is a div added in markdown');
@@ -19,7 +19,7 @@ Markdown('Can load markdown pages with Astro', async ({ runtime }) => {
 
 Markdown('Can load more complex jsxy stuff', async ({ runtime }) => {
   const result = await runtime.load('/complex');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   const $el = $('#test');
@@ -28,7 +28,7 @@ Markdown('Can load more complex jsxy stuff', async ({ runtime }) => {
 
 Markdown('Runs code blocks through syntax highlighter', async ({ runtime }) => {
   const result = await runtime.load('/code');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   const $el = $('code span');
@@ -47,7 +47,7 @@ Markdown('Bundles client-side JS for prod', async (context) => {
 
 Markdown('Renders correctly when deeply nested on a page', async ({ runtime }) => {
   const result = await runtime.load('/deep');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#deep').children().length, 3, 'Rendered all children');
@@ -62,7 +62,7 @@ Markdown('Renders correctly when deeply nested on a page', async ({ runtime }) =
 
 Markdown('Renders recursively', async ({ runtime }) => {
   const result = await runtime.load('/recursive');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('.a > h1').text(), 'A', 'Rendered title .a correctly');
@@ -72,7 +72,7 @@ Markdown('Renders recursively', async ({ runtime }) => {
 
 Markdown('Renders dynamic content though the content attribute', async ({ runtime }) => {
   const result = await runtime.load('/external');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#outer').length, 1, 'Rendered markdown content');
@@ -82,7 +82,7 @@ Markdown('Renders dynamic content though the content attribute', async ({ runtim
 
 Markdown('Does not close parent early when using content attribute (#494)', async ({ runtime }) => {
   const result = await runtime.load('/close');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#target').children().length, 2, '<Markdown content /> closed div#target early');

--- a/packages/astro/test/astro-slots.test.js
+++ b/packages/astro/test/astro-slots.test.js
@@ -14,7 +14,7 @@ setupBuild(Slots, './fixtures/astro-slots');
 
 Slots('Basic named slots work', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -26,7 +26,7 @@ Slots('Basic named slots work', async ({ runtime }) => {
 
 Slots('Dynamic named slots work', async ({ runtime }) => {
   const result = await runtime.load('/dynamic');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -38,7 +38,7 @@ Slots('Dynamic named slots work', async ({ runtime }) => {
 
 Slots('Slots render fallback content by default', async ({ runtime }) => {
   const result = await runtime.load('/fallback');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -47,7 +47,7 @@ Slots('Slots render fallback content by default', async ({ runtime }) => {
 
 Slots('Slots override fallback content', async ({ runtime }) => {
   const result = await runtime.load('/fallback-override');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -56,7 +56,7 @@ Slots('Slots override fallback content', async ({ runtime }) => {
 
 Slots('Slots work with multiple elements', async ({ runtime }) => {
   const result = await runtime.load('/multiple');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -65,7 +65,7 @@ Slots('Slots work with multiple elements', async ({ runtime }) => {
 
 Slots('Slots work on Components', async ({ runtime }) => {
   const result = await runtime.load('/component');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 

--- a/packages/astro/test/astro-styles-ssr.test.js
+++ b/packages/astro/test/astro-styles-ssr.test.js
@@ -116,9 +116,8 @@ StylesSSR('Astro scoped styles', async ({ runtime }) => {
       scopedClass = match;
       return match;
     });
-
-  if (!scopedClass) throw new Error(`Astro component missing scoped class`);
-
+  
+  assert.ok(scopedClass, `Astro component missing scoped class`);
   assert.match(el1.attr('class'), `blue ${scopedClass}`);
   assert.match(el2.attr('class'), `visible ${scopedClass}`);
 

--- a/packages/astro/test/benchmark/benchmark.js
+++ b/packages/astro/test/benchmark/benchmark.js
@@ -43,9 +43,7 @@ export class Benchmark {
   }
 
   check() {
-    if (this.withinPreviousRuns === false) {
-      throw new Error(`${this.options.name} ran too slowly`);
-    }
+    assert.ok(this.withinPreviousRuns !== false, `${this.options.name} ran too slowly`);
   }
 
   async save() {

--- a/packages/astro/test/builtins-polyfillnode.test.js
+++ b/packages/astro/test/builtins-polyfillnode.test.js
@@ -9,7 +9,7 @@ setup(Builtins, './fixtures/builtins-polyfillnode');
 
 Builtins('Doesnt alias to node: prefix', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 

--- a/packages/astro/test/builtins.test.js
+++ b/packages/astro/test/builtins.test.js
@@ -9,7 +9,7 @@ setup(Builtins, './fixtures/builtins');
 
 Builtins('Can be used with the node: prefix', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 

--- a/packages/astro/test/custom-elements.test.js
+++ b/packages/astro/test/custom-elements.test.js
@@ -9,7 +9,7 @@ setup(CustomElements, './fixtures/custom-elements');
 
 CustomElements('Work as constructors', async ({ runtime }) => {
   const result = await runtime.load('/ctr');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('my-element').length, 1, 'Element rendered');
@@ -18,7 +18,7 @@ CustomElements('Work as constructors', async ({ runtime }) => {
 
 CustomElements('Works with exported tagName', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('my-element').length, 1, 'Element rendered');
@@ -27,7 +27,7 @@ CustomElements('Works with exported tagName', async ({ runtime }) => {
 
 CustomElements('Hydration works with exported tagName', async ({ runtime }) => {
   const result = await runtime.load('/load');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents;
   const $ = doc(html);
@@ -42,7 +42,7 @@ CustomElements('Hydration works with exported tagName', async ({ runtime }) => {
 
 CustomElements('Polyfills are added before the hydration script', async ({ runtime }) => {
   const result = await runtime.load('/load');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents;
   const $ = doc(html);
@@ -54,7 +54,7 @@ CustomElements('Polyfills are added before the hydration script', async ({ runti
 
 CustomElements('Polyfills are added even if not hydrating', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents;
   const $ = doc(html);
@@ -66,7 +66,7 @@ CustomElements('Polyfills are added even if not hydrating', async ({ runtime }) 
 
 CustomElements('Custom elements not claimed by renderer are rendered as regular HTML', async ({ runtime }) => {
   const result = await runtime.load('/nossr');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('client-element').length, 1, 'Rendered the client-only element');

--- a/packages/astro/test/lit-element.test.js
+++ b/packages/astro/test/lit-element.test.js
@@ -9,7 +9,7 @@ setup(LitElement, './fixtures/lit-element');
 
 LitElement('Renders a custom element by tag name', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 
@@ -20,7 +20,7 @@ LitElement('Renders a custom element by tag name', async ({ runtime }) => {
 // Skipped because not supported by Lit
 LitElement.skip('Renders a custom element by the constructor', async ({ runtime }) => {
   const result = await runtime.load('/ctr');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
 

--- a/packages/astro/test/no-head-el.test.js
+++ b/packages/astro/test/no-head-el.test.js
@@ -13,7 +13,7 @@ setup(NoHeadEl, './fixtures/no-head-el', {
 
 NoHeadEl('Places style and scripts before the first non-head element', async ({ runtime }) => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents;
   const $ = doc(html);
@@ -27,7 +27,7 @@ NoHeadEl('Places style and scripts before the first non-head element', async ({ 
 
 NoHeadEl('Injects HMR script even when there are no elements on the page', async ({ runtime }) => {
   const result = await runtime.load('/no-elements');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents;
   const $ = doc(html);

--- a/packages/astro/test/plain-markdown.test.js
+++ b/packages/astro/test/plain-markdown.test.js
@@ -22,7 +22,7 @@ Markdown('Can load a simple markdown page with Astro', async ({ runtime }) => {
 
 Markdown('Can load a realworld markdown page with Astro', async ({ runtime }) => {
   const result = await runtime.load('/realworld');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   assert.equal(result.statusCode, 200);
   const $ = doc(result.contents);

--- a/packages/astro/test/preact-component.test.js
+++ b/packages/astro/test/preact-component.test.js
@@ -9,7 +9,7 @@ setup(PreactComponent, './fixtures/preact-component');
 
 PreactComponent('Can load class component', async ({ runtime }) => {
   const result = await runtime.load('/class');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#class-component').length, 1, 'Can use class components');
@@ -17,7 +17,7 @@ PreactComponent('Can load class component', async ({ runtime }) => {
 
 PreactComponent('Can load function component', async ({ runtime }) => {
   const result = await runtime.load('/fn');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#fn-component').length, 1, 'Can use function components');
@@ -26,7 +26,7 @@ PreactComponent('Can load function component', async ({ runtime }) => {
 
 PreactComponent('Can use hooks', async ({ runtime }) => {
   const result = await runtime.load('/hooks');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#world').length, 1);
@@ -34,7 +34,7 @@ PreactComponent('Can use hooks', async ({ runtime }) => {
 
 PreactComponent('Can export a Fragment', async ({ runtime }) => {
   const result = await runtime.load('/frag');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('body').children().length, 0, "nothing rendered but it didn't throw.");

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -35,7 +35,7 @@ React('No error creating the runtime', () => {
 
 React('Can load React', async () => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#react-h2').text(), 'Hello world!');
@@ -45,7 +45,7 @@ React('Can load React', async () => {
 
 React('Includes reactroot on hydrating components', async () => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   const div = $('#research');
@@ -66,7 +66,7 @@ React('Throws helpful error message on window SSR', async () => {
 
 React('Can load Vue', async () => {
   const result = await runtime.load('/');
-  if (result.error) throw new Error(result.error);
+  assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
   assert.equal($('#vue-h2').text(), 'Hasta la vista, baby');


### PR DESCRIPTION
## Changes

- small test cleanup to leverage `uvu/assert` for simple checks