### PR TITLE
add docs and www smoke tests to github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,19 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-engines
 
-      - name: Build
+      - name: Build Astro
         run: yarn build:all
 
       - name: Test
         run: yarn test
+
+      - name: "Smoke Test: Build "docs""
+        run: yarn build
+        working-directory: ./docs
+
+      - name: "Smoke Test: Build "www""
+        run: yarn build
+        working-directory: ./www
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

- Currently, Vercel is bottlenecked at a single concurrent build
- We want to remove vercel from unrelated PRs to speed up Vercel feedback for the PRs that need it
- But... having docs & www sites build on all PRs gives us confidence that nothing broke in those PRs
- So... This moves that check into Github CI (which isn't bottlenecked) so that we can remove Vercel builds from unrelated PRs and stop using Vercel as a test suite :)