### PR TITLE
Prevent client: attributes from being passed to components

### DIFF
--- a/.changeset/eight-monkeys-hammer.md
+++ b/.changeset/eight-monkeys-hammer.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Removes a warning in Svelte hydrated components

--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -30,6 +30,8 @@ const traverse: typeof babelTraverse.default = (babelTraverse.default as any).de
 const babelGenerator: typeof _babelGenerator = _babelGenerator.default;
 const { transformSync } = esbuild;
 
+const hydrationDirectives = new Set(['client:load', 'client:idle', 'client:visible', 'client:media']);
+
 interface Attribute {
   start: number;
   end: number;
@@ -54,8 +56,6 @@ interface HydrationAttributes {
 function findHydrationAttributes(attrs: Record<string, string>): HydrationAttributes {
   let method: HydrationAttributes['method'];
   let value: undefined | string;
-
-  const hydrationDirectives = new Set(['client:load', 'client:idle', 'client:visible', 'client:media']);
 
   for (const [key, val] of Object.entries(attrs)) {
     if (hydrationDirectives.has(key)) {
@@ -155,7 +155,9 @@ function getTextFromAttribute(attr: any): string {
 function generateAttributes(attrs: Record<string, string>): string {
   let result = '{';
   for (const [key, val] of Object.entries(attrs)) {
-    if (key.startsWith('...')) {
+    if (hydrationDirectives.has(key)) {
+      continue;
+    } else if (key.startsWith('...')) {
       result += key + ',';
     } else {
       result += JSON.stringify(key) + ':' + val + ',';

--- a/packages/astro/test/astro-components.test.js
+++ b/packages/astro/test/astro-components.test.js
@@ -39,4 +39,10 @@ Components('Still throws an error for undefined components', async ({ runtime })
   assert.equal(result.statusCode, 500);
 });
 
+Components('Svelte component', async ({ runtime }) => {
+  const result = await runtime.load('/client');
+  const html = result.contents;
+  assert.ok(!/"client:load": true/.test(html), 'Client attrs not added');
+});
+
 Components.run();

--- a/packages/astro/test/fixtures/astro-components/src/pages/client.astro
+++ b/packages/astro/test/fixtures/astro-components/src/pages/client.astro
@@ -1,0 +1,9 @@
+---
+import SvelteComponent from '../components/Component.svelte';
+---
+<html>
+<head><title>Components</title></head>
+<body>
+  <SvelteComponent client:load />
+</body>
+</html>


### PR DESCRIPTION
Closes #890

## Changes

This prevents `client:load`, etc directives from being included in the resulting hyperscript, so they won't be passed to components or serialized in the client. 

This prevents a Svelte warning that occurs for unknown directives.

## Testing

Test added

## Docs

Bug fix
