### PR TITLE
Fix example font on Firefox

### DIFF
--- a/examples/framework-lit/public/style/global.css
+++ b/examples/framework-lit/public/style/global.css
@@ -4,7 +4,7 @@
 }
 
 :root {
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
   font-size: 1rem;
   --user-font-scale: 1rem - 16px;
   font-size: clamp(0.875rem, 0.4626rem + 1.0309vw + var(--user-font-scale), 1.125rem);

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -16,52 +16,52 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <style>
-        :global(:root) {
-            font-family: system-ui;
-            padding: 2em 0;
-        }
-        :global(.counter) {
-            display: grid;
-            grid-template-columns: repeat(3, minmax(0, 1fr));
-            place-items: center;
-            font-size: 2em;
-            margin-top: 2em;
-        }
-        :global(.children) {
-            display: grid;
-            place-items: center;
-            margin-bottom: 2em;
-        }
+      :global(:root) {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+        padding: 2em 0;
+      }
+      :global(.counter) {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        place-items: center;
+        font-size: 2em;
+        margin-top: 2em;
+      }
+      :global(.children) {
+        display: grid;
+        place-items: center;
+        margin-bottom: 2em;
+      }
     </style>
   </head>
   <body>
-      <main>
+    <main>
 
-        <react.Counter client:visible>
-            <h1>Hello React!</h1>
-            <p>What's up?</p>
-        </react.Counter>
+      <react.Counter client:visible>
+        <h1>Hello React!</h1>
+        <p>What's up?</p>
+      </react.Counter>
 
-        <PreactCounter client:visible>
-          <h1>Hello Preact!</h1>
-        </PreactCounter>
+      <PreactCounter client:visible>
+        <h1>Hello Preact!</h1>
+      </PreactCounter>
 
-        <SolidCounter client:visible>
-          <h1>Hello Solid!</h1>
-        </SolidCounter>
+      <SolidCounter client:visible>
+        <h1>Hello Solid!</h1>
+      </SolidCounter>
 
-        <VueCounter client:visible>
-            <h1>Hello Vue!</h1>
-        </VueCounter>
+      <VueCounter client:visible>
+          <h1>Hello Vue!</h1>
+      </VueCounter>
 
-        <SvelteCounter client:visible>
-            <h1>Hello Svelte!</h1>
-        </SvelteCounter>
+      <SvelteCounter client:visible>
+          <h1>Hello Svelte!</h1>
+      </SvelteCounter>
 
-        <A />
-        
-        <Renamed />
+      <A />
 
-      </main>
+      <Renamed />
+
+    </main>
   </body>
 </html>

--- a/examples/framework-preact/src/pages/index.astro
+++ b/examples/framework-preact/src/pages/index.astro
@@ -15,7 +15,7 @@ import Counter from '../components/Counter.jsx'
     />
     <style>
       :global(:root) {
-        font-family: system-ui;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
         padding: 2em 0;
       }
       :global(.counter) {

--- a/examples/framework-react/src/pages/index.astro
+++ b/examples/framework-react/src/pages/index.astro
@@ -17,7 +17,7 @@ const someProps = {
     />
     <style>
       :global(:root) {
-        font-family: system-ui;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
         padding: 2em 0;
       }
       :global(.counter) {

--- a/examples/framework-solid/src/pages/index.astro
+++ b/examples/framework-solid/src/pages/index.astro
@@ -11,7 +11,7 @@ import Counter from '../components/Counter.tsx';
     />
     <style>
       :global(:root) {
-        font-family: system-ui;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
         padding: 2em 0;
       }
       :global(.counter) {

--- a/examples/framework-svelte/src/pages/index.astro
+++ b/examples/framework-svelte/src/pages/index.astro
@@ -15,7 +15,7 @@ import Counter from '../components/Counter.svelte'
     />
     <style>
       :global(:root) {
-        font-family: system-ui;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
         padding: 2em 0;
       }
       :global(.counter) {

--- a/examples/framework-vue/src/pages/index.astro
+++ b/examples/framework-vue/src/pages/index.astro
@@ -15,7 +15,7 @@ import Counter from '../components/Counter.vue'
     />
     <style>
       :global(:root) {
-        font-family: system-ui;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
         padding: 2em 0;
       }
       :global(.counter) {

--- a/examples/starter/public/style/global.css
+++ b/examples/starter/public/style/global.css
@@ -4,7 +4,7 @@
 }
 
 :root {
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
   font-size: 1rem;
   --user-font-scale: 1rem - 16px;
   font-size: clamp(0.875rem, 0.4626rem + 1.0309vw + var(--user-font-scale), 1.125rem);

--- a/examples/with-markdown-plugins/public/global.css
+++ b/examples/with-markdown-plugins/public/global.css
@@ -1,5 +1,5 @@
 body {
-  font-family: system-ui;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 }
 
 .content {

--- a/examples/with-nanostores/public/style/global.css
+++ b/examples/with-nanostores/public/style/global.css
@@ -4,7 +4,7 @@
 }
 
 :root {
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
   font-size: 1rem;
   --user-font-scale: 1rem - 16px;
   font-size: clamp(0.875rem, 0.4626rem + 1.0309vw + var(--user-font-scale), 1.125rem);


### PR DESCRIPTION
## Changes

Super-minor change: adds fallbacks for the `system-ui` font family which Firefox doesn’t understand.

**Before** (Firefox)

![Screen Shot 2021-08-06 at 15 57 08](https://user-images.githubusercontent.com/1369770/128575134-222711bc-426d-4f4c-9f5b-9319fa4e0dfe.png)

**After** (Firefox)
![Screen Shot 2021-08-06 at 15 59 28](https://user-images.githubusercontent.com/1369770/128575152-3a12a699-5d75-44b2-b14e-6e6c549de0cd.png)


## Testing

Tested manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No docs or changeset needed

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
