### PR TITLE
📘 DOC: Move `site` to a prop instead of directly importing from within the c…

### DIFF
--- a/docs/src/components/MetaData.astro
+++ b/docs/src/components/MetaData.astro
@@ -1,6 +1,10 @@
 ---
-import { site } from '../config.ts';
-const { content = {}, canonicalURL } = Astro.props;
+export interface Props {
+  content: any,
+  site: any,
+  canonicalURL: URL | string,
+};
+const { content = {}, site, canonicalURL } = Astro.props;
 const formattedContentTitle = content.title ? `${content.title} 🚀 ${site.title}` : site.title;
 const imageSrc = content?.image?.src ?? site.image.src;
 const canonicalImageSrc = new URL(imageSrc, Astro.site);

--- a/docs/src/layouts/Main.astro
+++ b/docs/src/layouts/Main.astro
@@ -23,7 +23,7 @@ if (currentPage) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <title>{content.title ? `${content.title} 🚀 ${site.title}` : site.title}</title>
-    <MetaData {content} canonicalURL={Astro.request.canonicalURL}/>
+    <MetaData {content} {site} canonicalURL={Astro.request.canonicalURL}/>
 
     <!-- This is intentionally inlined to avoid FOUC -->
     <script>


### PR DESCRIPTION
…omponent.

## Changes

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Refactor `<MetaData/>` to be more reusable: `<MetaData {content} {site} canonicalUrl={Astro.request.canonicalUrl}/>`