### PR TITLE
Styled the dark version of the search bar.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: '🚀 A new release just went out!\nCheck it out: https://github.com/snowpackjs/astro/releases'
+          args: '**A new release just went out!** [Read the release notes.](<https://github.com/snowpackjs/astro/releases/>)'

--- a/docs/public/theme.css
+++ b/docs/public/theme.css
@@ -117,6 +117,7 @@ body {
   --docsearch-hit-shadow: none;
   --docsearch-hit-color: var(--theme-text);
   --docsearch-footer-shadow: inset 0 2px 10px #000;
+  --docsearch-modal-shadow: inset 0 0 8px #000;
 }
 
 ::selection {

--- a/docs/public/theme.css
+++ b/docs/public/theme.css
@@ -94,6 +94,7 @@ body {
   --theme-divider: hsla(var(--color-gray-10), 1);
   --theme-text: hsla(var(--color-gray-90), 1);
   --theme-text-light: hsla(var(--color-gray-80), 1);
+  
   /* @@@: not used anywhere */
   --theme-text-lighter: hsla(var(--color-gray-40), 1);
   --theme-bg: hsla(215, 28%, 17%, 1);
@@ -106,6 +107,15 @@ body {
   --theme-navbar-bg: hsla(215, 28%, 17%, 1);
   --theme-selection-color: hsla(var(--color-base-white), 100%, 1);
   --theme-selection-bg: hsla(var(--color-purple), var(--theme-accent-opacity));
+
+  /* DocSearch [Algolia] */
+  --docsearch-modal-background: var(--theme-bg);
+  --docsearch-searchbox-focus-background: var(--theme-divider);
+  --docsearch-footer-background: var(--theme-divider);
+  --docsearch-text-color: var(--theme-text);
+  --docsearch-hit-background: var(--theme-divider);
+  --docsearch-hit-shadow: none;
+  --docsearch-hit-color: var(--theme-text);
 }
 
 ::selection {

--- a/docs/public/theme.css
+++ b/docs/public/theme.css
@@ -116,6 +116,7 @@ body {
   --docsearch-hit-background: var(--theme-divider);
   --docsearch-hit-shadow: none;
   --docsearch-hit-color: var(--theme-text);
+  --docsearch-footer-shadow: inset 0 2px 10px #000;
 }
 
 ::selection {

--- a/docs/src/components/Header/Search.css
+++ b/docs/src/components/Header/Search.css
@@ -70,15 +70,7 @@
 	DocSearch (Algolia)
 \* ------------------------------------------------------------ */
 
-.DocSearch-Modal .DocSearch-Footer:before {
-	content: '';
-	width: 100%;
-	height: 2px;
-	background: var(--theme-accent);
-	position: absolute;
-	top: -0.1rem;
-	left: 0;
-	box-shadow: -10px 0 10px var(--theme-accent);
+.DocSearch-Modal .DocSearch-Footer {
 }
 
 .DocSearch-Modal .DocSearch-Hit a {

--- a/docs/src/components/Header/Search.css
+++ b/docs/src/components/Header/Search.css
@@ -1,67 +1,87 @@
 /** Style Algolia */
 :root {
-  --docsearch-primary-color: var(--theme-accent);
-  --docsearch-logo-color: var(--theme-text);
+	--docsearch-primary-color: var(--theme-accent);
+	--docsearch-logo-color: var(--theme-text);
 }
 .search-input {
-  flex-grow: 1;
-  box-sizing: border-box;
-  width: 100%;
-  margin: 0;
-  padding: 0.33em 0.5em;
-  overflow: visible;
-  font-weight: 500;
-  font-size: 1rem;
-  font-family: inherit;
-  line-height: inherit;
-  background-color: var(--theme-divider);
-  border-color: var(--theme-divider);
-  color: var(--theme-text-light);
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 0.25rem;
-  outline: 0;
-  cursor: pointer;
-  transition-timing-function: ease-out;
-  transition-duration: 0.2s;
-  transition-property: border-color, color;
-  -webkit-font-smoothing: antialiased;
+	flex-grow: 1;
+	box-sizing: border-box;
+	width: 100%;
+	margin: 0;
+	padding: 0.33em 0.5em;
+	overflow: visible;
+	font-weight: 500;
+	font-size: 1rem;
+	font-family: inherit;
+	line-height: inherit;
+	background-color: var(--theme-divider);
+	border-color: var(--theme-divider);
+	color: var(--theme-text-light);
+	border-style: solid;
+	border-width: 1px;
+	border-radius: 0.25rem;
+	outline: 0;
+	cursor: pointer;
+	transition-timing-function: ease-out;
+	transition-duration: 0.2s;
+	transition-property: border-color, color;
+	-webkit-font-smoothing: antialiased;
 }
 .search-input:hover,
 .search-input:focus {
-  color: var(--theme-text);
-  border-color: var(--theme-text-light);
+	color: var(--theme-text);
+	border-color: var(--theme-text-light);
 }
 .search-input:hover::placeholder,
 .search-input:focus::placeholder {
-  color: var(--theme-text-light);
+	color: var(--theme-text-light);
 }
 .search-input::placeholder {
-  color: var(--theme-text-light);
+	color: var(--theme-text-light);
 }
 .search-hint {
-  position: absolute;
-  top: 7px;
-  right: 19px;
-  padding: 3px 5px;
-  display: none;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  letter-spacing: 0.125em;
-  font-size: 13px;
-  font-family: var(--font-mono);
-  pointer-events: none;
-  border-color: var(--theme-text-lighter);
-  color: var(--theme-text-light);
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 0.25rem;
-  line-height: 14px;
+	position: absolute;
+	top: 7px;
+	right: 19px;
+	padding: 3px 5px;
+	display: none;
+	display: none;
+	align-items: center;
+	justify-content: center;
+	letter-spacing: 0.125em;
+	font-size: 13px;
+	font-family: var(--font-mono);
+	pointer-events: none;
+	border-color: var(--theme-text-lighter);
+	color: var(--theme-text-light);
+	border-style: solid;
+	border-width: 1px;
+	border-radius: 0.25rem;
+	line-height: 14px;
 }
 
 @media (min-width: 50em) {
-  .search-hint {
-    display: flex;
-  }
+	.search-hint {
+		display: flex;
+	}
+}
+
+/* ------------------------------------------------------------ *\
+	DocSearch (Algolia)
+\* ------------------------------------------------------------ */
+
+.DocSearch-Modal .DocSearch-Footer:before {
+	content: '';
+	width: 100%;
+	height: 2px;
+	background: var(--theme-accent);
+	position: absolute;
+	top: -0.1rem;
+	left: 0;
+	box-shadow: -10px 0 10px var(--theme-accent);
+}
+
+.DocSearch-Modal .DocSearch-Hit a {
+	box-shadow: none;
+	border: 1px solid var(--theme-accent);
 }


### PR DESCRIPTION
Addressed Issue #943.

## Changes

- Styled the dark version of the search bar (Algolia).
- Added an orange line above the footer for both themes. There is a white gap there (maybe comes from an overflow somewhere), that's why I used a `:before` - a border wouldn't fix the gap.
- Removed shadows from search results and added a border for both themes.

## Testing

`yarn start`

## Docs

Documentation styles adjusted.