### PR TITLE
Allow using the Fragment built-in in Astro components

### DIFF
--- a/.changeset/flat-apes-pump.md
+++ b/.changeset/flat-apes-pump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Restores the ability to use Fragment in astro components

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -95,4 +95,12 @@ Basics('Allows spread attributes with TypeScript (#521)', async ({ runtime }) =>
   assert.equal($('#spread-ts').attr('c'), '2');
 });
 
+Basics('Allows using the Fragment element to be used', async ({ runtime }) => {
+  const result = await runtime.load('/fragment');
+  assert.ok(!result.error, 'No errors thrown');
+  const html = result.contents;
+  const $ = doc(html);
+  assert.equal($('#one').length, 1, 'Element in a fragment rendered');
+});
+
 Basics.run();

--- a/packages/astro/test/fixtures/astro-basic/src/pages/fragment.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/fragment.astro
@@ -1,0 +1,12 @@
+<html lang="en">
+<head>
+  <title>Fragment test</title>
+</head>
+<body>
+<ul>
+<Fragment>
+  <li id="one">One</li>
+</Fragment>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
Closes #582

## Changes

This restores the ability to use `Fragment` in astro components. This is mostly not needed, as you can just use children everywhere but expressions. Fragment is used a bit internally and restoring this allows you to use it in a transform in the compiler. Also allows users to use `Fragment` instead of `<>` in expressions, if desired.

## Testing

Test added

## Docs

N/A
