### PR TITLE
Move rehype-raw to a dependency

### DIFF
--- a/.changeset/bright-doors-remain.md
+++ b/.changeset/bright-doors-remain.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-support': patch
+---
+
+Move rehype-raw to a dependency

--- a/packages/markdown-support/package.json
+++ b/packages/markdown-support/package.json
@@ -24,6 +24,7 @@
     "remark-footnotes": "^3.0.0",
     "remark-gfm": "^1.0.0",
     "remark-parse": "^9.0.0",
+    "rehype-raw": "^5.1.0",
     "remark-rehype": "^8.1.0",
     "remark-slug": "^6.1.0",
     "unified": "^9.2.1",
@@ -33,7 +34,6 @@
     "@types/github-slugger": "^1.3.0",
     "github-slugger": "^1.3.0",
     "rehype-parse": "^7.0.1",
-    "rehype-raw": "^5.1.0",
     "rehype-stringify": "^8.0.0",
     "unified": "^9.2.1",
     "unist-util-visit": "^3.1.0"


### PR DESCRIPTION
This was mistakenly a devDependency, breaking `npm init astro`