### PR TITLE
Revert short line-height for `<ul>`'s

### DIFF
--- a/docs/public/index.css
+++ b/docs/public/index.css
@@ -89,12 +89,9 @@ h5 {
   font-size: 1rem;
 }
 
-p {
-  line-height: 1.65em;
-}
-
+p,
 .content ul {
-  line-height: 1.1em;
+  line-height: 1.65em;
 }
 
 p,


### PR DESCRIPTION
Docs typesetting fix for the attached screenshot

![image](https://user-images.githubusercontent.com/10626596/129496213-655f97f5-6883-4dbf-a56d-621f4678e0a0.png)
