### PR TITLE
Exclude @vue/runtime-core from processing to fix Vue SSR for nested components

### DIFF
--- a/.changeset/seven-shoes-stare.md
+++ b/.changeset/seven-shoes-stare.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/renderer-vue": patch
+---
+
+Exclude @vue/runtime-core from processing to fix Vue SSR for nested components

--- a/packages/renderers/renderer-vue/index.js
+++ b/packages/renderers/renderer-vue/index.js
@@ -4,4 +4,5 @@ export default {
   client: './client',
   server: './server',
   knownEntrypoints: ['vue'],
+  external: ['@vue/runtime-core'],
 };


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

It adds a `@vue/runtime-core` package to `external` of the `@astrojs/renderer-vue` config. 

More description about root causes of the issue are there -> https://github.com/snowpackjs/astro/issues/828

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

I was using a slightly modified version of Astro Vue app - https://github.com/Igloczek/astro-vue-nested-components
Then changed `node_modules/@astrojs/renderer-vue/index.js` to contains my changes, and run Astro.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
It's just a bugfix.