### PR TITLE
docs: fix the templating setup for the `<title/>` in `MainLayout.astro`

### DIFF
--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -67,3 +67,7 @@ export const sidebar = [
   //   ],
   // },
 ];
+
+export const site = {
+  title: 'Astro Documentation',
+};

--- a/docs/src/layouts/Main.astro
+++ b/docs/src/layouts/Main.astro
@@ -4,6 +4,7 @@ import SiteSidebar from '../components/SiteSidebar.astro';
 import ThemeToggle from '../components/ThemeToggle.tsx';
 import DocSidebar from '../components/DocSidebar.tsx';
 import MenuToggle from '../components/MenuToggle.tsx';
+import { site } from "../config.ts";
 
 const { content = {}, centered = false } = Astro.props;
 const headers = content?.astro?.headers;
@@ -20,7 +21,7 @@ if (currentPage) {
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <title>{content.title}</title>
+    <title>{content.title ? `${content.title} 🚀 ${site.title}` : site.title}</title>
 
     <!-- This is intentionally inlined to avoid FOUC -->
     <script>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -2,7 +2,7 @@
 import Layout from '../layouts/Main.astro';
 ---
 
-<Layout centered content={{ title: 'Astro Documentation' }}>
+<Layout centered>
   <h1>
     <code style="white-space: nowrap;">npm init astro</code>
   </h1>


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Outputs the `<title/>` as either `section name 🚀 Astro Documentation` or `Astro Documentation`