### PR TITLE
Correctly serialize falsey values at top-level of components

### DIFF
--- a/.changeset/healthy-pants-rule.md
+++ b/.changeset/healthy-pants-rule.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for `false` being rendered in conditionals

--- a/packages/astro/test/astro-expr.test.js
+++ b/packages/astro/test/astro-expr.test.js
@@ -80,6 +80,12 @@ Expressions('Does not render falsy values using &&', async ({ runtime }) => {
   assert.equal($('#false').length, 0, `Expected {false && <span id="false" />} not to render`);
   assert.equal($('#null').length, 0, `Expected {null && <span id="null" />} not to render`);
   assert.equal($('#undefined').length, 0, `Expected {undefined && <span id="undefined" />} not to render`);
+
+  // Inside of a component
+  assert.equal($('#frag-true').length, 1, `Expected {true && <span id="true" />} to render`);
+  assert.equal($('#frag-false').length, 0, `Expected {false && <span id="false" />} not to render`);
+  assert.equal($('#frag-null').length, 0, `Expected {null && <span id="null" />} not to render`);
+  assert.equal($('#frag-undefined').length, 0, `Expected {undefined && <span id="undefined" />} not to render`);
 });
 
 Expressions.run();

--- a/packages/astro/test/fixtures/astro-expr/src/components/falsy.astro
+++ b/packages/astro/test/fixtures/astro-expr/src/components/falsy.astro
@@ -1,0 +1,23 @@
+---
+const { items, emptyItems } = Astro.props;
+
+const internal = [];
+---
+
+<!-- False -->
+{false && (
+  <span id="frag-false" />
+)}
+
+<!-- Null -->
+{null && (
+  <span id="frag-null" />
+)}
+
+<!-- True -->
+{true && (
+  <span id="frag-true" />
+)}
+
+<!-- Undefined -->
+{false && (<span id="frag-undefined" />)}

--- a/packages/astro/test/fixtures/astro-expr/src/pages/falsy.astro
+++ b/packages/astro/test/fixtures/astro-expr/src/pages/falsy.astro
@@ -1,3 +1,6 @@
+---
+import Falsey from '../components/falsy.astro';
+---
 <html lang="en">
 <head>
   <title>My site</title>
@@ -8,5 +11,9 @@
   {undefined && <span id="undefined" />}
   {true && <span id="true" />}
   <span id="zero">{0 && "VALUE"}</span>
+
+  <section id="fragment-container">
+    <Falsey />
+  </section>
 </body>
 </html>


### PR DESCRIPTION
Fixes #679

## Changes

This makes our handling of children inside of Fragments the same as inside of elements. This is the cause of the `false` values being rendered, our handling of fragments was too naive.

## Testing

Test added

## Docs

N/A, bug fix
