### PR TITLE
Docs: npm@7 requires an extra `--` for arguments passed to the comman…

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 The easiest way to check out one of these examples on your machine is by running this command in an empty directory:
 
 ```
-npm init astro --template [EXAMPLE_NAME]
+npm init astro -- --template [EXAMPLE_NAME]
 ```
 
 ## Community Examples
@@ -12,11 +12,11 @@ npm init astro --template [EXAMPLE_NAME]
 Visit [awesome-astro](https://github.com/one-aalam/awesome-astro) for a full list of community examples. You can use `npm init astro` to check out any community examples:
 
 ```
-npm init astro --template [GITHUB_USER]/[REPO_NAME]
+npm init astro -- --template [GITHUB_USER]/[REPO_NAME]
 ```
 
 Paths to examples nested inside of a repo are also supported:
 
 ```
-npm init astro --template [GITHUB_USER]/[REPO_NAME]/path/to/example
+npm init astro -- --template [GITHUB_USER]/[REPO_NAME]/path/to/example
 ```

--- a/examples/blog-multiple-authors/README.md
+++ b/examples/blog-multiple-authors/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Blog with Multiple Authors
 
 ```
-npm init astro --template blog-multiple-authors
+npm init astro -- --template blog-multiple-authors
 ```
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Blog
 
 ```
-npm init astro --template blog
+npm init astro -- --template blog
 ```
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Docs Site
 
 ```
-npm init astro --template docs
+npm init astro -- --template docs
 ```
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/framework-multiple/README.md
+++ b/examples/framework-multiple/README.md
@@ -1,7 +1,7 @@
 # Kitchen Sink: Microfrontends with Astro
 
 ```
-npm init astro --template framework-multiple
+npm init astro -- --template framework-multiple
 ```
 
 This example showcases Astro's built-in support for multiple frameworks ([React](https://reactjs.org), [Preact](https://preactjs.com), [Svelte](https://svelte.dev), and [Vue (`v3.x`)](https://v3.vuejs.org/)).

--- a/examples/framework-preact/README.md
+++ b/examples/framework-preact/README.md
@@ -1,7 +1,7 @@
 # Using Preact with Astro
 
 ```
-npm init astro --template framework-preact
+npm init astro -- --template framework-preact
 ```
 
 This example showcases Astro's built-in support for [Preact](https://preactjs.com/).

--- a/examples/framework-react/README.md
+++ b/examples/framework-react/README.md
@@ -1,7 +1,7 @@
 # Using React with Astro
 
 ```
-npm init astro --template framework-react
+npm init astro -- --template framework-react
 ```
 
 This example showcases Astro's built-in support for [React](https://reactjs.org/).

--- a/examples/framework-svelte/README.md
+++ b/examples/framework-svelte/README.md
@@ -1,7 +1,7 @@
 # Using Svelte with Astro
 
 ```
-npm init astro --template framework-svelte
+npm init astro -- --template framework-svelte
 ```
 
 This example showcases Astro's built-in support for [Svelte](https://svelte.dev/).

--- a/examples/framework-vue/README.md
+++ b/examples/framework-vue/README.md
@@ -1,7 +1,7 @@
 # Using Vue with Astro
 
 ```
-npm init astro --template framework-vue
+npm init astro -- --template framework-vue
 ```
 
 This example showcases Astro's built-in support for [Vue (`v3.x`)](https://v3.vuejs.org/).

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Portfolio
 
 ```
-npm init astro --template portfolio
+npm init astro -- --template portfolio
 ```
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/with-markdown/README.md
+++ b/examples/with-markdown/README.md
@@ -1,7 +1,7 @@
 # Astro Example: Markdown
 
 ```
-npm init astro --template with-markdown
+npm init astro -- --template with-markdown
 ```
 
 This example showcases Astro's [built-in Markdown support](../../docs/markdown.md).

--- a/examples/with-nanostores/README.md
+++ b/examples/with-nanostores/README.md
@@ -1,7 +1,7 @@
 # Astro Example: Nanostores
 
 ```
-npm init astro --template with-nanostores
+npm init astro -- --template with-nanostores
 ```
 
 This example showcases using [`nanostores`](https://github.com/nanostores/nanostores) to provide shared state between components from different frameworks.

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -1,7 +1,7 @@
 # Astro with Tailwind
 
 ```
-npm init astro --template with-tailwindcss
+npm init astro -- --template with-tailwindcss
 ```
 
 Astro comes with [Tailwind](https://tailwindcss.com) support out of the box. This example showcases how to style your Astro project with Tailwind.


### PR DESCRIPTION
…d, per @natemoo-re's description.

Fixes #737

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Update the docs in the example directories from `npm init astro --template react-framework` to `npm init astro -- --template react-framework`