### PR TITLE
Update deploy.sh to include touch .nojekyll

### DIFF
--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -45,6 +45,9 @@ By default, the build output will be placed at `dist/`. You may deploy this `dis
 
    # navigate into the build output directory
    cd dist
+   
+   # add .nojekyll to bypass GitHub Page's default behavior
+   touch .nojekyll
 
    # if you are deploying to a custom domain
    # echo 'www.example.com' > CNAME

--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -31,8 +31,7 @@ By default, the build output will be placed at `dist/`. You may deploy this `dis
 ## GitHub Pages
 
 1. Set the correct `buildOptions.site` in `astro.config.mjs`.
-2. Run `touch public/.nojekyll` to create a `.nojekyll` file in `public/`. This [bypasses GitHub Page's default behavior](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/) to ignore paths prefixed with `_`.
-3. Inside your project, create `deploy.sh` with the following content (uncommenting the appropriate lines), and run it to deploy:
+1. Inside your project, create `deploy.sh` with the following content (uncommenting the appropriate lines), and run it to deploy:
 
    ```bash{13,20,23}
    #!/usr/bin/env sh


### PR DESCRIPTION
## Changes

Added `touch .nojekyll` to the deploy.sh example in the Github Pages section. Because `npm run build` doesn't pull through .nojekyll from public as outlined in step 2 I think because its a dotfile.

This was the original issue #816 

## Testing

No tests added as its just an extra line and comment in the code example. 

## Docs

Yes, the Github Pages deploy.sh script was updated.
