### PR TITLE
fix table header text color

### DIFF
--- a/docs/public/index.css
+++ b/docs/public/index.css
@@ -223,7 +223,7 @@ tr:nth-of-type(odd) {
 }
 th {
   background: var(--color-black);
-  color: white;
+  color: var(--theme-color);
   font-weight: bold;
 }
 td,


### PR DESCRIPTION
## Changes

- switched table header color to use theme CSS var

Before:
<img width="755" alt="image" src="https://user-images.githubusercontent.com/32459922/126840506-d85c2ace-8b7e-4099-8c2d-033714e82db6.png">

After:
<img width="750" alt="image" src="https://user-images.githubusercontent.com/32459922/126840538-8a3cfe96-9258-4c28-906e-33be37279725.png">


## Testing

No tests, CSS change

## Docs

bug fix only
