### PR TITLE
Docs/fix sitesidebar template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ package-lock.json
 
 # .vscode files other than at top-level
 **/.vscode
+
+# do not commit .env files or any files that end with `.env`
+*.env

--- a/docs/src/components/SiteSidebar.astro
+++ b/docs/src/components/SiteSidebar.astro
@@ -11,7 +11,7 @@ const {currentPage} = Astro.props;
           <h2 class="nav-group-title">{category.text}</h2>
           <ul>
             {category.children.map(child => (
-              <li class="nav-link"><a href={`${Astro.site.pathname}${child.link}`} aria-current={`${currentPage === child.link ? 'page' : ''}`}>{child.text}</a></li>
+              <li class="nav-link"><a href={`${Astro.site.pathname}${child.link}`} aria-current={`${currentPage === child.link ? 'page' : 'false'}`}>{child.text}</a></li>
             ))}
           </ul>
         </div>


### PR DESCRIPTION
## Changes

- Docs component
- Add `*.env` to `.gitignore` so that environmental files don't get commited.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
The semantics for `aria-current` mean that an empty aria-current attribute evaluates to true, so the non-current page links either need no `aria-current` attribute or `aria-current="false"`. 

I get an error when trying to define an if statement that switches between no attribute and an attribute with `aria-current="page"` so currently I'm just setting `aria-current="false"` where needed.