### PR TITLE
Fix nested client load directive

### DIFF
--- a/.changeset/fair-dogs-tie.md
+++ b/.changeset/fair-dogs-tie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Properly escapes script tags with nested client:load directives when passing Astro components into framework components via props. Browsers interpret script end tags in strings as script end tags, resulting in syntax errors.


### PR DESCRIPTION
Relates to #681.

## Changes

- This escapes `</script>` tags in string literals properly so the browser wouldn't parse them as actual `</script>` tags.
- See https://codepen.io/risker/pen/dyWqxLW?editors=1000 for a very simple issue reproduction.
- It can be worked around by escaping the / in the string, which is what I've done here: https://codepen.io/risker/pen/OJmBLPo?editors=1000

A simple example what this allows. Previously, there could not be a `client:load` directive in `children` because browsers broke the injected script.
```astro
<Browser
    client:load
    items={[
        {
            children: await (
                <>
                    <ReactCounter client:load />
                </>
            ),
        },
    ]}
/>
```

## Testing

Manually tested in my work-in-progress repository by changing stuff in `node_modules`. We could possibly add some unit tests for the `serialize` function, if need be.

## Docs

Bug fix only.
