### PR TITLE
fix preact render to update a component on first render

### DIFF
--- a/.changeset/cold-lies-move.md
+++ b/.changeset/cold-lies-move.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/renderer-preact': patch
+---
+
+Fix an issue where preact component UI wouldn't update on hydrate

--- a/packages/renderers/renderer-preact/client.js
+++ b/packages/renderers/renderer-preact/client.js
@@ -1,4 +1,4 @@
-import { h, hydrate } from 'preact';
+import { h, render } from 'preact';
 import StaticHtml from './static-html.js';
 
-export default (element) => (Component, props, children) => hydrate(h(Component, props, h(StaticHtml, { value: children })), element);
+export default (element) => (Component, props, children) => render(h(Component, props, h(StaticHtml, { value: children })), element);


### PR DESCRIPTION
## Changes

- Currently, the preact renderer isn't able to update a component's placeholder state on the server.
- In reading the docs, `hydrate()` is intended when the server output and client output are exactly the same. If the component can change, we should be using `render()`.

## Testing

- I'm not sure if we have a way to test this, currently.