### PR TITLE
Add PORT env var to be used

### DIFF
--- a/.changeset/few-carpets-sing.md
+++ b/.changeset/few-carpets-sing.md
@@ -1,5 +1,5 @@
 ---
-"astro": minor
+"astro": patch
 ---
 
 Allow dev server port to be set by `PORT` environment variable

--- a/.changeset/few-carpets-sing.md
+++ b/.changeset/few-carpets-sing.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Allow dev server port to be set by `PORT` environment variable

--- a/packages/astro/src/cli.ts
+++ b/packages/astro/src/cli.ts
@@ -35,15 +35,42 @@ interface CLIState {
   };
 }
 
+type TypeOf = 'string' | 'boolean' | 'number'
+// Validates property types of object
+const validateOptions = (opts: Record<string, any>, specs: Record<string, TypeOf | ([(v: any) => unknown, TypeOf])>) => 
+   Object.entries(specs).reduce<Record<string, any>>((options, [k, spec]) => {
+    const v = opts[k]
+
+    if (typeof spec === 'string' && typeof v === spec) {
+        options[k] = v
+    } else if (Array.isArray(spec)) {
+      const [coercion, test] = spec
+      const result = coercion(v)
+      if (typeof result === test) {
+        options[k] = result
+      }
+    }
+    
+    return options
+  }, {})
+
 /** Determine which action the user requested */
 function resolveArgs(flags: Arguments): CLIState {
-  const options: CLIState['options'] = {
-    projectRoot: typeof flags.projectRoot === 'string' ? flags.projectRoot : undefined,
-    site: typeof flags.site === 'string' ? flags.site : undefined,
-    sitemap: typeof flags.sitemap === 'boolean' ? flags.sitemap : undefined,
-    port: typeof flags.port === 'number' ? flags.port : undefined,
-    config: typeof flags.config === 'string' ? flags.config : undefined,
-  };
+  const { PORT } = process.env
+  
+  // Merge options (Flags take priority)
+  const options = {
+    ...validateOptions({ port: PORT }, {
+      port: [parseInt, 'number']
+    }),
+    ...validateOptions(flags, {
+      projectRoot: 'string',
+      site: 'string',
+      sitemap: 'boolean',
+      port: 'number',
+      config: 'string'
+    })
+  }
 
   if (flags.version) {
     return { cmd: 'version', options };
@@ -101,7 +128,7 @@ function mergeCLIFlags(astroConfig: AstroConfig, flags: CLIState['options']) {
 }
 
 /** Handle `astro run` command */
-async function runCommand(rawRoot: string, cmd: (a: AstroConfig, options: any) => Promise<void>, options: CLIState['options']) {
+async function runCommand(rawRoot: string, cmd: (a: AstroConfig, opts: any) => Promise<void>, options: CLIState['options']) {
   try {
     const projectRoot = options.projectRoot || rawRoot;
     const astroConfig = await loadConfig(projectRoot, options.config);

--- a/packages/astro/src/cli.ts
+++ b/packages/astro/src/cli.ts
@@ -35,42 +35,45 @@ interface CLIState {
   };
 }
 
-type TypeOf = 'string' | 'boolean' | 'number'
+type TypeOf = 'string' | 'boolean' | 'number';
 // Validates property types of object
-const validateOptions = (opts: Record<string, any>, specs: Record<string, TypeOf | ([(v: any) => unknown, TypeOf])>) => 
-   Object.entries(specs).reduce<Record<string, any>>((options, [k, spec]) => {
-    const v = opts[k]
+const validateOptions = (opts: Record<string, any>, specs: Record<string, TypeOf | [(v: any) => unknown, TypeOf]>) =>
+  Object.entries(specs).reduce<Record<string, any>>((options, [k, spec]) => {
+    const v = opts[k];
 
     if (typeof spec === 'string' && typeof v === spec) {
-        options[k] = v
+      options[k] = v;
     } else if (Array.isArray(spec)) {
-      const [coercion, test] = spec
-      const result = coercion(v)
+      const [coercion, test] = spec;
+      const result = coercion(v);
       if (typeof result === test) {
-        options[k] = result
+        options[k] = result;
       }
     }
-    
-    return options
-  }, {})
+
+    return options;
+  }, {});
 
 /** Determine which action the user requested */
 function resolveArgs(flags: Arguments): CLIState {
-  const { PORT } = process.env
-  
+  const { PORT } = process.env;
+
   // Merge options (Flags take priority)
   const options = {
-    ...validateOptions({ port: PORT }, {
-      port: [parseInt, 'number']
-    }),
+    ...validateOptions(
+      { port: PORT },
+      {
+        port: [parseInt, 'number'],
+      }
+    ),
     ...validateOptions(flags, {
       projectRoot: 'string',
       site: 'string',
       sitemap: 'boolean',
       port: 'number',
-      config: 'string'
-    })
-  }
+      config: 'string',
+    }),
+  };
 
   if (flags.version) {
     return { cmd: 'version', options };


### PR DESCRIPTION
Resolves #872 

## Changes

- Adds groundwork for allowing environment variables to be used by the CLI
- Keeps CLI Flags as priority over environment variables, [based on this post](https://stackoverflow.com/questions/32272911/precedence-of-configuration-options-environment-registry-configuration-file-a) (flag > envvar > config > default)
- Allows `PORT` environment variable to be used (`PORT=4200 yarn dev`)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manually tested this by running the build and starting the cli directly from the `astro.cjs` file

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
I haven't updated this yet because I'm unsure where this information should live.


**NOTE:** I was attempting to set this up so we could easily support additional environment variables in the future without much effort. I could probably instead add just a simple change instead of the current PR like so:

```diff
-     port: typeof flags.port === 'number' ? flags.port : undefined,
+    port: typeof flags.port === 'number' ? flags.port : parseInt(PORT || '') || undefined,
```

So just let me know if I over-complicated it and I'll swap it out