### PR TITLE
Add default index file to parsing

### DIFF
--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -165,7 +165,7 @@ function generateAttributes(attrs: Record<string, string>): string {
 }
 
 function getComponentUrl(astroConfig: AstroConfig, url: string, parentUrl: string | URL) {
-  const componentExt = path.extname(url);
+  const componentExt = path.extname(url) || 'index';
   const ext = PlainExtensions.has(componentExt) ? '.js' : `${componentExt}.js`;
   const outUrl = new URL(url, parentUrl);
   return '/_astro/' + outUrl.href.replace(astroConfig.projectRoot.href, '').replace(/\.[^.]+$/, ext);


### PR DESCRIPTION
It turned out that Astro can't correctly work with components that are imported from directory's index file.
    For example, we have this structure:
    
    src/
    ├── components/
            └── Header/
                    ├── Header.tsx
                    └── index.js
    
    // index.js
    export {Header} from './Header'
    
    If we import Header in .astro file it will be rendered just fine but if we want to make it interactive then we will get an error 404
    /_astro/src/components/Header not found
    
    I was trying to make it work with index.jsx/ts/tsx extensions but couldn't figure out how to make it work without rewriting tests

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
