### PR TITLE
Reduce meta viewport tag

### DIFF
--- a/docs/src/components/HeadCommon.astro
+++ b/docs/src/components/HeadCommon.astro
@@ -1,5 +1,5 @@
 <!-- Global Metadata -->
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <link rel="sitemap" href="/sitemap.xml"/>
 

--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -8,7 +8,7 @@ const { title, description, permalink } = Astro.props;
 ---
 
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="viewport" content="width=device-width" />
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -14,7 +14,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width" />
     <style>
         :global(:root) {
             font-family: system-ui;

--- a/examples/framework-preact/src/pages/index.astro
+++ b/examples/framework-preact/src/pages/index.astro
@@ -11,7 +11,7 @@ import Counter from '../components/Counter.jsx'
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width"
     />
     <style>
       :global(:root) {

--- a/examples/framework-react/src/pages/index.astro
+++ b/examples/framework-react/src/pages/index.astro
@@ -13,7 +13,7 @@ const someProps = {
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width"
     />
     <style>
       :global(:root) {

--- a/examples/framework-solid/src/pages/index.astro
+++ b/examples/framework-solid/src/pages/index.astro
@@ -7,7 +7,7 @@ import Counter from '../components/Counter.tsx';
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width"
     />
     <style>
       :global(:root) {

--- a/examples/framework-svelte/src/pages/index.astro
+++ b/examples/framework-svelte/src/pages/index.astro
@@ -11,7 +11,7 @@ import Counter from '../components/Counter.svelte'
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width"
     />
     <style>
       :global(:root) {

--- a/examples/framework-vue/src/pages/index.astro
+++ b/examples/framework-vue/src/pages/index.astro
@@ -11,7 +11,7 @@ import Counter from '../components/Counter.vue'
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width"
     />
     <style>
       :global(:root) {

--- a/examples/snowpack/src/components/BaseHead.astro
+++ b/examples/snowpack/src/components/BaseHead.astro
@@ -11,7 +11,7 @@ const { title, description, permalink } = Astro.props as Props;
 ---
 
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="viewport" content="width=device-width" />
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />

--- a/examples/snowpack/src/pages/tutorials/getting-started.md
+++ b/examples/snowpack/src/pages/tutorials/getting-started.md
@@ -57,7 +57,7 @@ Create an `index.html` in your project with the following contents:
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width" />
     <meta name="description" content="Starter Snowpack App" />
     <title>Starter Snowpack App</title>
   </head>

--- a/examples/starter/src/pages/index.astro
+++ b/examples/starter/src/pages/index.astro
@@ -16,7 +16,7 @@ let title = 'My Astro Site';
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width">
     <title>{title}</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="stylesheet" href="/style/global.css">

--- a/examples/with-nanostores/src/pages/index.astro
+++ b/examples/with-nanostores/src/pages/index.astro
@@ -11,7 +11,7 @@ import AdminsPreact from '../components/AdminsPreact.jsx';
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width">
     <title>Astro</title>
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/packages/astro/test/fixtures/astro-dynamic/src/pages/media.astro
+++ b/packages/astro/test/fixtures/astro-dynamic/src/pages/media.astro
@@ -5,7 +5,7 @@ const MOBILE = "(max-width: 600px)";
 <html>
 <head>
   <title>Media hydration</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width">
 </head>
 <body>
   <!-- Inline value -->

--- a/packages/astro/test/fixtures/vue-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/vue-component/src/pages/index.astro
@@ -6,7 +6,7 @@ import Counter from '../components/Counter.vue'
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width"
     />
     <title>Vue component</title>
     <style>

--- a/www/src/components/BaseHead.astro
+++ b/www/src/components/BaseHead.astro
@@ -8,7 +8,7 @@ const { title, description, permalink } = Astro.props;
 ---
 
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="viewport" content="width=device-width" />
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 


### PR DESCRIPTION
## Changes

This updates all meta viewport tags to `<meta name="viewport" content="width=device-width" />`, reducing the complexity developers experience creating web sites.

**Before** (there are 2 variants found in Astro):
```html
<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
```
```html
<meta name="viewport" content="width=device-width, initial-scale=1" />
```

**After**:
```html
<meta name="viewport" content="width=device-width" />
```

The removed portions were applicable in older browsers; specifically iOS < 9.

Additional details from WebHint:
- https://webhint.io/docs/user-guide/hints/hint-meta-viewport/

Details of its removal at Vercel:
- https://github.com/vercel/next.js/pull/10823#issuecomment-594833527

More information on `viewport-fit` specifically being unnecessary as well:
- https://bubblin.io/blog/notch

## Testing

Testing can be conducted using older devices, or by trusting the sources above — the Vercel team, the creator of Preact, the WebHint OpenJS Foundation Project.

## Docs

The docs themselves do not appear to be changed, but some templates that generate the docs are updated.