### PR TITLE
Add CSS in example project: docs

### DIFF
--- a/examples/docs/src/layouts/Main.astro
+++ b/examples/docs/src/layouts/Main.astro
@@ -23,6 +23,8 @@ const githubEditUrl = `https://github.com/USER/REPO/blob/main/${currentFile}`
     <title>{content.title}</title>
     
     <link rel="stylesheet" href="/index.css" />
+    <link rel="stylesheet" href="/theme.css" />
+    <link rel="stylesheet" href="/code.css" />
     <script src="/theme.js" />
     <link rel="icon" 
           type="image/svg+xml" 


### PR DESCRIPTION
## Changes
Adds references to the CSS in the example project docs

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/35617441/128646850-e9f538f6-a152-48c2-9bdf-bfd3b14c370a.png) | ![image](https://user-images.githubusercontent.com/35617441/128646867-4f908355-77b6-408f-a332-84cf50f88977.png) |

Found this problem when I set up a clean astro project with `npm init astro`. Used documentation template and when running it, the site had no theme or code CSS. Doesn't seem like the project references `theme.css` nor `code.css` anywhere. Guessing this is how it's supposed to be?

## Testing
Tested locally. 

## Docs
Only bug fix, no doc change required.
