### PR TITLE
Fixes #1033 - Markdown with applied scopedStyles doesn't run Prism syntax highlight

### DIFF
--- a/.changeset/curly-queens-pay.md
+++ b/.changeset/curly-queens-pay.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Allow Markdown with scoped styles to coexist happily with code syntax highlight via Prism'

--- a/.changeset/curly-queens-pay.md
+++ b/.changeset/curly-queens-pay.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
-Allow Markdown with scoped styles to coexist happily with code syntax highlight via Prism'
+- Allow Markdown with scoped styles to coexist happily with code syntax highlighting via Prism

--- a/packages/astro/components/Prism.astro
+++ b/packages/astro/components/Prism.astro
@@ -3,7 +3,8 @@ import Prism from 'prismjs';
 import { addAstro } from '@astrojs/prism';
 import loadLanguages from 'prismjs/components/index.js';
 
-const { lang, code } = Astro.props;
+const { class: className, lang, code } = Astro.props;
+let classLanguage = `language-${lang}`
 
 const languageMap = new Map([
   ['ts', 'typescript']
@@ -39,7 +40,6 @@ if (grammar) {
   html = Prism.highlight(code, grammar, lang);
 }
 
-let className = lang ? `language-${lang}` : '';
 ---
 
-<pre class={className}><code class={className}>{html}</code></pre>
+<pre class={className}><code class={classLanguage} lang={classLanguage}>{html}</code></pre>

--- a/packages/astro/components/Prism.astro
+++ b/packages/astro/components/Prism.astro
@@ -42,4 +42,4 @@ if (grammar) {
 
 ---
 
-<pre class={className}><code class={classLanguage} lang={classLanguage}>{html}</code></pre>
+<pre class={className}><code class={classLanguage}>{html}</code></pre>

--- a/packages/astro/src/compiler/transform/prism.ts
+++ b/packages/astro/src/compiler/transform/prism.ts
@@ -4,6 +4,7 @@ import { getAttrValue } from '../../ast.js';
 
 export const PRISM_IMPORT = `import Prism from 'astro/components/Prism.astro';`;
 const prismImportExp = /import Prism from ['"]astro\/components\/Prism.astro['"]/;
+
 /** escaping code samples that contain template string replacement parts, ${foo} or example. */
 function escape(code: string) {
   return code
@@ -22,6 +23,7 @@ function unescapeCode(code: TemplateNode) {
     return child;
   });
 }
+
 /** default export - Transform prism   */
 export default function (module: Script): Transformer {
   let usesPrism = false;
@@ -43,15 +45,17 @@ export default function (module: Script): Transformer {
             const className = getAttrValue(codeEl.attributes, 'class') || '';
             const classes = className.split(' ');
 
-            let lang;
+            let lang: string | undefined;
             for (let cn of classes) {
               const matches = /language-(.+)/.exec(cn);
               if (matches) {
                 lang = matches[1];
+                break;
               }
             }
 
             if (!lang) return;
+            let classesWithoutLang = classes.filter((cn) => cn !== `language-${lang}`);
 
             let codeData = codeEl.children && codeEl.children[0];
             if (!codeData) return;
@@ -71,6 +75,17 @@ export default function (module: Script): Transformer {
                       type: 'Text',
                       raw: lang,
                       data: lang,
+                    },
+                  ],
+                },
+                {
+                  type: 'Attribute',
+                  name: 'class',
+                  value: [
+                    {
+                      type: 'Text',
+                      raw: classesWithoutLang.join(' '),
+                      data: classesWithoutLang.join(' '),
                     },
                   ],
                 },

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -41,7 +41,7 @@ Markdown('Scoped styles should not break syntax highlight', async ({ runtime }) 
 
   const $ = doc(result.contents);
   assert.ok($('pre').is('[class]'), 'Pre tag has scopedStlye class passed down');
-  assert.ok($('code').attr('lang') === 'language-js', 'Code tag has correct language');
+  assert.ok($('code').hasClass('language-js'), 'Code tag has correct language');
   assert.ok($('code span').length > 0, 'There are child spans in code blocks');
 });
 

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -40,7 +40,7 @@ Markdown('Scoped styles should not break syntax highlight', async ({ runtime }) 
   assert.ok(!result.error, `build error: ${result.error}`);
 
   const $ = doc(result.contents);
-  assert.ok($('pre').is('[class]'), 'Pre tag has scopedStlye class passed down');
+  assert.ok($('pre').is('[class]'), 'Pre tag has scopedStyle class passed down');
   assert.ok($('code').hasClass('language-js'), 'Code tag has correct language');
   assert.ok($('code span').length > 0, 'There are child spans in code blocks');
 });

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -35,6 +35,16 @@ Markdown('Runs code blocks through syntax highlighter', async ({ runtime }) => {
   assert.ok($el.length > 0, 'There are child spans in code blocks');
 });
 
+Markdown('Scoped styles should not break syntax highlight', async ({ runtime }) => {
+  const result = await runtime.load('/scopedStyles-code');
+  assert.ok(!result.error, `build error: ${result.error}`);
+
+  const $ = doc(result.contents);
+  assert.ok($('pre').is('[class]'), 'Pre tag has scopedStlye class passed down');
+  assert.ok($('code').attr('lang') === 'language-js', 'Code tag has correct language');
+  assert.ok($('code span').length > 0, 'There are child spans in code blocks');
+});
+
 Markdown('Bundles client-side JS for prod', async (context) => {
   await context.build();
 

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/scopedStyles-code.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/scopedStyles-code.astro
@@ -1,0 +1,14 @@
+---
+import { Markdown } from 'astro/components';
+import Layout from '../layouts/content.astro';
+
+---
+<Markdown>
+<Layout>
+  ## Interesting Topic
+
+  ```js
+  const thing = () => {};
+  ```
+</Layout>
+</Markdown>

--- a/packages/markdown-support/src/index.ts
+++ b/packages/markdown-support/src/index.ts
@@ -4,7 +4,7 @@ import createCollectHeaders from './rehype-collect-headers.js';
 import scopedStyles from './remark-scoped-styles.js';
 import remarkExpressions from './remark-expressions.js';
 import rehypeExpressions from './rehype-expressions.js';
-import { rehypeCodeBlock } from './codeblock.js';
+import { remarkCodeBlock, rehypeCodeBlock } from './codeblock.js';
 import { loadPlugins } from './load-plugins.js';
 import raw from 'rehype-raw';
 
@@ -56,6 +56,7 @@ export async function renderMarkdown(content: string, opts?: MarkdownRenderingOp
     parser.use(scopedStyles(scopedClassName));
   }
 
+  parser.use(remarkCodeBlock());
   parser.use(markdownToHtml, { allowDangerousHtml: true, passThrough: ['raw', 'mdxTextExpression'] });
   parser.use(rehypeExpressions);
 


### PR DESCRIPTION
Enables the syntax highlight when it's used with scoped styles (eg: code within a div wrapper)

## Changes

- Enabled remark transform of `remarkCodeBlocks`

  The code was already there, but it was not used 🤷🏻. 
  Enabling it will preserve the `lang` & `class` property for the `code` tag.

  This will already enabled syntax highlight in prism, but the scoped className is not passed down correctly.
  Because of that, i've made the following change:

- Prism transform should pass down the received `class`
  Add the incoming scoped className to prism transformer.

- Finally, fix the Prism component to render correctly the `pre/code` tags 
   - According to PRISM docs, the lang could be used only in the `code` tag

```jsx
  <pre class={classNames}><code lang="language-xx">...</code></pre>
```

## Testing

Added a UT for this specific case.
All existing unit tests passes correctly.

## Input

```astro
---
import { Markdown } from 'astro/components';
import Layout from '../layouts/content.astro';

---
<Markdown>
<Layout>
  ## Interesting Topic

  ```js
  const thing = () => {};
  `` `
</Layout>
</Markdown>
```

## Output

The output is the following HTML:

```html
<!doctype html><html><head></head><body><div class="container"><h2 id="interesting-topic" class="astro-hSYZt6Y0">Interesting Topic</h2><pre class="astro-hSYZt6Y0"><code class="language-js" lang="language-js"><span class="token keyword">const</span> <span class="token function-variable function">thing</span> <span class="token operator">=</span> <span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token operator">=></span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">;</span>
</code></pre></div></body></html>
```