### PR TITLE
Add internals to knownEntrypoints

### DIFF
--- a/.changeset/wise-months-run.md
+++ b/.changeset/wise-months-run.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes warnings for Astro internals for fetch-content and slots

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -352,7 +352,8 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
     'astro/dist/internal/__astro_component.js',
     'astro/dist/internal/element-registry.js',
     'astro/dist/internal/fetch-content.js',
-    'astro/dist/internal/__astro_slot.js'
+    'astro/dist/internal/__astro_slot.js',
+    'prismjs'
   ];
   for (const renderer of rendererInstances) {
     knownEntrypoints.push(renderer.server);

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -348,7 +348,12 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
 
   // Make sure that Snowpack builds our renderer plugins
   const rendererInstances = await configManager.buildRendererInstances();
-  const knownEntrypoints: string[] = ['astro/dist/internal/__astro_component.js', 'astro/dist/internal/element-registry.js'];
+  const knownEntrypoints: string[] = [
+    'astro/dist/internal/__astro_component.js',
+    'astro/dist/internal/element-registry.js',
+    'astro/dist/internal/fetch-content.js',
+    'astro/dist/internal/__astro_slot.js'
+  ];
   for (const renderer of rendererInstances) {
     knownEntrypoints.push(renderer.server);
     if (renderer.client) {


### PR DESCRIPTION
## Changes

With the blog template we get these warnings:

```
[14:01:30] [snowpack] astro/dist/internal/fetch-content.js: Unscannable package import found.
Snowpack scans source files for package imports at startup, and on every change.
But, sometimes an import gets added during the build process, invisible to our file scanner.
We'll prepare this package for you now, but should add "astro/dist/internal/fetch-content.js" to "knownEntrypoints"
in your config file so that this gets prepared with the rest of your imports during startup.
[14:01:30] [snowpack] + astro/dist/internal/fetch-content.js@0.18.0
[14:01:31] [snowpack] astro/dist/internal/__astro_slot.js: Unscannable package import found.
Snowpack scans source files for package imports at startup, and on every change.
But, sometimes an import gets added during the build process, invisible to our file scanner.
We'll prepare this package for you now, but should add "astro/dist/internal/__astro_slot.js" to "knownEntrypoints"
in your config file so that this gets prepared with the rest of your imports during startup.
[14:01:31] [snowpack] + astro/dist/internal/__astro_slot.js@0.18.0
```

This is fixed by adding to knownEntrypoints

## Testing

Can't be tested in the monorepo.

## Docs

Bug fix