### PR TITLE
Fix: JSX renderer "Hello world!" error

### DIFF
--- a/.changeset/lovely-cats-sin.md
+++ b/.changeset/lovely-cats-sin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix error when no renderers are passed

--- a/packages/astro/snowpack-plugin-jsx.cjs
+++ b/packages/astro/snowpack-plugin-jsx.cjs
@@ -83,9 +83,7 @@ Unable to resolve a renderer that handles JSX transforms! Please include a \`ren
 
         return {
           '.js': {
-            code: `(() => {
-              throw new Error("Hello world!");
-            })()`,
+            code: '',
           },
         };
       }


### PR DESCRIPTION
## Changes

With no JSX renderers specified, JSX files would throw `"Hello world!"`. This was a test feature that accidentally got shipped.

## Testing

Manually confirmed. We don't have a good way to test log messages.

## Docs

N/A