### PR TITLE
feat(docs): scroll the current page link into view in the SiteSidebar

### DIFF
--- a/docs/src/components/SiteSidebar.astro
+++ b/docs/src/components/SiteSidebar.astro
@@ -3,6 +3,14 @@ import { sidebar } from '../config.ts';
 const {currentPage} = Astro.props;
 ---
 
+<script type="module">
+const scrollToCurrentSection = () => {
+  const siteSidebar = document.getElementById('sidebar-site');
+  const currentPageElement = siteSidebar.querySelector('[aria-current="page"]');
+  currentPageElement.scrollIntoView({block: 'center'});
+}
+scrollToCurrentSection();
+</script>
 
 <nav>
   <ul class="nav-groups">  
@@ -12,7 +20,7 @@ const {currentPage} = Astro.props;
           <h2 class="nav-group-title">{category.text}</h2>
           <ul>
             {category.children.map(child => (
-              <li class={`nav-link ${currentPage === child.link ? 'is-active' : ''}`}><a href={`${Astro.site.pathname}${child.link}`}>{child.text}</a></li>
+              <li class="nav-link"><a href={`${Astro.site.pathname}${child.link}`} aria-current={`${currentPage === child.link ? 'page' : ''}`}>{child.text}</a></li>
             ))}
           </ul>
         </div>
@@ -69,13 +77,13 @@ const {currentPage} = Astro.props;
     background-color: var(--theme-bg-hover);
   }
 
-  .nav-link.is-active a {
+  .nav-link a[aria-current="page"] {
     color: var(--theme-text-accent);
     background-color: var(--theme-bg-accent);
     font-weight: 600;
   }
 
-  :global(:root.theme-dark) .nav-link.is-active a {
+  :global(:root.theme-dark) .nav-link a[aria-current="page"] {
     color: var(--color-white);
   }
 


### PR DESCRIPTION
Currently it doesn't look amazing because the navbar is static and the whole page can even get scrolled to make the link viewable.

## Changes

- Docs

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
- Adds a script that scrolls to the current section link on page load (since the script is `type="module"` it runs after the content has finished loading.)
- Changes the SiteSidebar current link styling to use `a[aria-current="true"]` instead of `.navlink.is-active a`
- TODO: There's a bit of a problem with the navbar since it is static, the page can render without the navbar showing because the page has been scrolled down too far.