### PR TITLE
fix astro.build header links

### DIFF
--- a/www/src/components/MainHeader.astro
+++ b/www/src/components/MainHeader.astro
@@ -28,11 +28,11 @@
         <span>Astro</span>
       </a>
     </h1>
-    <a class="header-subitem header-subitem-secondary" href="https://docs.astro.build/" target="_blank">
+    <a class="header-subitem" href="https://docs.astro.build/" target="_blank">
       <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="book" class="svg-inline--fa fa-book fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M448 360V24c0-13.3-10.7-24-24-24H96C43 0 0 43 0 96v320c0 53 43 96 96 96h328c13.3 0 24-10.7 24-24v-16c0-7.5-3.5-14.3-8.9-18.7-4.2-15.4-4.2-59.3 0-74.7 5.4-4.3 8.9-11.1 8.9-18.6zM128 134c0-3.3 2.7-6 6-6h212c3.3 0 6 2.7 6 6v20c0 3.3-2.7 6-6 6H134c-3.3 0-6-2.7-6-6v-20zm0 64c0-3.3 2.7-6 6-6h212c3.3 0 6 2.7 6 6v20c0 3.3-2.7 6-6 6H134c-3.3 0-6-2.7-6-6v-20zm253.4 250H96c-17.7 0-32-14.3-32-32 0-17.6 14.4-32 32-32h285.4c-1.9 17.1-1.9 46.9 0 64z"></path></svg>
       Documentation
     </a>
-    <a class="header-subitem" href="https://twitter.com/astrodotbuild" target="_blank">
+    <a class="header-subitem header-subitem-secondary" href="https://twitter.com/astrodotbuild" target="_blank">
       <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"  viewBox="0 0 24 24"><path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/></svg>
       Twitter
     </a>
@@ -68,6 +68,7 @@ article {
   color: var(--theme-text-lighter);
   font-size: initial;
   padding: 0.5rem;
+  margin-top: 0;
 }
 .header-subitem:hover {
   color: var(--theme-accent);

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -57,6 +57,7 @@ let lang = 'en';
 
         <div class="hint">
           <p>Psst... <a href="https://astro.build/chat">get early access to new features</a> by joining our Discord community.</p>
+          <p>You can also reach out to us on <a href="https://twitter.com/astrodotbuild">Twitter</a> or <a href="https://github.com/snowpackjs/astro">Github</a> with any questions, and suggestions for improvement.</p>
         </div>
       </Article>
     </Main>
@@ -67,6 +68,9 @@ let lang = 'en';
         opacity: 0.8;
         margin-top: 2em;
         padding: 2em 0;
+      }
+      .hint > p:first-child {
+        margin-bottom: 2em;
       }
       .action-button {
         border: 1px solid var(--color-green);


### PR DESCRIPTION
## Changes

Switched Twitter link for Documentation link in header and added
inline Twitter, and Github links to bottom of page.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
