### PR TITLE
Added docs for community plugins 📗

### DIFF
--- a/docs/src/pages/guides/publish-to-npm.md
+++ b/docs/src/pages/guides/publish-to-npm.md
@@ -23,13 +23,16 @@ Here's an example package that we'd like to publish to npm. It includes two Astr
 
 Your package manifest. This includes information about your package such as name, description, any dependencies, and other important metadata. If you don't know what the `package.json` file is, we highly recommend you to have a quick read on [the npm documentation](https://docs.npmjs.com/creating-a-package-json-file).
 
+When making a astro component use the `astro-component` keyword, this makes it easier for people to find your component.
+
 We recommend that you define an [exports entry](https://nodejs.org/api/packages.html) for your `index.js` package entrypoint like so:
 
 ```json
 {
   "name": "@example/my-components",
   "version": "0.0.1",
-  "exports": "./index.js"
+  "exports": "./index.js",
+  "keywords": ["astro-component"]
 }
 ```
 
@@ -89,6 +92,8 @@ Looking for components already made by the community?
 Here are the current available community developed Astro components.
 
 - [Astro Static Tweet](https://www.npmjs.com/package/@rebelchris/astro-static-tweet) ~ A component to embed tweets as static HTML so you don't have to load the Twitter JavaScripts.
+
+You can also [search npm for astro components.](https://www.npmjs.com/search?q=keywords%3Aastro-component)
 
 Did you make a component?
 

--- a/docs/src/pages/guides/publish-to-npm.md
+++ b/docs/src/pages/guides/publish-to-npm.md
@@ -81,3 +81,15 @@ To support importing by file within your package, add each file to your **packag
   }
 }
 ```
+
+## Community components
+
+Looking for components already made by the community?
+
+Here are the current available community developed Astro components.
+
+- [Astro Static Tweet](https://www.npmjs.com/package/@rebelchris/astro-static-tweet) ~ A component to embed tweets as static HTML so you don't have to load the Twitter JavaScripts.
+
+Did you make a component?
+
+[Create a PR to submit your component in these docs](https://github.com/snowpackjs/astro/issues/new/choose)


### PR DESCRIPTION
## Changes

Added a section in the publish your own component page.
This is to rank community build components so we have a nice overview.

## Testing

Tested by locally running
See this screenshot:

<img width="1143" alt="Screenshot 2021-07-21 at 20 18 34" src="https://user-images.githubusercontent.com/554874/126539455-f821f781-0657-4d38-88a5-777a8224e2ab.png">

## Docs

Yes only the docs were updated actually.
See above screenshot for added text.
