### PR TITLE
Add `lang` variable to docs frontmatter for translations

### DIFF
--- a/docs/src/pages/fi/getting-started.md
+++ b/docs/src/pages/fi/getting-started.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Aloittaminen
+lang: fi
 ---
 
 Astro on moderni työkalu staattisten sivustojen luomiseen. Voit löytää lisätietoa Astrosta englanniksi [kotisivultamme](https://astro.build/) tai [julkistusviestistämme](https://astro.build/blog/introducing-astro). Tämä sivu on yleiskatsaus Astron dokumentaatioon ja liittyviin sisältöihin.

--- a/docs/src/pages/fi/installation.md
+++ b/docs/src/pages/fi/installation.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Asennus
+lang: fi
 ---
 
 Astron voi asentaa parilla eri tavalla uuteen projektiin.

--- a/docs/src/pages/fi/quick-start.md
+++ b/docs/src/pages/fi/quick-start.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Pika-aloitus
+lang: fi
 ---
 
 ```shell

--- a/docs/src/pages/nl/getting-started.md
+++ b/docs/src/pages/nl/getting-started.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Beginnen
+lang: nl
 ---
 
 Astro is een moderne statische sitebouwer. Leer alles over Astro op onze [homepage](https://astro.build/) of ons [release-bericht](https://astro.build/blog/introducing-astro). Deze pagina is een overzicht van de Astro documentatie en alle gerelateerde bronnen.


### PR DESCRIPTION
## Changes


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Adds a `lang` attribute to translated doc pages so that the pages have the correct language set.