### PR TITLE
Docs: replace `npm run start` with `npm start`

### DIFF
--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -17,7 +17,7 @@ npm init astro
 npm install
 
 # start developing!
-npm run start
+npm start
 
 # when you're ready: build your static site to `dist/`
 npm run build

--- a/examples/blog-multiple-authors/README.md
+++ b/examples/blog-multiple-authors/README.md
@@ -43,7 +43,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm run start` | Starts local dev server at `localhost:3000` |
+| `npm start`     | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -43,7 +43,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm run start` | Starts local dev server at `localhost:3000` |
+| `npm start`     | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -20,7 +20,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm run start` | Starts local dev server at `localhost:3000` |
+| `npm start`     | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/docs/src/pages/index.md
+++ b/examples/docs/src/pages/index.md
@@ -48,7 +48,7 @@ The default Astro project has the following `scripts` in the `/package.json` fil
 For local development, run:
 
 ```
-npm run start
+npm start
 ```
 
 To build for production, run the following command:

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -13,7 +13,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm run start` | Starts local dev server at `localhost:3000` |
+| `npm start`     | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/snowpack/README.md
+++ b/examples/snowpack/README.md
@@ -27,7 +27,7 @@ npm install
 3. Run the Astro dev environment.
 
 ```shell
-npm run start
+npm start
 ```
 
 4. Build the website. (Not yet working.)

--- a/examples/snowpack/src/pages/tutorials/getting-started.md
+++ b/examples/snowpack/src/pages/tutorials/getting-started.md
@@ -80,7 +80,7 @@ Add the Snowpack development server to `package.json` under as the `start` scrip
 Run the following on the command line to start the Snowpack development server
 
 ```
-npm run start
+npm start
 ```
 
 If all went well, Snowpack automatically opens your site in a new browser!

--- a/examples/snowpack/src/pages/tutorials/quick-start.md
+++ b/examples/snowpack/src/pages/tutorials/quick-start.md
@@ -29,7 +29,7 @@ For long-term development, the best way to use Snowpack is with a package.json s
 
 ```js
 // Recommended: package.json scripts
-// npm run start (or: "yarn run ...", "pnpm run ...")
+// npm start (or: "yarn run ...", "pnpm run ...")
 "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build"

--- a/examples/snowpack/src/pages/tutorials/react.md
+++ b/examples/snowpack/src/pages/tutorials/react.md
@@ -36,7 +36,7 @@ You can now head to the new directory and start Snowpack with the following two 
 
 ```bash
 cd react-snowpack
-npm run start
+npm start
 ```
 
 You should see your new website up and running!

--- a/examples/snowpack/src/pages/tutorials/svelte.md
+++ b/examples/snowpack/src/pages/tutorials/svelte.md
@@ -39,7 +39,7 @@ Head to the new `svelte-snowpack` directory and start Snowpack with the followin
 
 ```bash
 cd svelte-snowpack
-npm run start
+npm start
 ```
 
 You should see your new website up and running!
@@ -75,7 +75,7 @@ module.exports = {
   ],
 ```
 
-Restart your Snowpack dev server to run it with the new configuration. Exit the process (ctrl + c in most Windows/Linux/macOS) and start it again with `npm run start`.
+Restart your Snowpack dev server to run it with the new configuration. Exit the process (ctrl + c in most Windows/Linux/macOS) and start it again with `npm start`.
 
 > 💡 Tip: Restart the Snowpack development server when you make configuration changes (changes to the `snowpack.config.js`).
 

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -32,7 +32,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm run start` | Starts local dev server at `localhost:3000` |
+| `npm start`     | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?


### PR DESCRIPTION
## Changes

- docs: Quick Start
- examples: README

## Testing

## Docs

There was a mix of "npm run start" and "npm start" in the documentation, so it has been unified to "npm start".
It's not a mistake but it should be consistent.
