### PR TITLE
📘 DOC: adds a skip link so that you can skip the nav via keyboard

### DIFF
--- a/docs/public/index.css
+++ b/docs/public/index.css
@@ -433,6 +433,35 @@ h2.heading {
   white-space: nowrap;
   border-width: 0;
 }
+
+.focus\:not-sr-only:focus,
+.focus\:not-sr-only:focus-visible {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
+.skiplink,
+.skiplink:focus,
+.skiplink:focus-visible {
+  position: absolute;
+  padding: 0.25em;
+  font-size: larger;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 999;
+  display: block;
+  background-color: var(--theme-bg);
+  color: var(--theme-text-accent);
+  border-radius: 0.25em;
+  outline: var(--theme-text-accent) solid 1px;
+  outline-offset: 0;
+}
 /* Screenreader Only Text - End */
 
 :target {

--- a/docs/src/layouts/Main.astro
+++ b/docs/src/layouts/Main.astro
@@ -256,6 +256,7 @@ if (currentPage) {
 
   <body>
     <header>
+      <a href="#article" class="sr-only focus:not-sr-only skiplink"><span>Skip to Content</span></a>
       <nav class="nav-wrapper" title="Top Navigation">
         <div class="menu-toggle">
             <MenuToggle client:idle/>


### PR DESCRIPTION
## Changes

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
<img width="275" alt="image" src="https://user-images.githubusercontent.com/10626596/126727248-0e8a4757-e6e8-4cac-8cda-81280019626a.png">

Adds a Skip Link that is normally invisible but is focusable by tabbing to it at the top of the page so that keyboard users can skip the SiteSidebar and other nav and get directly to the main content.