### PR TITLE
[i18n][Docs] Change some Spanish translations for Getting Started page

### DIFF
--- a/.changeset/strong-pets-turn.md
+++ b/.changeset/strong-pets-turn.md
@@ -1,0 +1,5 @@
+---
+'docs': patch
+---
+
+change Spanish translations for Getting Started page

--- a/docs/src/pages/es/getting-started.md
+++ b/docs/src/pages/es/getting-started.md
@@ -4,59 +4,59 @@ title: Empezando
 lang: es
 ---
 
-Astro es un creador de sitios estáticos moderno. Aprende de qué de trata Astro en nuestra [página principal](https://astro.build/) o nuestra [publicación](https://astro.build/blog/introducing-astro) de lanzamiento. Esta página es una descripción general de la documentación de Astro y todos los recursos relacionados.
+Astro es un creador de sitios estáticos moderno. Aprende de qué trata Astro en nuestra [página principal](https://astro.build/) o nuestra [publicación de lanzamiento](https://astro.build/blog/introducing-astro). Esta página es una descripción general de la documentación de Astro y todos los recursos relacionados.
 
 ¿Buscas una descripción general rápida de lo que es Astro? Visita nuestra [página](https://astro.build/) principal.
 
-## Intenta Astro
+## Prueba Astro
 
-La forma más fácil de probar Astro es corriendo `npm init astro` en un nuevo directorio en su máquina. Nuestro asistente CLI ayudará a comenzar un nuevo projecto astro.
+La forma más fácil de probar Astro es ejecutando `npm init astro` en un nuevo directorio en tu máquina. Nuestro asistente CLI te ayudará a comenzar un nuevo proyecto Astro.
 
-Para comenzar con Astro en 5 sencillos y rápidos pasos, visita nuestra guía [Inicio rápido](/quick-start).
+Para comenzar con Astro en 5 sencillos y rápidos pasos, visita nuestra guía de [inicio rápido](/quick-start).
 
 Alternativamente, lee nuestra guía de [instalación](/installation) para un recorrido completo de cómo configurar Astro.
 
-### Playground En Línea
+### Playground en línea
 
-Si estás interesado en jugar con Astro en el navegador, puedes usar un playground de código en línea. Trata nuestro modelo "Hola Mundo!" en [CodeSandbox](https://codesandbox.io/s/astro-template-hugb3).
+Si estás interesado en jugar con Astro en el navegador, puedes usar un playground de código en línea. Prueba nuestro template "Hola Mundo!" en [CodeSandbox](https://codesandbox.io/s/astro-template-hugb3).
 
 _Nota: Algunas caracteristicas (ex: Fast Refresh) actualmente están limitadas en CodeSandbox._
 
 ## Aprende Astro
 
-Todo tipo de personas vienen a Astro de diferentes orígenes trayendo consigo diferentes estilos de aprendizaje. Ya sea que prefieran un enfoque más teórico o práctico esperamos que esta sección le resulte útil.
+Todo tipo de personas vienen a Astro de diferentes orígenes trayendo consigo diferentes estilos de aprendizaje. Ya sea que prefieras un enfoque más teórico o práctico, esperamos que esta sección te resulte útil.
 
 - Si prefieres **aprender haciendo**, comienza con nuestra biblioteca de [ejemplos](https://github.com/snowpackjs/astro/tree/main/examples).
 - Si prefieres **aprender conceptos paso a paso**, comienza con nuestros [conceptos básicos y guías](https://docs.astro.build/core-concepts/project-structure).
 
 Como cualquier tecnología desconocida, Astro viene con una ligera curva de aprendizaje. Sin embargo, con práctica y algo de paciencia, sabemos que lo dominarás en poco tiempo.
 
-### Aprende el sintaxis de `.astro`
+### Aprende la sintaxis de `.astro`
 
-Cuando comienzes a aprender Astro, verás muchos archivos con la extensión `.astro`. Esta en la **Sintaxis de Componentes de Astro**: un formato de archivo especial similar a HTML que Astro usa para crear modelos. Fue diseñado para que cualquiera que tenga experiencia con HTML o JSX se sienta familiarizado.
+Cuando comienzes a aprender Astro, verás muchos archivos con la extensión `.astro`. Esta es la **sintaxis de componentes de Astro**: un formato de archivo especial similar a HTML que Astro usa para crear templates. Fue diseñado para que resulte familiar a cualquiera que tenga experiencia con HTML o JSX.
 
 Nuestra guía sobre [componentes Astro](https://docs.astro.build/core-concepts/astro-components) presenta la sintaxis de Astro y es la mejor manera de aprender.
 
-### Referencia de API
+### Referencia de la API
 
-Esta sección de documentación es útil cuando deseas obtener más detalles sobre un API de Astro en particular. Por ejemplo, la [Referencia de Configuración](https://docs.astro.build/reference/configuration-reference) enumera todas las opciones de configuración posibles disponibles para usted. La [Referencia de Componentes Integrados](https://docs.astro.build/reference/builtin-components) enumera todos los componentes disponibles, como `<Markdown/>` y `<Prism/>`.
+Esta sección de documentación es útil cuando deseas obtener más detalles sobre una API de Astro en particular. Por ejemplo, la [referencia de configuración](https://docs.astro.build/reference/configuration-reference) enumera todas las opciones de configuración disponibles. La [referencia de componentes incluidos](https://docs.astro.build/reference/builtin-components) enumera todos los componentes básicos disponibles, como `<Markdown/>` y `<Prism/>`.
 
 ### Documentación versionada
 
 Esta documentación siempre refleja la última versión estable de Astro. Una vez que alcancemos la version v1.0, agregaremos la capacidad de ver documentación versionada.
 
-## Mantenerse Informado
+## Mantenerse informado
 
 La cuenta de Twitter [@astrodotbuild](https://twitter.com/astrodotbuild) es la fuente oficial de las actualizaciones del equipo de Astro.
 
 También publicamos anuncios de lanzamiento en nuestra comunidad de [Discord](https://astro.build/chat) en el canal de #announcements.
 
-No todos los lanzamientos de Astro merecen su propia publicación en el blog, pero pueden encontrar un registro de cambios detallado para cada versión en el archivo [CHANGELOG.md](https://github.com/snowpackjs/astro/blob/main/packages/astro/CHANGELOG.md) en el repositorio de Astro.
+No todos los lanzamientos de Astro merecen su propia publicación en el blog, pero puedes encontrar un registro de cambios detallado para cada versión en el archivo [CHANGELOG.md](https://github.com/snowpackjs/astro/blob/main/packages/astro/CHANGELOG.md) en el repositorio de Astro.
 
-## ¿Algo Falta?
+## ¿Falta algo?
 
-Si falta algo en la documentación o si alguna parte le resulta confusa, por favor [presenta el problema](https://github.com/snowpackjs/astro/issues/new/choose) de la documentación con sugerencias de mejora, o tuitea a la cuenta de Twitter [@astrodotbuild](https://twitter.com/astrodotbuild). Nos encanta saber de ti!
+Si falta algo en la documentación o si alguna parte te resulta confusa, por favor [abre una issue para la documentación](https://github.com/snowpackjs/astro/issues/new/choose) con tus sugerencias de mejora o menciona a la cuenta de Twitter [@astrodotbuild](https://twitter.com/astrodotbuild). ¡Nos encanta saber de ti!
 
-## Crédito
+## Créditos
 
 Esta guía de **Empezando** se basó originalmente en la guía de Empezando de [React](https://reactjs.org/).


### PR DESCRIPTION
## Changes

- Replaces some words that have the same literal translation but are used for different cases.
- Some words are not translated because they are better understood in English for technical docs (template instead of modelo).
- Uses second person of singular (tú) more consistently.
- Minor fixes.

## Testing

No tests were written.

## Docs

Getting Started page for Spanish was updated.
