### PR TITLE
📘 DOC: Remove `font-weight:400;` from anchor links 

### DIFF
--- a/docs/public/index.css
+++ b/docs/public/index.css
@@ -109,7 +109,6 @@ small,
 
 a {
   color: var(--theme-text-accent);
-  font-weight: 400;
   text-underline-offset: 0.08em;
   align-items: center;
   gap: 0.5rem;


### PR DESCRIPTION
Anchor links should be the same weight as the text without a link.

If we wanted to, we *could* set the font-weight as `heavier` maybe? Is that an option? So that it just chooses an increase in font-weight for differentiation from text outside of a link.

This was mainly a problem with headings that have links, the difference in font-weight stuck out like a sore thumb to me.
