### PR TITLE
Update default `tailwindConfig` property

### DIFF
--- a/.changeset/two-days-cry.md
+++ b/.changeset/two-days-cry.md
@@ -1,0 +1,22 @@
+---
+"astro": patch
+"create-astro": patch
+"@example/blog-multiple-authors": patch
+"@example/blog": patch
+"@example/docs": patch
+"@example/framework-lit": patch
+"@example/framework-multiple": patch
+"@example/framework-preact": patch
+"@example/framework-react": patch
+"@example/framework-solid": patch
+"@example/framework-svelte": patch
+"@example/framework-vue": patch
+"@example/portfolio": patch
+"@example/starter": patch
+"@example/with-markdown-plugins": patch
+"@example/with-markdown": patch
+"@example/with-tailwindcss": patch
+"docs": patch
+---
+
+Update default `tailwindConfig` property to use the common value

--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -18,7 +18,7 @@ export default {
   },
   devOptions: {
     port: 3000, // The port to run the dev server on.
-    // tailwindConfig: '',  // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   // component renderers which are enabled by default
   renderers: [

--- a/examples/blog-multiple-authors/astro.config.mjs
+++ b/examples/blog-multiple-authors/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-preact'],
 };

--- a/examples/blog/astro.config.mjs
+++ b/examples/blog/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-preact'],
 };

--- a/examples/docs/astro.config.mjs
+++ b/examples/docs/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-preact'],
 };

--- a/examples/framework-lit/astro.config.mjs
+++ b/examples/framework-lit/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-lit'],
 };

--- a/examples/framework-multiple/astro.config.mjs
+++ b/examples/framework-multiple/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-preact', '@astrojs/renderer-react', '@astrojs/renderer-svelte', '@astrojs/renderer-vue', '@astrojs/renderer-solid'],
 };

--- a/examples/framework-preact/astro.config.mjs
+++ b/examples/framework-preact/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-preact'],
 };

--- a/examples/framework-react/astro.config.mjs
+++ b/examples/framework-react/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-react'],
 };

--- a/examples/framework-solid/astro.config.mjs
+++ b/examples/framework-solid/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-solid'],
 };

--- a/examples/framework-svelte/astro.config.mjs
+++ b/examples/framework-svelte/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-svelte'],
 };

--- a/examples/framework-vue/astro.config.mjs
+++ b/examples/framework-vue/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-vue'],
 };

--- a/examples/portfolio/astro.config.mjs
+++ b/examples/portfolio/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-preact'],
 };

--- a/examples/starter/astro.config.mjs
+++ b/examples/starter/astro.config.mjs
@@ -9,6 +9,6 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
 };

--- a/examples/with-markdown-plugins/astro.config.mjs
+++ b/examples/with-markdown-plugins/astro.config.mjs
@@ -16,6 +16,6 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
 };

--- a/examples/with-tailwindcss/astro.config.mjs
+++ b/examples/with-tailwindcss/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    tailwindConfig: './tailwind.config.js', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    tailwindConfig: './tailwind.config.js', // Path to tailwind.config.js
   },
   renderers: ['@astrojs/renderer-preact'],
 };

--- a/packages/astro/test/fixtures/lit-element/astro.config.mjs
+++ b/packages/astro/test/fixtures/lit-element/astro.config.mjs
@@ -9,7 +9,7 @@ export default {
   },
   devOptions: {
     // port: 3000,         // The port to run the dev server on.
-    // tailwindConfig: '', // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },
   renderers: [
     '@astrojs/renderer-lit'

--- a/packages/create-astro/src/config.ts
+++ b/packages/create-astro/src/config.ts
@@ -12,7 +12,7 @@ export const createConfig = ({ renderers }: { renderers: string[] }) => {
   devOptions: {
     // hostname: 'localhost',  // The hostname to run the dev server on. 
     // port: 3000,             // The port to run the dev server on.
-    // tailwindConfig: '',     // Path to tailwind.config.js if used, e.g. './tailwind.config.js'
+    // tailwindConfig: './tailwind.config.js',  // Path to tailwind.config.js
   },`,
     `  renderers: ${JSON.stringify(renderers, undefined, 2)
       .split('\n')


### PR DESCRIPTION
## Changes

Updates the default `tailwindConfig` property of `astro.config.mjs` to the commonly used path `./tailwind.config.js`. This allows the user to easily uncomment the property and start working for the common Tailwind config file.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Regarding this section https://docs.astro.build/guides/styling#-tailwind
I'm unsure if we should update the docs section to be worded differently with this change. 