### PR TITLE
Update layouts.md re link-handling for .scss files

### DIFF
--- a/docs/src/pages/core-concepts/layouts.md
+++ b/docs/src/pages/core-concepts/layouts.md
@@ -54,6 +54,8 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 </BaseLayout>
 ```
 
+**Note**: If you use .scss files rather than .css files, any stylesheet links in your layout should still point to .css files because of Astro’s auto-compilation process. When Astro “needs” the styling files, it’ll be “looking for” the final .css file(s) that it compiles from the .scss file(s). For example, if you have a .scss file at `./public/style/global.scss`, use this link: `<link rel="stylesheet" href="/style/global.css">` — **not** `<link rel="stylesheet" href="/style/global.scss">`. For additional related information, please see [Styling &amp; CSS](https://docs.astro.build/guides/styling).
+
 ## Nesting Layouts
 
 You can nest layouts when you want to create more specific page types without copy-pasting. It is common in Astro to have one generic `BaseLayout` and then many more specific layouts (`PostLayout`, `ProductLayout`, etc.) that reuse and build on top of it.


### PR DESCRIPTION
Adding a note to make clear that users of .scss files should still link to the final compiled .css files, as per https://discord.com/channels/830184174198718474/853350631389265940/871151798075949066. (See also https://github.com/snowpackjs/astro/pull/977/.)

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
