### PR TITLE
Docs/ Add MetaData component for Open Graph and Twitter embeds

### DIFF
--- a/docs/src/components/MetaData.astro
+++ b/docs/src/components/MetaData.astro
@@ -16,7 +16,7 @@ let formattedContentTitle = content.title ? `${content.title} 🚀 ${site.title}
 <!-- END OpenGraph Tags -->
 
 <!-- Twitter Tags -->
-<meta name="twitter:card" content="summary"/>
+<meta name="twitter:card" content="summary_large_image"/>
 <meta name="twitter:site" content={site.twitter.site}/>
 <meta name="twitter:creator" content={site.twitter.creator}/>
 <meta name="twitter:title" content={formattedContentTitle}/>

--- a/docs/src/components/MetaData.astro
+++ b/docs/src/components/MetaData.astro
@@ -1,0 +1,35 @@
+---
+import { site } from '../config.ts';
+const { content = {}, canonicalURL } = Astro.props;
+let formattedContentTitle = content.title ? `${content.title} 🚀 ${site.title}` : site.title;
+---
+
+<!-- OpenGraph Tags -->
+<meta property="og:title" content={formattedContentTitle}/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content={canonicalURL}/>
+<meta property="og:locale" content={content.ogLocale ? content.ogLocale : site.ogLocale}/>
+<meta property="og:image" content={content?.image?.src ? content.image.src : site.image.src}/>
+<meta property="og:image:alt" content={content?.image?.alt ? content.image.alt : site.image.alt}/>
+<meta property="og:description" content={content.description ? content.description : site.description}/>
+<meta property="og:site_name" content={site.title}/>
+<!-- END OpenGraph Tags -->
+
+<!-- Twitter Tags -->
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:site" content={site.twitter.site}/>
+<meta name="twitter:creator" content={site.twitter.creator}/>
+<meta name="twitter:title" content={formattedContentTitle}/>
+<meta name="twitter:description" content={content.description ? content.description : site.description}/>
+<meta name="twitter:image" content={content?.image?.src ? content.image.src : site.image.src}/>
+<meta name="twitter:image:alt" content={content?.image?.alt ? content.image.alt : site.image.alt}/>
+<!-- END Twitter Tags -->
+
+<link rel="canonical" href={canonicalURL}/>
+
+<!-- 
+  TODO: Add json+ld data, maybe https://schema.org/APIReference makes sense? 
+  Docs: https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data
+  https://www.npmjs.com/package/schema-dts seems like a great resource for implementing this.
+  Even better, there's a React component that integrates with `schema-dts`: https://github.com/google/react-schemaorg
+-->

--- a/docs/src/components/MetaData.astro
+++ b/docs/src/components/MetaData.astro
@@ -3,6 +3,7 @@ import { site } from '../config.ts';
 const { content = {}, canonicalURL } = Astro.props;
 const formattedContentTitle = content.title ? `${content.title} 🚀 ${site.title}` : site.title;
 const imageSrc = content?.image?.src ?? site.image.src;
+const canonicalImageSrc = new URL(imageSrc, Astro.site);
 const imageAlt = content?.image?.alt ?? site.image.alt;
 ---
 
@@ -11,7 +12,7 @@ const imageAlt = content?.image?.alt ?? site.image.alt;
 <meta property="og:type" content="article"/>
 <meta property="og:url" content={canonicalURL}/>
 <meta property="og:locale" content={content.ogLocale ?? site.ogLocale}/>
-<meta property="og:image" content={imageSrc}/>
+<meta property="og:image" content={canonicalImageSrc}/>
 <meta property="og:image:alt" content={imageAlt}/>
 <meta property="og:description" content={content.description ? content.description : site.description}/>
 <meta property="og:site_name" content={site.title}/>
@@ -23,7 +24,7 @@ const imageAlt = content?.image?.alt ?? site.image.alt;
 <meta name="twitter:creator" content={site.twitter.creator}/>
 <meta name="twitter:title" content={formattedContentTitle}/>
 <meta name="twitter:description" content={content.description ? content.description : site.description}/>
-<meta name="twitter:image" content={imageSrc}/>
+<meta name="twitter:image" content={canonicalImageSrc}/>
 <meta name="twitter:image:alt" content={imageAlt}/>
 <!-- END Twitter Tags -->
 

--- a/docs/src/components/MetaData.astro
+++ b/docs/src/components/MetaData.astro
@@ -1,16 +1,18 @@
 ---
 import { site } from '../config.ts';
 const { content = {}, canonicalURL } = Astro.props;
-let formattedContentTitle = content.title ? `${content.title} 🚀 ${site.title}` : site.title;
+const formattedContentTitle = content.title ? `${content.title} 🚀 ${site.title}` : site.title;
+const imageSrc = content?.image?.src ?? site.image.src;
+const imageAlt = content?.image?.alt ?? site.image.alt;
 ---
 
 <!-- OpenGraph Tags -->
 <meta property="og:title" content={formattedContentTitle}/>
 <meta property="og:type" content="article"/>
 <meta property="og:url" content={canonicalURL}/>
-<meta property="og:locale" content={content.ogLocale ? content.ogLocale : site.ogLocale}/>
-<meta property="og:image" content={content?.image?.src ? content.image.src : site.image.src}/>
-<meta property="og:image:alt" content={content?.image?.alt ? content.image.alt : site.image.alt}/>
+<meta property="og:locale" content={content.ogLocale ?? site.ogLocale}/>
+<meta property="og:image" content={imageSrc}/>
+<meta property="og:image:alt" content={imageAlt}/>
 <meta property="og:description" content={content.description ? content.description : site.description}/>
 <meta property="og:site_name" content={site.title}/>
 <!-- END OpenGraph Tags -->
@@ -21,8 +23,8 @@ let formattedContentTitle = content.title ? `${content.title} 🚀 ${site.title}
 <meta name="twitter:creator" content={site.twitter.creator}/>
 <meta name="twitter:title" content={formattedContentTitle}/>
 <meta name="twitter:description" content={content.description ? content.description : site.description}/>
