### PR TITLE
Fixed typo in getting-started.md

### DIFF
--- a/docs/src/pages/getting-started.md
+++ b/docs/src/pages/getting-started.md
@@ -3,7 +3,7 @@ layout: ~/layouts/Main.astro
 title: Getting Started
 ---
 
-Astro is modern static site builder. Learn what Astro is all about from [our homepage](https://astro.build/) or [our release post](https://astro.build/blog/introducing-astro). This page is an overview of the Astro documentation and all related resources.
+Astro is a modern static site builder. Learn what Astro is all about from [our homepage](https://astro.build/) or [our release post](https://astro.build/blog/introducing-astro). This page is an overview of the Astro documentation and all related resources.
 
 Looking for a quick overview of what Astro is? [Visit our homepage.](https://astro.build)
 


### PR DESCRIPTION
Just added missing "a" in the first sentence.

## Changes

First sentence did not include the "a". Please see updated file git comparison.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No test needed, single char added in documentation first page. Merge created in Github with merge checks.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Yes. Doc updated. Only 1 char added because it was missing in the sentence.