### PR TITLE
Fix code examples that would fail if copy-pasted

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -42,7 +42,7 @@ const data = Astro.fetchContent('../pages/post/*.md'); // returns an array of po
    **/
     astro: {
       headers: [],  // an array of h1...h6 elements in the markdown file
-      source: ''    // raw source of the markdown file
+      source: '',    // raw source of the markdown file
       html: ''      // rendered HTML of the markdown file
     },
     url: '' // the rendered path

--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -42,7 +42,7 @@ const data = Astro.fetchContent('../pages/post/*.md'); // returns an array of po
    **/
     astro: {
       headers: [],  // an array of h1...h6 elements in the markdown file
-      source: ''    // raw source of the markdown file
+      source: '',    // raw source of the markdown file
       html: ''      // rendered HTML of the markdown file
     },
     url: '' // the rendered path

--- a/docs/src/pages/reference/renderer-reference.md
+++ b/docs/src/pages/reference/renderer-reference.md
@@ -59,9 +59,9 @@ export default {
   snowpackPlugin: '@snowpack/plugin-xxx', // optional, the name of a snowpack plugin to inject
   snowpackPluginOptions: { example: true }, // optional, any options to be forwarded to the snowpack plugin
   knownEntrypoint: ['framework'], // optional, entrypoint modules that will be used by compiled source
-  external: ['dep'] // optional, dependencies that should not be built by snowpack
-  polyfills: ['./shadow-dom-polyfill.js'] // optional, module scripts that should be loaded before client hydration.
-  hydrationPolyfills: ['./hydrate-framework.js'] // optional, polyfills that need to run before hydration ever occurs.
+  external: ['dep'], // optional, dependencies that should not be built by snowpack
+  polyfills: ['./shadow-dom-polyfill.js'], // optional, module scripts that should be loaded before client hydration.
+  hydrationPolyfills: ['./hydrate-framework.js'], // optional, polyfills that need to run before hydration ever occurs.
   jsxImportSource: 'preact', // optional, the name of the library from which JSX is imported
   jsxTransformOptions: async () => { // optional, a function to transform JSX files
     const { default: { default: jsx }} = await import('@babel/plugin-transform-react-jsx');

--- a/examples/snowpack/src/pages/tutorials/react.md
+++ b/examples/snowpack/src/pages/tutorials/react.md
@@ -118,7 +118,7 @@ The `mount` configuration changes where Snowpack looks for and builds files. Eve
 ```diff
   mount: {
 -   /* ... */
-+   // directory name: 'build directory'
++   // directory name: 'build directory',
 +   public: '/',
 +   src: '/dist',
   },

--- a/examples/snowpack/src/pages/tutorials/svelte.md
+++ b/examples/snowpack/src/pages/tutorials/svelte.md
@@ -172,7 +172,7 @@ The `mount` configuration changes where Snowpack scan for and builds files. Head
 
   mount: {
 -   /* ... */
-+   // directory name: 'build directory'
++   // directory name: 'build directory',
 +   public: '/',
 +   src: '/dist',
   },


### PR DESCRIPTION
## Changes

This updates 5 code examples in Astro documentation that fail when copy-pasted due to some missing commas.

## Testing

Copy-paste the code examples and then attempt to execute them in their intended context.

## Docs

I think this is a bug fix only.
