### PR TITLE
Fix curly braces

### DIFF
--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -182,7 +182,7 @@ interface GetComponentWrapperOptions {
 const PlainExtensions = new Set(['.js', '.jsx', '.ts', '.tsx']);
 /** Generate Astro-friendly component import */
 function getComponentWrapper(_name: string, hydration: HydrationAttributes, { url, importSpecifier }: ComponentInfo, opts: GetComponentWrapperOptions) {
-  const { astroConfig, filename } = opts;
+  const { astroConfig, compileOptions, filename } = opts;
 
   let name = _name;
   let method = hydration.method;
@@ -192,8 +192,7 @@ function getComponentWrapper(_name: string, hydration: HydrationAttributes, { ur
     const [legacyName, legacyMethod] = _name.split(':');
     name = legacyName;
     method = legacyMethod as HydrationAttributes['method'];
-
-    const { compileOptions, filename } = opts;
+    
     const shortname = path.posix.relative(compileOptions.astroConfig.projectRoot.pathname, filename);
     warn(compileOptions.logging, shortname, yellow(`Deprecation warning: Partial hydration now uses a directive syntax. Please update to "<${name} client:${method} />"`));
   }
@@ -225,7 +224,7 @@ function getComponentWrapper(_name: string, hydration: HydrationAttributes, { ur
       }
     };
 
-    let metadata: string = '';
+    let metadata = '';
     if (method) {
       const componentUrl = getComponentUrl(astroConfig, url, pathToFileURL(filename));
       const componentExport = getComponentExport();
@@ -768,7 +767,7 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
             }
             if (parent.name === 'code') {
               // Special case, escaped { characters from markdown content
-              text = node.raw.replace(/&#x26;#123;/g, '{');
+              text = node.raw.replace(/CURLY_BRACE/g, '{');
             }
             buffers[curr] += ',' + JSON.stringify(text);
             return;

--- a/packages/astro/src/compiler/transform/prism.ts
+++ b/packages/astro/src/compiler/transform/prism.ts
@@ -10,14 +10,14 @@ function escape(code: string) {
     .replace(/[`$]/g, (match) => {
       return '\\' + match;
     })
-    .replace(/&#123;/g, '{');
+    .replace(/CURLY_BRACE/g, '{');
 }
 
 /** Unescape { characters transformed by Markdown generation */
 function unescapeCode(code: TemplateNode) {
   code.children = code.children?.map((child) => {
     if (child.type === 'Text') {
-      return { ...child, raw: child.raw.replace(/&#x26;#123;/g, '{') };
+      return { ...child, raw: child.raw.replace(/CURLY_BRACE/g, '{') };
     }
     return child;
   });

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -80,6 +80,17 @@ Markdown('Renders dynamic content though the content attribute', async ({ runtim
   assert.ok($('#inner').is('[class]'), 'Scoped class passed down');
 });
 
+Markdown('Renders curly braces correctly', async ({ runtime }) => {
+  const result = await runtime.load('/braces');
+  assert.ok(!result.error, `build error: ${result.error}`);
+
+  const $ = doc(result.contents);
+  assert.equal($('code').length, 3, 'Rendered curly braces markdown content');
+  assert.equal($('code:first-child').text(), '({})', 'Rendered curly braces markdown content');
+  assert.equal($('code:nth-child(2)').text(), '{...props}', 'Rendered curly braces markdown content');
+  assert.equal($('code:last-child').text(), '{/* JavaScript */}', 'Rendered curly braces markdown content');
+});
+
 Markdown('Does not close parent early when using content attribute (#494)', async ({ runtime }) => {
   const result = await runtime.load('/close');
   assert.ok(!result.error, `build error: ${result.error}`);

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/braces.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/braces.astro
@@ -1,0 +1,14 @@
+---
+import { Markdown } from 'astro/components';
+const title = 'My Blog Post';
+const description = 'This is a post about some stuff.';
+---
+
+<Markdown>
+  ## Interesting Topic
+
+  `({})`
+  `{...props}` 
+  `{/* JavaScript */}`
+  
+</Markdown>

--- a/packages/markdown-support/src/codeblock.ts
+++ b/packages/markdown-support/src/codeblock.ts
@@ -21,7 +21,7 @@ export function rehypeCodeBlock() {
   const escapeCode = (code: any) => {
     code.children = code.children.map((child: any) => {
       if (child.type === 'text') {
-        return { ...child, value: child.value.replace(/\{/g, '&#123;') };
+        return { ...child, value: child.value.replace(/\{/g, 'CURLY_BRACE') };
       }
       return child;
     });


### PR DESCRIPTION
## Changes

Should fix #727

Absolutely not sure about this fix.
I just found that if we use `'&#123;'` and try to replace it, we got unexpected result and braces are stayed as symbol. 
So I decided to use some custom constant to replace `{` with it and then we can replace constant to `{` during transformation.   

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
