### PR TITLE
Remove components from example md file

### DIFF
--- a/examples/blog/public/blog.scss
+++ b/examples/blog/public/blog.scss
@@ -269,3 +269,27 @@ img.cover {
   max-height: 50vh;
   object-fit: cover;
 }
+
+blockquote {
+  font-size: 1.5rem;
+  --padding-block: 1rem;
+  --padding-inline: 1.25rem;
+  --color: var(--theme-divider);
+
+  display: flex;
+  flex-direction: column;
+
+  padding: var(--padding-block) var(--padding-inline);
+  margin-left: calc(var(--padding-inline) * -1);
+  margin-right: calc(var(--padding-inline) * -1);
+
+  background: transparent;
+  border-left: calc(var(--padding-inline) / 2) solid var(--color);
+  border-radius: 0;
+}
+
+blockquote .source {
+  font-weight: 500;
+  color: var(--color);
+  font-size: 1rem;
+}

--- a/examples/blog/src/pages/posts/introducing-astro.md
+++ b/examples/blog/src/pages/posts/introducing-astro.md
@@ -21,9 +21,7 @@ Today I'm excited to publicly share Astro: a new kind of static site builder tha
 
 This post marks the first public beta release of Astro. **Missing features and bugs are still to be expected at this early stage.** There are still some months to go before an official 1.0 release, but there are already several fast sites built with Astro in production today. We would love your early feedback as we move towards a v1.0 release later this year.
 
-<Note>
-  To learn more about Astro and start building your first site, check out [the project README.](https://github.com/snowpackjs/astro#-guides)
-</Note>
+> To learn more about Astro and start building your first site, check out [the project README.](https://github.com/snowpackjs/astro#-guides).
 
 ## Getting Started
 
@@ -62,9 +60,7 @@ This new approach to web architecture is called [islands architecture](https://j
 
 ## Embracing the Pit of Success
 
-<BlockQuote author="Jeff Atwood" source="Falling Into The Pit of Success" sourceHref="https://blog.codinghorror.com/falling-into-the-pit-of-success/">
-  A well-designed system makes it easy to do the right things and annoying (but not impossible) to do the wrong things
-</BlockQuote>
+> A well-designed system makes it easy to do the right things and annoying (but not impossible) to do the wrong things<div class="source"><p>– Jeff Atwood</p>[Falling Into The Pit of Success](https://blog.codinghorror.com/falling-into-the-pit-of-success/)</div>
 
 Poor performance is often framed as a failure of the developer, but we respectfully disagree. In many cases, poor performance is a failure of tooling. It should be difficult to build a slow website.
 


### PR DESCRIPTION
Blog example contains components for `<Note>` and `<BlockQuote>`

## Changes

- Converts `<Note>` and `<BlockQuote>` components in `.md` to markdown
- Adds blockquote styles to `blog.scss`

### Before changes
<img width="716" alt="Screen Shot 2021-07-23 at 3 34 17 AM" src="https://user-images.githubusercontent.com/3117665/126750851-67bf49ec-4026-4db7-b24b-bd6b0a5d91cc.png">

### After changes

<img width="811" alt="Screen Shot 2021-07-23 at 3 31 16 AM" src="https://user-images.githubusercontent.com/3117665/126750533-66c47526-692e-44e9-ae97-d2dd4c14cc4a.png">

## Testing

No tests added, maybe you could test for components in markdown though?

## Docs

No docs added, bug fix only
