### PR TITLE
Correctly compile `lang="sass" styles`

### DIFF
--- a/.changeset/cold-bikes-float.md
+++ b/.changeset/cold-bikes-float.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 Added sass support

--- a/.changeset/itchy-bobcats-rest.md
+++ b/.changeset/itchy-bobcats-rest.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Added sass support

--- a/packages/astro/src/compiler/transform/styles.ts
+++ b/packages/astro/src/compiler/transform/styles.ts
@@ -107,7 +107,10 @@ async function transformStyle(code: string, { logging, type, filename, scopedCla
       css = code;
       break;
     }
-    case 'sass':
+    case 'sass': {
+      css = sass.renderSync({ data: code, includePaths, indentedSyntax: true }).css.toString('utf8');
+      break;
+    }
     case 'scss': {
       css = sass.renderSync({ data: code, includePaths }).css.toString('utf8');
       break;

--- a/packages/astro/src/compiler/transform/styles.ts
+++ b/packages/astro/src/compiler/transform/styles.ts
@@ -107,12 +107,9 @@ async function transformStyle(code: string, { logging, type, filename, scopedCla
       css = code;
       break;
     }
-    case 'sass': {
-      css = sass.renderSync({ data: code, includePaths, indentedSyntax: true }).css.toString('utf8');
-      break;
-    }
+    case 'sass':
     case 'scss': {
-      css = sass.renderSync({ data: code, includePaths }).css.toString('utf8');
+      css = sass.renderSync({ data: code, includePaths, indentedSyntax: styleType === 'sass' }).css.toString('utf8');
       break;
     }
     default: {


### PR DESCRIPTION
close #851 

## Changes

- Adds `indentedSyntax: true` for compiling `sass` stylesheets, so that they are no longer compiled as `scss`

## Testing

Tested by recreating steps in #851 (with locally built Astro), now shows correct behavior

## Docs

Current behavior reflects that described in the documentation, thus no change needed
