### PR TITLE
docs: fix broken link to Markdown component

### DIFF
--- a/docs/src/pages/guides/markdown-content.md
+++ b/docs/src/pages/guides/markdown-content.md
@@ -7,7 +7,7 @@ Astro comes with out-of-the-box Markdown support powered by the expansive [remar
 
 ## Remark and Rehype Plugins
 
-In addition to custom components inside the [`<Markdown>` component](/guides/markdown-content#markdown-component), Astro comes with [GitHub-flavored Markdown](https://github.github.com/gfm/) support, [Footnotes](https://github.com/remarkjs/remark-footnotes) syntax, [Smartypants](https://github.com/silvenon/remark-smartypants), and syntax highlighting via [Prism](https://prismjs.com/) pre-enabled.
+In addition to custom components inside the [`<Markdown>` component](/guides/markdown-content#astros-markdown-component), Astro comes with [GitHub-flavored Markdown](https://github.github.com/gfm/) support, [Footnotes](https://github.com/remarkjs/remark-footnotes) syntax, [Smartypants](https://github.com/silvenon/remark-smartypants), and syntax highlighting via [Prism](https://prismjs.com/) pre-enabled.
 
 Also, Astro supports third-party plugins for Markdown. You can provide your plugins in `astro.config.mjs`.
 


### PR DESCRIPTION
## Changes/Testing
No relevant changes or tests, docs-only.

## Docs
Fix broken link in Markdown documentation.

As an alternative, the `<Markdown>` component section can also be renamed to just "Markdown Component", and keep the old link unchanged.