### PR TITLE
Fix typo by removing `css||`

### DIFF
--- a/docs/src/pages/installation.md
+++ b/docs/src/pages/installation.md
@@ -114,7 +114,7 @@ console.log('See me in the Terminal')
   </body>
 </html>
 
-<style lang='css||scss'>
+<style lang='scss'>
   body{
     h1{
       color:orange;


### PR DESCRIPTION
## Changes

- Remove `css||` in style tag.
- This is confusing. The implication is you can use one or (`||`) the other, but the instructions above just say "copy-and-paste".
- At the moment, if you try following these instructions to the letter, it looks as though styling doesn't work. The differentiation between CSS and SCSS is explained elsewhere in the docs.

## Testing

- No tests, just a docs edit.

## Docs

- Typo fix only