### PR TITLE
Fixes duplicate head content

### DIFF
--- a/.changeset/angry-hairs-return.md
+++ b/.changeset/angry-hairs-return.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes issue with head content being rendered in the wrong place

--- a/.changeset/dry-buses-design.md
+++ b/.changeset/dry-buses-design.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes issue with head content being put into the wrong place

--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -146,8 +146,8 @@ async function __render(props, ...children) {
       value: props,
       enumerable: true
     },
-    css: {
-      value: (props[__astroInternal] && props[__astroInternal].css) || [],
+    pageCSS: {
+      value: (props[__astroContext] && props[__astroContext].pageCSS) || [],
       enumerable: true
     },
     isPage: {
@@ -177,6 +177,7 @@ export async function __renderPage({request, children, props, css}) {
 
   Object.defineProperty(props, __astroContext, {
     value: {
+      pageCSS: css,
       request
     },
     writable: false,
@@ -185,7 +186,6 @@ export async function __renderPage({request, children, props, css}) {
 
   Object.defineProperty(props, __astroInternal, {
     value: {
-      css,
       isPage: true
     },
     writable: false,

--- a/packages/astro/src/compiler/transform/head.ts
+++ b/packages/astro/src/compiler/transform/head.ts
@@ -73,7 +73,7 @@ export default function (opts: TransformOptions): Transformer {
             start: 0,
             end: 0,
             type: 'Expression',
-            codeChunks: ['Astro.css.map(css => (', '))'],
+            codeChunks: ['Astro.pageCSS.map(css => (', '))'],
             children: [
               {
                 type: 'Element',
@@ -162,22 +162,15 @@ export default function (opts: TransformOptions): Transformer {
         );
       }
 
-      const conditionalNode = {
-        start: 0,
-        end: 0,
-        type: 'Expression',
-        codeChunks: ['Astro.isPage ? (', ') : null'],
-        children: [
-          {
-            start: 0,
-            end: 0,
-            type: 'Fragment',
-            children,
-          },
-        ],
-      };
-
-      eoh.append(conditionalNode);
+      if(eoh.foundHeadOrHtmlElement) {
+        const topLevelFragment = {
+          start: 0,
+          end: 0,
+          type: 'Fragment',
+          children,
+        };
+        eoh.append(topLevelFragment);
+      }
     },
   };
 }

--- a/packages/astro/test/fixtures/astro-doctype/src/components/Meta.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/components/Meta.astro
@@ -1,0 +1,5 @@
+---
+import SubMeta from './SubMeta.astro';
+---
+<meta name="author" content="Astro Fan">
+<SubMeta />

--- a/packages/astro/test/fixtures/astro-doctype/src/components/SubMeta.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/components/SubMeta.astro
@@ -1,0 +1,1 @@
+<meta name="keywords" content="JavaScript,Astro">

--- a/packages/astro/test/fixtures/astro-doctype/src/layouts/WithDoctype.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/layouts/WithDoctype.astro
@@ -1,0 +1,14 @@
+---
+import '../styles/global.css';
+import Meta from '../components/Meta.astro';
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>My App</title>
+    <Meta />
+  </head>
+  <body>
+
+  </body>
+</html>


### PR DESCRIPTION
This fixes a problem that people have been seeing where the doctype and/or head content is put into the wrong place.

## Changes

This updates the `head.ts` file that is responsible for injecting head content and makes it only do so if there is an html or head tag, rather than doing so for all page components.

## Testing

Tests added

## Docs

Bug fix only