### PR TITLE
Account for pathnames being part of the site config

### DIFF
--- a/packages/astro/src/build/util.ts
+++ b/packages/astro/src/build/util.ts
@@ -11,7 +11,11 @@ export function canonicalURL(url: string, base?: string): URL {
   pathname = pathname.replace(/\/1\/?$/, ''); // neither is a trailing /1/ (impl. detail of collections)
   if (!path.extname(pathname)) pathname = pathname.replace(/(\/+)?$/, '/'); // add trailing slash if there’s no extension
   pathname = pathname.replace(/\/+/g, '/'); // remove duplicate slashes (URL() won’t)
-  return new URL(pathname, base);
+  if(base) {
+    return new URL('.' + pathname, base);
+  } else {
+    return new URL(pathname, base);
+  }
 }
 
 /** Resolve final output URL */

--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -117,7 +117,7 @@ ${result.imports.join('\n')}
 
 ${/* Global Astro Namespace (shadowed & extended by the scoped namespace inside of __render()) */ ''}
 const __TopLevelAstro = {
-  site: new URL('/', ${JSON.stringify(site)}),
+  site: new URL(${JSON.stringify(site)}),
   fetchContent: (globResult) => fetchContent(globResult, import.meta.url),
 };
 const Astro = __TopLevelAstro;

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -68,8 +68,8 @@ async function load(config: RuntimeConfig, rawPathname: string | undefined): Pro
   const { logging, snowpackRuntime, snowpack, configManager } = config;
   const { buildOptions, devOptions } = config.astroConfig;
 
-  let origin = buildOptions.site ? new URL(buildOptions.site).origin : `http://${devOptions.hostname}:${devOptions.port}`;
-  const fullurl = new URL(rawPathname || '/', origin);
+  const site = new URL(buildOptions.site || `http://${devOptions.hostname}:${devOptions.port}`);
+  const fullurl = new URL(rawPathname || '/', site.origin);
 
   const reqPath = decodeURI(fullurl.pathname);
   info(logging, 'access', reqPath);
@@ -214,7 +214,7 @@ async function load(config: RuntimeConfig, rawPathname: string | undefined): Pro
       request: {
         // params should go here when implemented
         url: requestURL,
-        canonicalURL: canonicalURL(requestURL.pathname, requestURL.origin),
+        canonicalURL: canonicalURL(requestURL.pathname, site.toString()),
       },
       children: [],
       props: pageProps,

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -18,10 +18,10 @@ Global('Astro.request.url', async (context) => {
 Global('Astro.request.canonicalURL', async (context) => {
   // given a URL, expect the following canonical URL
   const canonicalURLs = {
-    '/': 'https://mysite.dev/',
-    '/post/post': 'https://mysite.dev/post/post/',
-    '/posts': 'https://mysite.dev/posts/',
-    '/posts/2': 'https://mysite.dev/posts/2/',
+    '/': 'https://mysite.dev/blog/',
+    '/post/post': 'https://mysite.dev/blog/post/post/',
+    '/posts': 'https://mysite.dev/blog/posts/',
+    '/posts/2': 'https://mysite.dev/blog/posts/2/',
   };
 
   for (const [url, canonicalURL] of Object.entries(canonicalURLs)) {
@@ -36,7 +36,7 @@ Global('Astro.site', async (context) => {
   assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
-  assert.equal($('#site').attr('href'), 'https://mysite.dev');
+  assert.equal($('#site').attr('href'), 'https://mysite.dev/blog/');
 });
 
 Global.run();

--- a/packages/astro/test/fixtures/astro-global/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-global/astro.config.mjs
@@ -1,6 +1,6 @@
 export default {
   buildOptions: {
-    site: 'https://mysite.dev',
+    site: 'https://mysite.dev/blog/',
     sitemap: false,
   },
 };

--- a/packages/astro/test/fixtures/astro-global/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/index.astro
@@ -5,6 +5,6 @@
 </head>
 <body>
   <div id="pathname">{Astro.request.url.pathname}</div>
-  <a id="site" href={Astro.site.origin}>Home</a>
+  <a id="site" href={Astro.site.toString()}>Home</a>
 </body>
 </html>


### PR DESCRIPTION
Fixes #688

## Changes

This makes it so that we use buildOptions.site consistently throughout the internals. Instead of just using it to get the origin, use it fully to construct URLs, which gives us correct URLs in the case where the site includes a pathname other than `/`.

## Testing

Updated existing tests

## Docs

Bug fix
