### PR TITLE
Fix left curly bracket formatting

### DIFF
--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -768,7 +768,7 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
             }
             if (parent.name === 'code') {
               // Special case, escaped { characters from markdown content
-              text = node.raw.replace(/CURLY_BRACE/g, '{');
+              text = node.raw.replace(/LEFT_CURLY_BRACKET_FIX\0/g, '{');
             }
             buffers[curr] += ',' + JSON.stringify(text);
             return;

--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -183,7 +183,7 @@ interface GetComponentWrapperOptions {
 const PlainExtensions = new Set(['.js', '.jsx', '.ts', '.tsx']);
 /** Generate Astro-friendly component import */
 function getComponentWrapper(_name: string, hydration: HydrationAttributes, { url, importSpecifier }: ComponentInfo, opts: GetComponentWrapperOptions) {
-  const { astroConfig, compileOptions, filename } = opts;
+  const { astroConfig, filename, compileOptions } = opts;
 
   let name = _name;
   let method = hydration.method;
@@ -193,7 +193,7 @@ function getComponentWrapper(_name: string, hydration: HydrationAttributes, { ur
     const [legacyName, legacyMethod] = _name.split(':');
     name = legacyName;
     method = legacyMethod as HydrationAttributes['method'];
-    
+
     const shortname = path.posix.relative(compileOptions.astroConfig.projectRoot.pathname, filename);
     warn(compileOptions.logging, shortname, yellow(`Deprecation warning: Partial hydration now uses a directive syntax. Please update to "<${name} client:${method} />"`));
   }
@@ -225,7 +225,7 @@ function getComponentWrapper(_name: string, hydration: HydrationAttributes, { ur
       }
     };
 
-    let metadata = '';
+    let metadata: string = '';
     if (method) {
       const componentUrl = getComponentUrl(astroConfig, url, pathToFileURL(filename));
       const componentExport = getComponentExport();

--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -768,7 +768,7 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
             }
             if (parent.name === 'code') {
               // Special case, escaped { characters from markdown content
-              text = node.raw.replace(/LEFT_CURLY_BRACKET_FIX\0/g, '{');
+              text = node.raw.replace(/ASTRO_ESCAPED_LEFT_CURLY_BRACKET\0/g, '{');
             }
             buffers[curr] += ',' + JSON.stringify(text);
             return;

--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -183,7 +183,7 @@ interface GetComponentWrapperOptions {
 const PlainExtensions = new Set(['.js', '.jsx', '.ts', '.tsx']);
 /** Generate Astro-friendly component import */
 function getComponentWrapper(_name: string, hydration: HydrationAttributes, { url, importSpecifier }: ComponentInfo, opts: GetComponentWrapperOptions) {
-  const { astroConfig, filename, compileOptions } = opts;
+  const { astroConfig, compileOptions, filename } = opts;
 
   let name = _name;
   let method = hydration.method;
@@ -193,7 +193,7 @@ function getComponentWrapper(_name: string, hydration: HydrationAttributes, { ur
     const [legacyName, legacyMethod] = _name.split(':');
     name = legacyName;
     method = legacyMethod as HydrationAttributes['method'];
-
+    
     const shortname = path.posix.relative(compileOptions.astroConfig.projectRoot.pathname, filename);
     warn(compileOptions.logging, shortname, yellow(`Deprecation warning: Partial hydration now uses a directive syntax. Please update to "<${name} client:${method} />"`));
   }
@@ -225,7 +225,7 @@ function getComponentWrapper(_name: string, hydration: HydrationAttributes, { ur
       }
     };
 
-    let metadata: string = '';
+    let metadata = '';
     if (method) {
       const componentUrl = getComponentUrl(astroConfig, url, pathToFileURL(filename));
       const componentExport = getComponentExport();
@@ -768,7 +768,7 @@ async function compileHtml(enterNode: TemplateNode, state: CodegenState, compile
             }
             if (parent.name === 'code') {
               // Special case, escaped { characters from markdown content
-              text = node.raw.replace(/&#x26;#123;/g, '{');
+              text = node.raw.replace(/CURLY_BRACE/g, '{');
             }
             buffers[curr] += ',' + JSON.stringify(text);
             return;

--- a/packages/astro/src/compiler/transform/prism.ts
+++ b/packages/astro/src/compiler/transform/prism.ts
@@ -11,14 +11,14 @@ function escape(code: string) {
     .replace(/[`$]/g, (match) => {
       return '\\' + match;
     })
-    .replace(/CURLY_BRACE/g, '{');
+    .replace(/ASTRO_ESCAPED_LEFT_CURLY_BRACKET\0/g, '{');
 }
 
 /** Unescape { characters transformed by Markdown generation */
 function unescapeCode(code: TemplateNode) {
   code.children = code.children?.map((child) => {
     if (child.type === 'Text') {
-      return { ...child, raw: child.raw.replace(/CURLY_BRACE/g, '{') };
+      return { ...child, raw: child.raw.replace(/ASTRO_ESCAPED_LEFT_CURLY_BRACKET\0/g, '{') };
     }
     return child;
   });

--- a/packages/astro/src/compiler/transform/prism.ts
+++ b/packages/astro/src/compiler/transform/prism.ts
@@ -11,14 +11,14 @@ function escape(code: string) {
     .replace(/[`$]/g, (match) => {
       return '\\' + match;
     })
-    .replace(/&#123;/g, '{');
+    .replace(/CURLY_BRACE/g, '{');
 }
 
 /** Unescape { characters transformed by Markdown generation */
 function unescapeCode(code: TemplateNode) {
   code.children = code.children?.map((child) => {
     if (child.type === 'Text') {
-      return { ...child, raw: child.raw.replace(/&#x26;#123;/g, '{') };
+      return { ...child, raw: child.raw.replace(/CURLY_BRACE/g, '{') };
     }
     return child;
   });

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -90,6 +90,17 @@ Markdown('Renders dynamic content though the content attribute', async ({ runtim
   assert.ok($('#inner').is('[class]'), 'Scoped class passed down');
 });
 
+Markdown('Renders curly braces correctly', async ({ runtime }) => {
+  const result = await runtime.load('/braces');
+  assert.ok(!result.error, `build error: ${result.error}`);
+
+  const $ = doc(result.contents);
+  assert.equal($('code').length, 3, 'Rendered curly braces markdown content');
+  assert.equal($('code:first-child').text(), '({})', 'Rendered curly braces markdown content');
+  assert.equal($('code:nth-child(2)').text(), '{...props}', 'Rendered curly braces markdown content');
+  assert.equal($('code:last-child').text(), '{/* JavaScript */}', 'Rendered curly braces markdown content');
+});
+
 Markdown('Does not close parent early when using content attribute (#494)', async ({ runtime }) => {
   const result = await runtime.load('/close');
   assert.ok(!result.error, `build error: ${result.error}`);

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/braces.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/braces.astro
@@ -1,0 +1,14 @@
+---
+import { Markdown } from 'astro/components';
+const title = 'My Blog Post';
+const description = 'This is a post about some stuff.';
+---
+
+<Markdown>
+  ## Interesting Topic
+
+  `({})`
+  `{...props}` 
+  `{/* JavaScript */}`
+  
+</Markdown>

--- a/packages/markdown-support/src/codeblock.ts
+++ b/packages/markdown-support/src/codeblock.ts
@@ -21,7 +21,7 @@ export function rehypeCodeBlock() {
   const escapeCode = (code: any) => {
     code.children = code.children.map((child: any) => {
       if (child.type === 'text') {
-        return { ...child, value: child.value.replace(/\{/g, 'LEFT_CURLY_BRACKET_FIX\0') };
+        return { ...child, value: child.value.replace(/\{/g, 'ASTRO_ESCAPED_LEFT_CURLY_BRACKET\0') };
       }
       return child;
     });

--- a/packages/markdown-support/src/codeblock.ts
+++ b/packages/markdown-support/src/codeblock.ts
@@ -21,7 +21,7 @@ export function rehypeCodeBlock() {
   const escapeCode = (code: any) => {
     code.children = code.children.map((child: any) => {
       if (child.type === 'text') {
-        return { ...child, value: child.value.replace(/\{/g, 'CURLY_BRACE') };
+        return { ...child, value: child.value.replace(/\{/g, 'LEFT_CURLY_BRACKET_FIX\0') };
       }
       return child;
     });

--- a/packages/markdown-support/src/codeblock.ts
+++ b/packages/markdown-support/src/codeblock.ts
@@ -21,7 +21,7 @@ export function rehypeCodeBlock() {
   const escapeCode = (code: any) => {
     code.children = code.children.map((child: any) => {
       if (child.type === 'text') {
-        return { ...child, value: child.value.replace(/\{/g, '&#123;') };
+        return { ...child, value: child.value.replace(/\{/g, 'CURLY_BRACE') };
       }
       return child;
     });


### PR DESCRIPTION
## Changes

This resolves an issue where left curly brackets are incorrectly formatted by Astro, addressing #727.

This is a patch of #936, preserving the excellent work of @mmarkelov, with 3 (minor) differences:

- The changes are reduced, to minimize the real or perceived impact of the fix.
- The fix is made really explicit to ease future development or refactoring — `LEFT_CURLY_BRACKET_FIX`.
- The fix includes a null character (`\0`), greatly reducing the possibility of any accidental "false positive" fixes.

## Testing

Tests are included, all from @mmarkelov’s original PR.

## Docs

This doesn’t change documentation, but it does improve it.

See: https://docs.astro.build/core-concepts/astro-components#comparing-astro-versus-jsx