### PR TITLE
Do not observe visible hydrate components more than once

### DIFF
--- a/docs/src/components/RightSidebar/MoreMenu.astro
+++ b/docs/src/components/RightSidebar/MoreMenu.astro
@@ -64,5 +64,5 @@ const {editHref} = Astro.props;
   </li>
 </ul>
 <div style="margin: 2rem 0; text-align: center;">
-  <ThemeToggleButton client:idle />
+  <ThemeToggleButton client:visible />
 </div>

--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -181,10 +181,12 @@ export async function __renderPage({request, children, props, css}) {
 
   const isLayout = (__astroContext in props);
   if(!isLayout) {
+    let astroRootUIDCounter = 0;
     Object.defineProperty(props, __astroContext, {
       value: {
         pageCSS: css,
-        request
+        request,
+        createAstroRootUID(seed) { return seed + astroRootUIDCounter++; },
       },
       writable: false,
       enumerable: false

--- a/packages/astro/src/internal/__astro_component.ts
+++ b/packages/astro/src/internal/__astro_component.ts
@@ -187,10 +187,10 @@ export function __astro_component(Component: any, metadata: AstroComponentMetada
     }
 
     // If we ARE hydrating this component, let's generate the hydration script
-    const stringifiedProps = JSON.stringify(props);
-    const astroId = hash.unique(html + stringifiedProps);
-    const script = await generateHydrateScript({ instance, astroId, props }, metadata as Required<AstroComponentMetadata>);
-    const astroRoot = `<astro-root uid="${astroId}">${html}</astro-root>`;
+    const uniqueId = props[Symbol.for('astro.context')].createAstroRootUID(html);
+    const uniqueIdHashed = hash.unique(uniqueId);
+    const script = await generateHydrateScript({ instance, astroId: uniqueIdHashed, props }, metadata as Required<AstroComponentMetadata>);
+    const astroRoot = `<astro-root uid="${uniqueIdHashed}">${html}</astro-root>`;
     return [astroRoot, script].join('\n');
   };
 }

--- a/packages/astro/test/fixtures/vue-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/vue-component/src/pages/index.astro
@@ -21,7 +21,9 @@ import Counter from '../components/Counter.vue'
       <Counter start="0">SSR Rendered, No Client</Counter>
       <Counter start="1" client:load>SSR Rendered, client:load</Counter>
       <Counter start="10" client:idle>SSR Rendered, client:idle</Counter>
+      <!-- Test that two client:visibles have unique uids -->
       <Counter start="100" client:visible>SSR Rendered, client:visible</Counter>
+      <Counter start="1000" client:visible>SSR Rendered, client:visible</Counter>
     </main>
   </body>
 </html>

--- a/packages/astro/test/fixtures/vue-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/vue-component/src/pages/index.astro
@@ -18,7 +18,10 @@ import Counter from '../components/Counter.vue'
   </head>
   <body>
     <main>
-      <Counter start="5" client:visible>Hello world!</Counter>
+      <Counter start="0">SSR Rendered, No Client</Counter>
+      <Counter start="1" client:load>SSR Rendered, client:load</Counter>
+      <Counter start="10" client:idle>SSR Rendered, client:idle</Counter>
+      <Counter start="100" client:visible>SSR Rendered, client:visible</Counter>
     </main>
   </body>
 </html>

--- a/packages/astro/test/vue-component.test.js
+++ b/packages/astro/test/vue-component.test.js
@@ -13,9 +13,10 @@ Vue('Can load Vue', async ({ runtime }) => {
   assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
-  assert.equal($('h1').text(), 'Hello world!', 'Can use slots');
-  assert.equal($('button').length, 2, 'Can render components');
-  assert.equal($('pre').text(), '5', 'Can render nested components');
+  const allPreValues = $('pre').toArray().map((el) => $(el).text());
+  assert.equal(allPreValues, ['0', '1', '10', '100'], 'renders all 4 components correctly');
+  assert.equal($('astro-root').length, 3, 'renders 3 astro-roots');
+  assert.equal($('astro-root[uid]').length, 3, 'all astro-roots have uid attributes');
 });
 
 Vue.run();

--- a/packages/astro/test/vue-component.test.js
+++ b/packages/astro/test/vue-component.test.js
@@ -14,9 +14,11 @@ Vue('Can load Vue', async ({ runtime }) => {
 
   const $ = doc(result.contents);
   const allPreValues = $('pre').toArray().map((el) => $(el).text());
-  assert.equal(allPreValues, ['0', '1', '10', '100'], 'renders all 4 components correctly');
-  assert.equal($('astro-root').length, 3, 'renders 3 astro-roots');
-  assert.equal($('astro-root[uid]').length, 3, 'all astro-roots have uid attributes');
+  assert.equal(allPreValues, ['0', '1', '10', '100', '1000'], 'renders all components correctly');
+  assert.equal($('astro-root').length, 4, 'renders 3 astro-roots');
+  assert.equal($('astro-root[uid]').length, 4, 'all astro-roots have uid attributes');
+  const uniqueRootUIDs = $('astro-root').map((i, el) => $(el).attr('uid'));
+  assert.equal(new Set(uniqueRootUIDs).size, 4, 'all astro-roots have unique uid attributes');
 });
 
 Vue.run();


### PR DESCRIPTION
## Changes

There was an issue on the docs site where two islands of the same component, hydrated with `client:visible`, caused the `onVisible` hook to observe both components multiple times. This caused some sort of conflict between the two and incorrect results for `entry.isIntersecting`. The result was that the visible theme toggle wasn't hydrating on page load with `client:visible`.

## Testing

- Covered by existing `client:visible` test.
- Can't currently test this specific case in our test suite since it requires browser behavior.

## Docs

- N/A