### PR TITLE
Vercel Config

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,10 @@
+{
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "redirects": [
+    { 
+      "source": "/", 
+      "destination": "/getting-started"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "cleanUrls": true,
-  "trailingSlash": false,
-  "redirects": [{ "source": "/chat", "destination": "https://discord.gg/grF4GTXXYm" }]
-}

--- a/www/vercel.json
+++ b/www/vercel.json
@@ -1,0 +1,15 @@
+{
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "redirects": [
+    { 
+      "source": "/docs/:match*",
+      "destination": "https://docs.astro.build/:match*",
+      "permanent": false
+    },
+    { 
+      "source": "/chat", 
+      "destination": "https://discord.gg/grF4GTXXYm"
+    }
+  ]
+}


### PR DESCRIPTION
## Changes
 
- Adds redirects for `https://astro.build/docs/:match*` to `https://docs.astro.build/:match*`
- Adds redirect for `/` to `/getting-started` on docs site

This also required a few small tweaks on the Vercel side to support our monorepo build step

## Testing

This is me testing it!

## Docs

N/A