### PR TITLE
Allow triple-dashes in markdown

### DIFF
--- a/.changeset/pretty-wolves-flash.md
+++ b/.changeset/pretty-wolves-flash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/parser': patch
+---
+
+Prevents locking up checking for --- inside of the HTML portion

--- a/packages/astro-parser/src/parse/state/text.ts
+++ b/packages/astro-parser/src/parse/state/text.ts
@@ -13,7 +13,7 @@ export default function text(parser: Parser) {
     if (parser.current().name === 'code') {
       return !parser.match('<') && !parser.match('{');
     }
-    return !parser.match('---') && !parser.match('<') && !parser.match('{') && !parser.match('`');
+    return !parser.match('<') && !parser.match('{') && !parser.match('`');
   };
 
   while (parser.index < parser.template.length && shouldContinue()) {

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -88,7 +88,7 @@ Markdown('Does not close parent early when using content attribute (#494)', asyn
   assert.equal($('#target').children().length, 2, '<Markdown content /> closed div#target early');
 });
 
-Markdown.only('Can render markdown with --- for horizontal rule', async ({ runtime }) => {
+Markdown('Can render markdown with --- for horizontal rule', async ({ runtime }) => {
   const result = await runtime.load('/dash');
   assert.ok(!result.error, `build error: ${result.error}`);
 

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -88,4 +88,11 @@ Markdown('Does not close parent early when using content attribute (#494)', asyn
   assert.equal($('#target').children().length, 2, '<Markdown content /> closed div#target early');
 });
 
+Markdown.only('Can render markdown with --- for horizontal rule', async ({ runtime }) => {
+  const result = await runtime.load('/dash');
+  assert.ok(!result.error, `build error: ${result.error}`);
+
+  // It works!
+});
+
 Markdown.run();

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/dash.md
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/dash.md
@@ -1,0 +1,14 @@
+---
+title: My Blog Post
+layout: ../layouts/content.astro
+---
+
+## Title
+
+Hello world
+
+With this in the body ---
+
+## Another
+
+more content


### PR DESCRIPTION
Closes #720

## Changes

This removes checking for `---` inside of text. At this point the codefences are already detected so this check only causes the parser to keep spinning.

## Testing

Test added

## Docs

Bug fix
