### PR TITLE
Remove trailing comma in package.json

### DIFF
--- a/docs/src/pages/installation.md
+++ b/docs/src/pages/installation.md
@@ -60,7 +60,7 @@ You can now replace the placeholder "scripts" section of your `package.json` fil
   "scripts": {
 -    "test": "echo \"Error: no test specified\" && exit 1"
 +    "start": "astro dev",
-+    "build": "astro build",
++    "build": "astro build"
   },
 }
 ```


### PR DESCRIPTION
## Changes
Remove trailing comma in package.json because JSON doesn't allow it.

## Testing
I didn't test it because it is just a tiny syntax fix.

## Docs
Public documentation is updated.
