### PR TITLE
Remove sentence about dev server docs

### DIFF
--- a/docs/src/pages/reference/cli-reference.md
+++ b/docs/src/pages/reference/cli-reference.md
@@ -9,8 +9,6 @@ title: CLI Reference
 
 Runs the Astro development server. This starts an HTTP server that responds to requests for pages stored in `src/pages` (or which folder is specified in your [configuration](/reference/configuration-reference)).
 
-See the [dev server](/reference/dev) docs for more information on how the dev server works.
-
 **Flags**
 
 #### `--port`


### PR DESCRIPTION
## Changes

Removes sentence about (and link to) dev server docs since those don't exist yet.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

None - I just removed a sentence from the docs.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

This was an update to the docs.
