### PR TITLE
Add `Astro.resolve`

### DIFF
--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -2,6 +2,7 @@ import type { CompileResult, TransformResult } from '../@types/astro';
 import type { CompileOptions } from '../@types/compiler.js';
 
 import path from 'path';
+import url from 'url';
 import { MarkdownRenderingOptions, renderMarkdownWithFrontmatter } from '@astrojs/markdown-support';
 
 import { parse } from '@astrojs/parser';
@@ -109,6 +110,8 @@ export async function compileComponent(source: string, { compileOptions, filenam
   const result = await transformFromSource(source, { compileOptions, filename, projectRoot });
   const { hostname, port } = compileOptions.astroConfig.devOptions;
   const site = compileOptions.astroConfig.buildOptions.site || `http://${hostname}:${port}`;
+  const fileID = path.join('/_astro', path.relative(projectRoot, filename));
+  const fileURL = new URL(url.pathToFileURL(fileID).pathname, site);
 
   // return template
   let moduleJavaScript = `
@@ -123,6 +126,12 @@ ${/* Global Astro Namespace (shadowed & extended by the scoped namespace inside 
 const __TopLevelAstro = {
   site: new URL(${JSON.stringify(site)}),
   fetchContent: (globResult) => fetchContent(globResult, import.meta.url),
+  resolve(...segments) {
+    return segments.reduce(
+      (url, segment) => new URL(segment, url),
+      new URL(${JSON.stringify(fileURL)})
+    ).pathname
+  },
 };
 const Astro = __TopLevelAstro;
 
@@ -158,10 +167,14 @@ async function __render(props, ...children) {
       value: (props[__astroInternal] && props[__astroInternal].isPage) || false,
       enumerable: true
     },
+    resolve: {
+      value: (props[__astroContext] && props[__astroContext].resolve) || {},
+      enumerable: true
+    },
     request: {
       value: (props[__astroContext] && props[__astroContext].request) || {},
       enumerable: true
-    }
+    },
   });
 
   ${result.script}
@@ -184,7 +197,8 @@ export async function __renderPage({request, children, props, css}) {
     Object.defineProperty(props, __astroContext, {
       value: {
         pageCSS: css,
-        request
+        resolve: __TopLevelAstro.resolve,
+        request,
       },
       writable: false,
       enumerable: false


### PR DESCRIPTION
## Changes

This adds an `Astro.resolve(path: string)` function, available to the frontmatter of `.astro` files, and also available to component props as `props[Symbol.for('astro.context')].resolve(path: string)`. This addresses #1071

### Usage

In an Astro file:
```astro
<img src={Astro.resolve('../assets/bowser.webp')} alt="Bowser, King of the Koopa" />
```

In a component:
```js
import { h } from 'astro/dist/internal/h.js'

export default {
  isAstroComponent: true,
  async __render({ src = null, 'src:from': from, ...props }) {
    return h('img', {
      src: from
        ? props[Symbol.for('astro.context')].resolve(from)
      : src
    })
  }
}
```

## Testing

I might need help writing tests, because it’s not something I’ve done before in this project. I would be happy to add tests as time allows, but I would also accept tests, too, if that’s not too selfish to ask. 😅

## Docs

Documentation was not updated. I could not find an `.astro` or `.md` file with documentation on props. It’s also very late at the time of this writing, so I may have lacked the coherency to find the appropriate section to update.