### PR TITLE
📘 DOC: Add DuckDuckGo-based static form search

### DIFF
--- a/docs/public/index.css
+++ b/docs/public/index.css
@@ -284,10 +284,13 @@ img {
 
 header button {
   background-color: var(--theme-bg);
+  outline: var(--theme-text) solid 1px;
 }
 
 header button:hover,
-header button:focus {
+header button:focus:not(:focus-visible),
+header button:focus-visible {
+  background-color: var(--theme-bg-hover);
   outline: var(--theme-text) solid 1px;
 }
 

--- a/docs/public/theme.css
+++ b/docs/public/theme.css
@@ -76,10 +76,16 @@
   --theme-code-bg: hsla(217, 19%, 27%, 1);
   --theme-code-text: hsla(var(--color-gray-95), 1);
   --theme-navbar-bg: hsla(var(--color-base-white), 100%, 1);
-  --theme-navbar-height: 6rem;
+  --theme-navbar-height: 10rem;
   --theme-sidebar-offset: var(--theme-navbar-height);
   --theme-selection-color: hsla(var(--color-orange), 1);
   --theme-selection-bg: hsla(var(--color-orange), var(--theme-accent-opacity));
+}
+
+@media (min-width: 50em) {
+  :root {
+    --theme-navbar-height: 6rem;
+  }
 }
 
 body {

--- a/docs/src/components/Search.module.css
+++ b/docs/src/components/Search.module.css
@@ -1,0 +1,46 @@
+.flex {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+@media (min-width: 50em) {
+  .flex {
+    gap: 1rem;
+  }
+}
+
+.search-txt {
+  background-color: var(--theme-bg);
+  outline: var(--theme-text) solid 1px;
+}
+
+.search-txt:hover,
+.search-txt:focus:not(:focus-visible),
+.search-txt:focus-visible {
+  background-color: var(--theme-bg-hover);
+  outline: var(--theme-text) solid 1px;
+}
+
+.search-txt:active,
+.search-txt[aria-pressed='true'] {
+  background: var(--theme-text);
+  color: var(--theme-bg);
+}
+
+.search-txt {
+  display: flex;
+  align-items: center;
+  justify-items: center;
+  gap: 0.25em;
+  padding: 0.33em 0.67em;
+  border: 0;
+  background: var(--theme-bg);
+  display: flex;
+  font-size: 1rem;
+  align-items: center;
+  border-radius: 99em;
+  color: var(--theme-text);
+  background-color: var(--theme-bg);
+}

--- a/docs/src/components/Search.tsx
+++ b/docs/src/components/Search.tsx
@@ -1,0 +1,43 @@
+import type { FunctionalComponent } from 'preact';
+import { h, Fragment } from 'preact';
+import Styles from './Search.module.css';
+
+const Search: FunctionalComponent = () => {
+  return (
+    <form
+      action="https://duckduckgo.com/"
+      method="get"
+      class="search"
+      target="_blank"
+      id="docs-search"
+    >
+      <div class={Styles.flex}>
+        <div>
+          <label for="search-term" class="sr-only">
+            Search Terms
+          </label>
+          <input
+            type="search"
+            name="q"
+            id="search-term"
+            class={Styles['search-txt']}
+            placeholder="Search via DuckDuckGo"
+            autocomplete="off"
+            required="true"
+          />
+          <input
+            aria-hidden="true"
+            name="sites"
+            value="docs.astro.build"
+            hidden=""
+          />
+        </div>
+        <div>
+          <button type="submit">Search</button>
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default Search;

--- a/docs/src/layouts/Main.astro
+++ b/docs/src/layouts/Main.astro
@@ -3,6 +3,7 @@ import ArticleFooter from '../components/ArticleFooter.astro';
 import SiteSidebar from '../components/SiteSidebar.astro';
 import DocSidebar, { TableOfContents, More } from '../components/DocSidebar/DocSidebar.tsx';
 import MenuToggle from '../components/MenuToggle.tsx';
+import Search from "../components/Search.tsx";
 import MetaData from "../components/MetaData.astro";
 import { site } from "../config.ts";
 
@@ -140,6 +141,8 @@ if (currentPage) {
         display: flex;
         align-items: center;
         justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 0.5rem;
         width: 100%;
         max-width: 82em;
         padding: 0 1rem;
@@ -258,7 +261,6 @@ if (currentPage) {
           position: sticky;
         }
         #sidebar-content {
-          /* display: flex; */
           grid-column: 3;
         }
         .sm\:hidden {
@@ -326,6 +328,8 @@ if (currentPage) {
             </svg>
           </a>
         </div>
+
+        <Search/>
       </nav>
     </header>
 


### PR DESCRIPTION
## Changes

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Adds a DuckDuckGo form with `site:docs.astro.build` to the header of the docs site, so that people can more easily navigate the docs until we have algolia.