### PR TITLE
Fix GoToDefinition for component imports (and component usage)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,8 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceRoot}/tools/astro-vscode"],
-      "outFiles": ["${workspaceRoot}/tools/astro-vscode/dist/**/*.js"]
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}/tools/vscode"],
+      "outFiles": ["${workspaceRoot}/tools/vscode/dist/**/*.js"]
     },
     {
       "type": "node",
@@ -16,7 +16,7 @@
       "name": "Attach to Server",
       "port": 6040,
       "restart": true,
-      "outFiles": ["${workspaceRoot}/tools/astro-languageserver/dist/**/*.js"],
+      "outFiles": ["${workspaceRoot}/tools/languageserver/dist/**/*.js"],
       "skipFiles": ["<node_internals>/**"]
     }
   ],

--- a/tools/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/tools/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -228,10 +228,6 @@ export class TypeScriptDocumentSnapshot implements DocumentSnapshot {
 
   getOriginalPosition(pos: Position): Position {
     return pos;
-    /*return {
-      line: 0,
-      character: 0
-    };*/
   }
 
   destroyFragment() {

--- a/tools/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/tools/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -5,6 +5,8 @@ import { isInTag, positionAt, offsetAt } from '../../core/documents/utils';
 import { pathToUrl } from '../../utils';
 import { getScriptKindFromFileName, isAstroFilePath, toVirtualAstroFilePath } from './utils';
 
+const FILLER_DEFAULT_EXPORT = `\nexport default function() { return ''; };`;
+
 /**
  * The mapper to get from original snapshot positions to generated and vice versa.
  */
@@ -66,7 +68,15 @@ class AstroDocumentSnapshot implements DocumentSnapshot {
   }
 
   get text() {
-    return this.doc.getText();
+    let raw = this.doc.getText();
+    return this.transformContent(raw);
+  }
+
+  /** @internal */
+  private transformContent(content: string) {
+    return content.replace(/---/g, '///') +
+    // TypeScript needs this to know there's a default export.
+    FILLER_DEFAULT_EXPORT;
   }
 
   get filePath() {
@@ -128,7 +138,9 @@ export class DocumentFragmentSnapshot implements Omit<DocumentSnapshot, 'getFrag
 
   /** @internal */
   private transformContent(content: string) {
-    return content.replace(/---/g, '///');
+    return content.replace(/---/g, '///') +
+    // TypeScript needs this to know there's a default export.
+    FILLER_DEFAULT_EXPORT;
   }
 
   getText(start: number, end: number) {
@@ -212,6 +224,14 @@ export class TypeScriptDocumentSnapshot implements DocumentSnapshot {
 
   async getFragment(): Promise<DocumentFragmentSnapshot> {
     return this as unknown as any;
+  }
+
+  getOriginalPosition(pos: Position): Position {
+    return pos;
+    /*return {
+      line: 0,
+      character: 0
+    };*/
   }
 
   destroyFragment() {

--- a/tools/language-server/src/plugins/typescript/utils.ts
+++ b/tools/language-server/src/plugins/typescript/utils.ts
@@ -190,7 +190,7 @@ export function ensureRealAstroFilePath(filePath: string) {
 }
 
 export function ensureRealFilePath(filePath: string) {
-  return isVirtualFilePath(filePath) ? filePath.slice(0, 3) : filePath;
+  return isVirtualFilePath(filePath) ? filePath.slice(0, filePath.length - 3) : filePath;
 }
 
 export function findTsConfigPath(fileName: string, rootUris: string[]) {


### PR DESCRIPTION
Closes #1023 

https://www.loom.com/share/d1defd0411554997a40eb38f22030e7b

## Changes

Makes it so that typescript knows about Astro's exports. Also falls back to trying to resolve imports ourselves (to work with other framework imports).

## Testing

N/A

## Docs

N/A, bug fix