### PR TITLE
Fix contrast issue in lang picker

### DIFF
--- a/docs/src/components/Header/LanguageSelect.css
+++ b/docs/src/components/Header/LanguageSelect.css
@@ -9,7 +9,7 @@
   font-size: 1rem;
   font-family: inherit;
   line-height: inherit;
-  background-color: transparent;
+  background-color: var(--theme-bg);
   border-color: var(--theme-text-lighter);
   color: var(--theme-text-light);
   border-style: solid;
@@ -37,7 +37,7 @@
   position: absolute;
   top: 7px;
   left: 10px;
-  z-index: -1;
+  pointer-events: none;
 }
 
 @media (min-width: 50em) {


### PR DESCRIPTION
## Changes


- Fixes #1043

- I also replaced the `z-index` hack (that used `background-image: transparent` to work) with `pointer-events: none` that accomplishes the same thing that the author wanted (button is still pressed even if the cursor is over the icon)


| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/35617441/128541458-81d68b24-1e46-4a5f-a0dc-e22244f0b784.png) | ![image](https://user-images.githubusercontent.com/35617441/128553396-81454924-f3d1-438a-84bc-1b3fedab292f.png) |


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Built and tested locally in firefox and chrome. 
- No differences noticed in light mode.
- Dark mode is readable in both browsers.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
The styling of the docs was updated
