### PR TITLE
Update `format` script to format all files not ignored via `.prettierignore` that `prettier` has a valid parser for.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:core": "lerna run build --scope astro --scope @astrojs/parser --scope @astrojs/markdown-support",
     "build:vscode": "lerna run build --scope astro-languageserver --scope astro-vscode --scope @astrojs/parser",
     "dev:vscode": "lerna run dev --scope astro-languageserver --scope astro-vscode --scope @astrojs/parser --parallel --stream",
-    "format": "prettier -w \"**/*.{js,jsx,ts,tsx,md,json}\"",
+    "format": "prettier -w .",
     "lint": "eslint \"packages/**/*.ts\"",
     "test": "yarn workspace astro run test",
     "test:templates": "lerna run test --scope create-astro --stream"


### PR DESCRIPTION
## Changes

- Updates the `yarn format` script to format all files in the directory, so that we don't have to keep adding to the glob to support formatting `css` and `scss` files, etc.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
