### PR TITLE
Nuxt.js official page url corrected

### DIFF
--- a/docs/src/pages/comparing-astro-vs-other-tools.md
+++ b/docs/src/pages/comparing-astro-vs-other-tools.md
@@ -142,7 +142,7 @@ One big reason behind this performance difference is Astro's smaller JavaScript 
 
 ## Nuxt vs. Astro
 
-[Nuxt](https://nextjs.org/) is a popular website & application framework for Vue. It is similar to Next.js.
+[Nuxt](https://nuxtjs.org/) is a popular website & application framework for Vue. It is similar to Next.js.
 
 Nuxt uses Vue to render your website. Astro is more flexible: you can use any UI component libraries (React, Preact, Vue, Svelte, and others) or Astro's built-in component syntax that is similar to HTML/JSX.
 


### PR DESCRIPTION
## Changes

- Nuxt.js Official website url corrected from "https://nextjs.org/" to "https://nuxtjs.org/"

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