-<meta name="twitter:image" content={content?.image?.src ? content.image.src : site.image.src}/>
-<meta name="twitter:image:alt" content={content?.image?.alt ? content.image.alt : site.image.alt}/>
+<meta name="twitter:image" content={imageSrc}/>
+<meta name="twitter:image:alt" content={imageAlt}/>
 <!-- END Twitter Tags -->
 
 <link rel="canonical" href={canonicalURL}/>

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -73,7 +73,7 @@ export const site = {
   description: 'Build faster websites with less client-side Javascript',
   ogLocale: 'en_US',
   image: {
-    src: 'https://docs.astro.build/default-og-image.png?v=1',
+    src: '/default-og-image.png?v=1',
     alt:
       'astro logo on a starry expanse of space,' +
       ' with a purple saturn-like planet floating in the right foreground',

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -73,7 +73,7 @@ export const site = {
   description: 'Build faster websites with less client-side Javascript',
   ogLocale: 'en_US',
   image: {
-    src: '/default-og-image.png?v=1',
+    src: 'https://docs.astro.build/default-og-image.png?v=1',
     alt:
       'astro logo on a starry expanse of space,' +
       ' with a purple saturn-like planet floating in the right foreground',

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -73,7 +73,7 @@ export const site = {
   description: 'Build faster websites with less client-side Javascript',
   ogLocale: 'en_US',
   image: {
-    src: '/default-og-image.png',
+    src: '/default-og-image.png?v=1',
     alt:
       'astro logo on a starry expanse of space,' +
       ' with a purple saturn-like planet floating in the right foreground',

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -70,4 +70,16 @@ export const sidebar = [
 
 export const site = {
   title: 'Astro Documentation',
+  description: 'Build faster websites with less client-side Javascript',
+  ogLocale: 'en_US',
+  image: {
+    src: '/default-og-image.png',
+    alt:
+      'astro logo on a starry expanse of space,' +
+      ' with a purple saturn-like planet floating in the right foreground',
+  },
+  twitter: {
+    site: 'astrodotbuild',
+    creator: 'astrodotbuild',
+  },
 };

--- a/docs/src/layouts/Main.astro
+++ b/docs/src/layouts/Main.astro
@@ -4,6 +4,7 @@ import SiteSidebar from '../components/SiteSidebar.astro';
 import ThemeToggle from '../components/ThemeToggle.tsx';
 import DocSidebar from '../components/DocSidebar.tsx';
 import MenuToggle from '../components/MenuToggle.tsx';
+import MetaData from "../components/MetaData.astro";
 import { site } from "../config.ts";
 
 const { content = {}, centered = false } = Astro.props;
@@ -22,6 +23,7 @@ if (currentPage) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <title>{content.title ? `${content.title} 🚀 ${site.title}` : site.title}</title>
+    <MetaData {content} canonicalURL={Astro?.request?.canonicalURL}/>
 
     <!-- This is intentionally inlined to avoid FOUC -->
     <script>
@@ -45,7 +47,9 @@ if (currentPage) {
 
     <link rel="icon" 
           type="image/svg+xml" 
-          href="/favicon.svg">
+          href="/favicon.svg"/>
+
+    <link rel="sitemap" href="/sitemap.xml"/>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/src/layouts/Main.astro
+++ b/docs/src/layouts/Main.astro
@@ -23,7 +23,7 @@ if (currentPage) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <title>{content.title ? `${content.title} 🚀 ${site.title}` : site.title}</title>
-    <MetaData {content} canonicalURL={Astro?.request?.canonicalURL}/>
+    <MetaData {content} canonicalURL={Astro.request.canonicalURL}/>
 
     <!-- This is intentionally inlined to avoid FOUC -->
     <script>


### PR DESCRIPTION
## Changes

- Docs Closes #775 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Adds [Open Graph](https://ogp.me) and [Twitter Cards](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#attribution) tags to the docs site.