### PR TITLE
Fix `renderer-solid` not creating a reactive root

### DIFF
--- a/.changeset/friendly-tigers-smoke.md
+++ b/.changeset/friendly-tigers-smoke.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/renderer-solid': patch
+---
+
+Uses Solid's `render` function to render our components on the client.

--- a/packages/renderers/renderer-solid/client.js
+++ b/packages/renderers/renderer-solid/client.js
@@ -1,3 +1,4 @@
+import { createComponent } from 'solid-js';
 import { render } from 'solid-js/web';
 
 export default (element) => (Component, props, childHTML) => {
@@ -11,5 +12,5 @@ export default (element) => (Component, props, childHTML) => {
   // Using Solid's `render` method ensures that a `root` is created
   // in order to properly handle reactivity. It also handles
   // components that are not native HTML elements.
-  render(() => Component({ ...props, children }), element);
+  render(() => createComponent(Component, { ...props, children }), element);
 };

--- a/packages/renderers/renderer-solid/client.js
+++ b/packages/renderers/renderer-solid/client.js
@@ -1,15 +1,15 @@
-import { createComponent } from 'solid-js/web';
+import { render } from 'solid-js/web';
 
-export default (element) => (Component, props) => {
-  // Solid `createComponent` just returns a DOM node with all reactivity
-  // already attached. There's no VDOM, so there's no real need to "mount".
-  // Likewise, `children` can just reuse the nearest `astro-fragment` node.
-  const component = createComponent(Component, {
-    ...props,
-    children: element.querySelector('astro-fragment'),
-  });
+export default (element) => (Component, props, childHTML) => {
+  // Solid's `render` does not replace the element's children.
+  // Deleting the root's children is necessary before calling `render`.
+  element.replaceChildren();
 
-  const children = Array.isArray(component) ? component : [component];
+  const children = document.createElement('astro-fragment');
+  children.innerHTML = childHTML;
 
-  element.replaceChildren(...children);
+  // Using Solid's `render` method ensures that a `root` is created
+  // in order to properly handle reactivity. It also handles
+  // components that are not native HTML elements.
+  render(() => Component({ ...props, children }), element);
 };


### PR DESCRIPTION
## Changes

Fixes #847. Instead of creating the element and inserting it on the DOM, this PR makes use of Solid's `render` since it adds a reactive root to the component tree. Without it `createEffect` and other reactivity characteristics do not work. The `render` method also handles any kind of possible return from a Solid component since they are not necessarily native HTML elements.

## Testing

No tests were added, I couldn't find any tests regarding renderers to guide me in this case.

## Docs

Bug fix only
