### PR TITLE
Fixes duplicate head content

### DIFF
--- a/.changeset/angry-hairs-return.md
+++ b/.changeset/angry-hairs-return.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes issue with head content being rendered in the wrong place

--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -662,7 +662,7 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
                   buffers[curr] += `h(__astro_slot_content, { name: ${attributes.slot} },`;
                   paren++;
                 }
-                buffers[curr] += `h("${name}", ${generateAttributes(attributes)}`;
+                buffers[curr] += `h("${name}", ${generateAttributes(attributes)},`;
                 paren++;
                 return;
               }
@@ -692,7 +692,7 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
                   buffers[curr] += `h(__astro_slot_content, { name: ${attributes.slot} },`;
                   paren++;
                 }
-                buffers[curr] += `h(${componentName}, ${generateAttributes(attributes)}`;
+                buffers[curr] += `h(${componentName}, ${generateAttributes(attributes)},`;
                 paren++;
                 return;
               } else if (!componentInfo && !isCustomElementTag(componentName)) {

--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -146,8 +146,8 @@ async function __render(props, ...children) {
       value: props,
       enumerable: true
     },
-    css: {
-      value: (props[__astroInternal] && props[__astroInternal].css) || [],
+    pageCSS: {
+      value: (props[__astroContext] && props[__astroContext].pageCSS) || [],
       enumerable: true
     },
     isPage: {
@@ -177,6 +177,7 @@ export async function __renderPage({request, children, props, css}) {
 
   Object.defineProperty(props, __astroContext, {
     value: {
+      pageCSS: css,
       request
     },
     writable: false,
@@ -185,7 +186,6 @@ export async function __renderPage({request, children, props, css}) {
 
   Object.defineProperty(props, __astroInternal, {
     value: {
-      css,
       isPage: true
     },
     writable: false,

--- a/packages/astro/src/compiler/transform/head.ts
+++ b/packages/astro/src/compiler/transform/head.ts
@@ -162,7 +162,7 @@ export default function (opts: TransformOptions): Transformer {
         );
       }
 
-      if(eoh.foundHeadOrHtmlElement) {
+      if(eoh.foundHeadOrHtmlElement || eoh.foundHeadAndBodyContent) {
         const topLevelFragment = {
           start: 0,
           end: 0,

--- a/packages/astro/src/compiler/transform/head.ts
+++ b/packages/astro/src/compiler/transform/head.ts
@@ -73,7 +73,7 @@ export default function (opts: TransformOptions): Transformer {
             start: 0,
             end: 0,
             type: 'Expression',
-            codeChunks: ['Astro.css.map(css => (', '))'],
+            codeChunks: ['Astro.pageCSS.map(css => (', '))'],
             children: [
               {
                 type: 'Element',
@@ -162,22 +162,15 @@ export default function (opts: TransformOptions): Transformer {
         );
       }
 
-      const conditionalNode = {
-        start: 0,
-        end: 0,
-        type: 'Expression',
-        codeChunks: ['Astro.isPage ? (', ') : null'],
-        children: [
-          {
-            start: 0,
-            end: 0,
-            type: 'Fragment',
-            children,
-          },
-        ],
-      };
-
-      eoh.append(conditionalNode);
+      if(eoh.foundHeadOrHtmlElement) {
+        const topLevelFragment = {
+          start: 0,
+          end: 0,
+          type: 'Fragment',
+          children,
+        };
+        eoh.append(topLevelFragment);
+      }
     },
   };
 }

--- a/packages/astro/src/compiler/transform/util/end-of-head.ts
+++ b/packages/astro/src/compiler/transform/util/end-of-head.ts
@@ -11,6 +11,7 @@ export class EndOfHead {
   private stack: TemplateNode[] = [];
 
   public foundHeadElements = false;
+  public foundBodyElements = false;
   public append: (...node: TemplateNode[]) => void = () => void 0;
 
   get found(): boolean {
@@ -21,12 +22,23 @@ export class EndOfHead {
     return !!this.head || this.foundHeadElements;
   }
 
+  get foundHeadAndBodyContent(): boolean {
+    return this.foundHeadContent && this.foundBodyElements;
+  }
+
   get foundHeadOrHtmlElement(): boolean {
     return !!(this.html || this.head);
   }
 
   enter(node: TemplateNode) {
+    const name = node.name ? node.name.toLowerCase() : null;
+
     if (this.found) {
+      if (!validHeadElements.has(name)) {
+        if(node.type === 'Element') {
+          this.foundBodyElements = true;
+        }
+      }
       return;
     }
 
@@ -36,8 +48,6 @@ export class EndOfHead {
     if (!node.name) {
       return;
     }
-
-    const name = node.name.toLowerCase();
 
     if (name === 'head') {
       this.head = node;
@@ -55,6 +65,9 @@ export class EndOfHead {
     }
 
     if (!validHeadElements.has(name)) {
+      if(node.type === 'Element') {
+        this.foundBodyElements = true;
+      }
       this.firstNonHead = node;
       this.parent = this.stack[this.stack.length - 2];
       this.append = this.prependToFirstNonHead;

--- a/packages/astro/src/compiler/transform/util/end-of-head.ts
+++ b/packages/astro/src/compiler/transform/util/end-of-head.ts
@@ -1,17 +1,28 @@
 import type { TemplateNode } from '@astrojs/parser';
 
-const validHeadElements = new Set(['!doctype', 'title', 'meta', 'link', 'style', 'script', 'noscript', 'base']);
+const beforeHeadElements = new Set(['!doctype', 'html']);
+const validHeadElements = new Set(['title', 'meta', 'link', 'style', 'script', 'noscript', 'base']);
 
 export class EndOfHead {
+  private html: TemplateNode | null = null;
   private head: TemplateNode | null = null;
   private firstNonHead: TemplateNode | null = null;
   private parent: TemplateNode | null = null;
   private stack: TemplateNode[] = [];
 
+  public foundHeadElements = false;
   public append: (...node: TemplateNode[]) => void = () => void 0;
 
   get found(): boolean {
     return !!(this.head || this.firstNonHead);
+  }
+
+  get foundHeadContent(): boolean {
+    return !!this.head || this.foundHeadElements;
+  }
+
+  get foundHeadOrHtmlElement(): boolean {
+    return !!(this.html || this.head);
   }
 
   enter(node: TemplateNode) {
@@ -35,11 +46,21 @@ export class EndOfHead {
       return;
     }
 
+    // Skip !doctype and html elements
+    if(beforeHeadElements.has(name)) {
+      if(name === 'html') {
+        this.html = node;
+      }
+      return;
+    }
+
     if (!validHeadElements.has(name)) {
       this.firstNonHead = node;
       this.parent = this.stack[this.stack.length - 2];
       this.append = this.prependToFirstNonHead;
       return;
+    } else {
+      this.foundHeadElements = true;
     }
   }
 

--- a/packages/astro/src/internal/h.ts
+++ b/packages/astro/src/internal/h.ts
@@ -67,5 +67,6 @@ export async function h(tag: HTag, attrs: HProps, ...pChildren: Array<Promise<HC
 
 /** Fragment helper, similar to React.Fragment */
 export function Fragment(_: HProps, ...children: Array<HChild>) {
+  debugger;
   return Array.from(_children(children)).join('');
 }

--- a/packages/astro/src/internal/h.ts
+++ b/packages/astro/src/internal/h.ts
@@ -67,6 +67,5 @@ export async function h(tag: HTag, attrs: HProps, ...pChildren: Array<Promise<HC
 
 /** Fragment helper, similar to React.Fragment */
 export function Fragment(_: HProps, ...children: Array<HChild>) {
-  debugger;
   return Array.from(_children(children)).join('');
 }

--- a/packages/astro/test/astro-doctype.test.js
+++ b/packages/astro/test/astro-doctype.test.js
@@ -51,7 +51,7 @@ DType('Doctype can be provided in a layout', async ({ runtime }) => {
   assert.equal($('head link').length, 1, 'A link inside of the head');
 });
 
-DType.only('Doctype is added in a layout without one', async ({ runtime }) => {
+DType('Doctype is added in a layout without one', async ({ runtime }) => {
   const result = await runtime.load('/in-layout-no-doctype');
   assert.ok(!result.error, `build error: ${result.error}`);
 

--- a/packages/astro/test/astro-doctype.test.js
+++ b/packages/astro/test/astro-doctype.test.js
@@ -1,38 +1,13 @@
-import { fileURLToPath } from 'url';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
-import { loadConfig } from '#astro/config';
-import { createRuntime } from '#astro/runtime';
+import { doc } from './test-utils.js';
+import { setup } from './helpers.js';
 
 const DType = suite('doctype');
 
-let runtime, setupError;
+setup(DType, './fixtures/astro-doctype');
 
-DType.before(async () => {
-  try {
-    const astroConfig = await loadConfig(fileURLToPath(new URL('./fixtures/astro-doctype', import.meta.url)));
-
-    const logging = {
-      level: 'error',
-      dest: process.stderr,
-    };
-
-    runtime = await createRuntime(astroConfig, { logging });
-  } catch (err) {
-    console.error(err);
-    setupError = err;
-  }
-});
-
-DType.after(async () => {
-  (await runtime) && runtime.shutdown();
-});
-
-DType('No errors creating a runtime', () => {
-  assert.equal(setupError, undefined);
-});
-
-DType('Automatically prepends the standards mode doctype', async () => {
+DType('Automatically prepends the standards mode doctype', async ({ runtime }) => {
   const result = await runtime.load('/prepend');
   assert.ok(!result.error, `build error: ${result.error}`);
 
@@ -40,7 +15,7 @@ DType('Automatically prepends the standards mode doctype', async () => {
   assert.ok(html.startsWith('<!doctype html>'), 'Doctype always included');
 });
 
-DType('No attributes added when doctype is provided by user', async () => {
+DType('No attributes added when doctype is provided by user', async ({ runtime }) => {
   const result = await runtime.load('/provided');
   assert.ok(!result.error, `build error: ${result.error}`);
 
@@ -48,7 +23,7 @@ DType('No attributes added when doctype is provided by user', async () => {
   assert.ok(html.startsWith('<!doctype html>'), 'Doctype always included');
 });
 
-DType.skip('Preserves user provided doctype', async () => {
+DType.skip('Preserves user provided doctype', async ({ runtime }) => {
   const result = await runtime.load('/preserve');
   assert.ok(!result.error, `build error: ${result.error}`);
 
@@ -56,13 +31,32 @@ DType.skip('Preserves user provided doctype', async () => {
   assert.ok(html.startsWith('<!doctype HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">'), 'Doctype included was preserved');
 });
 
-DType('User provided doctype is case insensitive', async () => {
+DType('User provided doctype is case insensitive', async ({ runtime }) => {
   const result = await runtime.load('/capital');
   assert.ok(!result.error, `build error: ${result.error}`);
 
   const html = result.contents.toString('utf-8');
   assert.ok(html.startsWith('<!DOCTYPE html>'), 'Doctype left alone');
   assert.not.ok(html.includes('</!DOCTYPE>'), 'There should not be a closing tag');
+});
+
+DType('Doctype can be provided in a layout', async ({ runtime }) => {
+  const result = await runtime.load('/in-layout');
+  assert.ok(!result.error, `build error: ${result.error}`);
+
+  const html = result.contents.toString('utf-8');
+  assert.ok(html.startsWith('<!doctype html>'), 'doctype is at the front');
+
+  const $ = doc(html);
+  assert.equal($('head link').length, 1, 'A link inside of the head');
+});
+
+DType.only('Doctype is added in a layout without one', async ({ runtime }) => {
+  const result = await runtime.load('/in-layout-no-doctype');
+  assert.ok(!result.error, `build error: ${result.error}`);
+
+  const html = result.contents.toString('utf-8');
+  assert.ok(html.startsWith('<!doctype html>'), 'doctype is at the front');
 });
 
 DType.run();

--- a/packages/astro/test/fixtures/astro-doctype/src/components/Meta.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/components/Meta.astro
@@ -1,0 +1,5 @@
+---
+import SubMeta from './SubMeta.astro';
+---
+<meta name="author" content="Astro Fan">
+<SubMeta />

--- a/packages/astro/test/fixtures/astro-doctype/src/components/SubMeta.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/components/SubMeta.astro
@@ -1,0 +1,1 @@
+<meta name="keywords" content="JavaScript,Astro">

--- a/packages/astro/test/fixtures/astro-doctype/src/layouts/WithDoctype.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/layouts/WithDoctype.astro
@@ -1,0 +1,14 @@
+---
+import '../styles/global.css';
+import Meta from '../components/Meta.astro';
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>My App</title>
+    <Meta />
+  </head>
+  <body>
+
+  </body>
+</html>

--- a/packages/astro/test/fixtures/astro-doctype/src/layouts/WithoutDoctype.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/layouts/WithoutDoctype.astro
@@ -1,0 +1,11 @@
+---
+import '../styles/global.css'
+---
+<html lang="en">
+  <head>
+    <title>My App</title>
+  </head>
+  <body>
+
+  </body>
+</html>

--- a/packages/astro/test/fixtures/astro-doctype/src/pages/in-layout-no-doctype.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/pages/in-layout-no-doctype.astro
@@ -1,0 +1,4 @@
+---
+import WithoutDoctype from '../layouts/WithoutDoctype.astro';
+---
+<WithoutDoctype />

--- a/packages/astro/test/fixtures/astro-doctype/src/pages/in-layout.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/pages/in-layout.astro
@@ -1,0 +1,4 @@
+---
+import WithDoctype from '../layouts/WithDoctype.astro';
+---
+<WithDoctype />

--- a/packages/astro/test/fixtures/astro-doctype/src/styles/global.css
+++ b/packages/astro/test/fixtures/astro-doctype/src/styles/global.css
@@ -1,0 +1,3 @@
+body {
+  background: green;
+}

--- a/packages/astro/test/fixtures/no-head-el/src/pages/index.astro
+++ b/packages/astro/test/fixtures/no-head-el/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Something from '../components/Something.jsx';
 import Child from '../components/Child.astro';
 ---
+
 <title>My page</title>
 <style>
   .h1 {

--- a/packages/astro/test/fixtures/no-head-el/src/pages/no-elements.astro
+++ b/packages/astro/test/fixtures/no-head-el/src/pages/no-elements.astro
@@ -1,6 +1,0 @@
----
-import Something from '../components/Something.jsx';
-import Child from '../components/Child.astro';
----
-<Something client:load />
-<Child />

--- a/packages/astro/test/no-head-el.test.js
+++ b/packages/astro/test/no-head-el.test.js
@@ -25,14 +25,4 @@ NoHeadEl('Places style and scripts before the first non-head element', async ({ 
   assert.equal($('script[src="/_snowpack/hmr-client.js"]').length, 1, 'Only the hmr client for the page');
 });
 
-NoHeadEl('Injects HMR script even when there are no elements on the page', async ({ runtime }) => {
-  const result = await runtime.load('/no-elements');
-  assert.ok(!result.error, `build error: ${result.error}`);
-
-  const html = result.contents;
-  const $ = doc(html);
-
-  assert.equal($('script[src="/_snowpack/hmr-client.js"]').length, 1, 'Only the hmr client for the page');
-});
-
 NoHeadEl.run();


### PR DESCRIPTION
This fixes a problem that people have been seeing where the doctype and/or head content is put into the wrong place.

## Changes

This updates the `head.ts` file that is responsible for injecting head content and makes it only do so if there is an html or head tag, rather than doing so for all page components.

## Testing

Tests added

## Docs

Bug fix only
