### PR TITLE
Add warning when encountering 'zlib: unexpected end of file' message (#655)

### DIFF
--- a/.changeset/popular-shrimps-sin.md
+++ b/.changeset/popular-shrimps-sin.md
@@ -1,5 +1,5 @@
 ---
-'create-astro': minor
+'create-astro': patch
 ---
 
 Add warning when encountering 'zlib: unexpected end of file' error

--- a/.changeset/popular-shrimps-sin.md
+++ b/.changeset/popular-shrimps-sin.md
@@ -1,0 +1,5 @@
+---
+'create-astro': minor
+---
+
+Add warning when encountering 'zlib: unexpected end of file' error

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -120,6 +120,12 @@ export async function main() {
   } catch (err) {
     // degit is compiled, so the stacktrace is pretty noisy. Just report the message.
     console.error(red(err.message));
+
+    // Warning for issue #655
+    if (err.message === 'zlib: unexpected end of file') {
+      console.log(yellow("This seems to be a cache related problem. Remove the folder '~/.degit/github/snowpackjs' to fix this error."));
+      console.log(yellow('For more information check out this issue: https://github.com/snowpackjs/astro/issues/655'));
+    }
     process.exit(1);
   }
 

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { bold, cyan, gray, green, red } from 'kleur/colors';
+import { bold, cyan, gray, green, red, yellow } from 'kleur/colors';
 import fetch from 'node-fetch';
 import prompts from 'prompts';
 import degit from 'degit';


### PR DESCRIPTION
## Changes

PR based on comment: https://github.com/snowpackjs/astro/issues/835#issuecomment-885994107

I really want to avoid recommending "rm -rf ~/.degit/github/snowpackjs" as this will run on the home directory.

## Testing

Just commented `degit` out and throw the expected error.

```js
// await emitter.clone(cwd);
   throw new Error('zlib: unexpected end of file')
```

## Docs

This was a bug (semi) fix only.
