### PR TITLE
Use `Sniddl/discord-commits@v1.3` for the congrats bot

### DIFF
--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -14,7 +14,7 @@ jobs:
       uses: Sniddl/discord-commits@v1.3
       with:
         webhook: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
-        message: "**Sweet!** <${{ github.event.commits[0].author.name }}> just merged a PR!\nDiff: {{ github.context.payload.compare }}"
+        message: "**Sweet!** <${{ github.event.commits[0].author.name }}> just merged a PR! [[Diff]({{ github.context.payload.compare }})]"
         embed: '{ "title": "{{ commit.title }}", "description": "{{ commit.description }}", "url": "{{ commit.url }}", "author": { "name": "{{ commit.author.name }} ({{ commit.author.username }})", "icon_url": "https://avatars.io/gravatar/{{ commit.author.email }}"} }'
         last-commit-only: false
    

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -8,14 +8,13 @@ on:
 jobs:
   congrats:
     name: "discord:congratsbot"
-    #if: github.event.commits[0] && !github.event.commits[1]
     runs-on: ubuntu-latest
     steps:
-      - name: Send a Discord notification when a PR is merged
-      
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
-          # DISCORD_AVATAR: ${{ github.event.pull_request.user.avatar_url }}
-        uses: Ilshidur/action-discord@0.3.2
-        with:
-          args: '**Sweet!** <${{ github.event.commits[0].author.name }}> just merged ["${{ github.event.commits[0].message }}"](<https://github.com/snowpackjs/astro/commits/main>)'
+    - name: Send a Discord notification when a PR is merged
+      uses: Sniddl/discord-commits@v1.3
+      with:
+        webhook: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
+        message: "**Sweet!** <${{ github.event.commits[0].author.name }}> just merged a PR!\nDiff: {{ github.context.payload.compare }}"
+        embed: '{ "title": "{{ commit.title }}", "description": "{{ commit.description }}", "url": "{{ commit.url }}", "author": { "name": "{{ commit.author.name }} ({{ commit.author.username }})", "icon_url": "https://avatars.io/gravatar/{{ commit.author.email }}"} }'
+        last-commit-only: false
+   

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -3,7 +3,7 @@ name: "Discord:congratsbot"
 on:
   push:
     branches:
-      - main
+      - 'tools/congrats-bot-js-formatting'
 
 jobs:
   congrats:

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -14,8 +14,10 @@ jobs:
       
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
+          COMMIT_DATA: ${{ toJSON(github.events.commits[0]) }}
           # DISCORD_AVATAR: ${{ github.event.pull_request.user.avatar_url }}
+        run: 'echo $COMMIT_DATA'
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: '**Sweet!** <${{ github.event.commits[0].author.name }}> just merged ["${{ github.event.commits[0].description }}"](<https://github.com/snowpackjs/astro/commits/main>)'
+          args: '**Sweet!** <${{ github.event.commits[0].author.name }}> just merged ["${{ github.event.commits[0].message }}"](<https://github.com/snowpackjs/astro/commits/main>)'
    

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -10,11 +10,12 @@ jobs:
     name: "discord:congratsbot"
     runs-on: ubuntu-latest
     steps:
-    - name: Send a Discord notification when a PR is merged
-      uses: Sniddl/discord-commits@v1.3
-      with:
-        webhook: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
-        message: "**Sweet!** <${{ github.event.commits[0].author.name }}> just merged a PR! [[Diff]({{ github.context.payload.compare }})]"
-        embed: '{ "title": "{{ commit.title }}", "description": "{{ commit.description }}", "url": "{{ commit.url }}", "author": { "name": "{{ commit.author.name }} ({{ commit.author.username }})", "icon_url": "https://avatars.io/gravatar/{{ commit.author.email }}"} }'
-        last-commit-only: false
+      - name: Send a Discord notification when a PR is merged
+      
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
+          # DISCORD_AVATAR: ${{ github.event.pull_request.user.avatar_url }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: '**Sweet!** <${{ github.event.commits[0].author.name }}> just merged ["${{ github.event.commits[0].description }}"](<https://github.com/snowpackjs/astro/commits/main>)'
    

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -10,13 +10,15 @@ jobs:
     name: "discord:congratsbot"
     runs-on: ubuntu-latest
     steps:
+      - name: show what's in the commit object
+        env:
+          COMMIT_DATA: ${{ toJSON(github.event.commits[0]) }}
+        run: 'echo $COMMIT_DATA'
       - name: Send a Discord notification when a PR is merged
       
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
-          COMMIT_DATA: ${{ toJSON(github.events.commits[0]) }}
           # DISCORD_AVATAR: ${{ github.event.pull_request.user.avatar_url }}
-        run: 'echo $COMMIT_DATA'
         uses: Ilshidur/action-discord@0.3.2
         with:
           args: '**Sweet!** <${{ github.event.commits[0].author.name }}> just merged ["${{ github.event.commits[0].message }}"](<https://github.com/snowpackjs/astro/commits/main>)'


### PR DESCRIPTION
## Changes

Updates the congratsbot Discord webhook to use `Sniddl/discord-commits` for maybe some fancier embeds?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
