### PR TITLE
Add an alt tag for the hero image in the blog example

### DIFF
--- a/.changeset/heavy-pumas-cross.md
+++ b/.changeset/heavy-pumas-cross.md
@@ -1,0 +1,5 @@
+---
+"@example/blog": patch
+---
+
+Add an alt tag for the hero image in the blog example

--- a/examples/blog/src/components/BlogPost.astro
+++ b/examples/blog/src/components/BlogPost.astro
@@ -8,14 +8,14 @@ export interface Props {
   heroImage: string;
 }
 
-const { title, author, publishDate, heroImage } = Astro.props;
+const { title, author, publishDate, heroImage, alt } = Astro.props;
 ---
 
 <div class="layout">
   <article class="content">
   <div>
     <header>
-      {heroImage && <img width="720" height="420" class="hero-image" loading="lazy" src={heroImage} />}
+      {heroImage && <img width="720" height="420" class="hero-image" loading="lazy" src={heroImage} alt={alt} />}
       <p class="publish-date">{publishDate}</p>
       <h1 class="title">{title}</h1>
       <Author name="@FredKSchott" href="https://twitter.com/FredKSchott" />

--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -5,7 +5,7 @@ import BlogHeader from '../components/BlogHeader.astro';
 import BlogPost from '../components/BlogPost.astro';
 
 const {content} = Astro.props;
-const {title, description, publishDate, author, heroImage, permalink} = content;
+const {title, description, publishDate, author, heroImage, permalink, alt} = content;
 ---
 <html lang={ content.lang || 'en' }>
   <head>
@@ -15,7 +15,7 @@ const {title, description, publishDate, author, heroImage, permalink} = content;
 
   <body>
     <BlogHeader />
-    <BlogPost title={title} author={author} heroImage={heroImage} publishDate={publishDate}>
+    <BlogPost title={title} author={author} heroImage={heroImage} publishDate={publishDate} alt={alt}>
       <slot />
     </BlogPost>
   </body>

--- a/examples/blog/src/pages/posts/introducing-astro.md
+++ b/examples/blog/src/pages/posts/introducing-astro.md
@@ -4,6 +4,7 @@ description: "We're excited to announce Astro as a new way to build static websi
 publishDate: 'Tuesday, June 8 2021'
 author: 'fred'
 heroImage: '/social.jpg'
+alt: 'Astro'
 layout: '../../layouts/BlogPost.astro'
 ---
 


### PR DESCRIPTION
## Changes

- Adds an `alt` tag to the hero image of the blog example

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manually verified this adds an `alt` tag to the hero image

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
bug fix only
