### PR TITLE
Allow multiple public asset directories (requesting feedback)

### DIFF
--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -11,7 +11,7 @@ export default {
   src: './src', // Path to Astro components, pages, and data
   pages: './src/pages', // Path to Astro/Markdown pages
   dist: './dist', // When running `astro build`, path to final static output
-  public: './public', // A folder of static files Astro will copy to the root. Useful for favicons, images, and other files that don't need processing.
+  public: './public', // A folder (or array of folders) of static files Astro will copy to the root. Useful for favicons, images, and other files that don't need processing.
   buildOptions: {
     // site: '',            // Your public domain, e.g.: https://my-site.dev/. Used to generate sitemaps and canonical URLs.
     sitemap: true, // Generate sitemap (set to "false" to disable)

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -27,7 +27,7 @@ export interface AstroConfig {
   dist: string;
   projectRoot: URL;
   pages: URL;
-  public: URL;
+  public: URL[];
   src: URL;
   renderers?: string[];
   /** Options for rendering markdown content */

--- a/packages/astro/src/build.ts
+++ b/packages/astro/src/build.ts
@@ -223,24 +223,26 @@ ${stack}
     /**
      * 4. Copy Public Assets
      */
-    if (fs.existsSync(astroConfig.public)) {
-      info(logging, 'build', yellow(`! copying public folder...`));
-      timer.public = performance.now();
-      const cwd = fileURLToPath(astroConfig.public);
-      const publicFiles = await glob('**/*', { cwd, filesOnly: true });
-      await Promise.all(
-        publicFiles.map(async (filepath) => {
-          const srcPath = new URL(filepath, astroConfig.public);
-          const distPath = new URL(filepath, dist);
-          await fs.promises.mkdir(path.dirname(fileURLToPath(distPath)), { recursive: true });
-          await fs.promises.copyFile(srcPath, distPath);
-        })
-      );
-      debug(logging, 'build', `copied public folder [${stopTimer(timer.public)}]`);
-      info(logging, 'build', green('✔'), 'public folder copied.');
-    } else {
-      if (path.basename(astroConfig.public.toString()) !== 'public') {
-        info(logging, 'tip', yellow(`! no public folder ${astroConfig.public} found...`));
+    for (const pub in astroConfig.public) {
+      if (fs.existsSync(pub)) {
+        info(logging, 'build', yellow(`! copying public folder...`));
+        timer.public = performance.now();
+        const cwd = fileURLToPath(pub);
+        const publicFiles = await glob('**/*', { cwd, filesOnly: true });
+        await Promise.all(
+          publicFiles.map(async (filepath) => {
+            const srcPath = new URL(filepath, pub);
+            const distPath = new URL(filepath, dist);
+            await fs.promises.mkdir(path.dirname(fileURLToPath(distPath)), { recursive: true });
+            await fs.promises.copyFile(srcPath, distPath);
+          })
+        );
+        debug(logging, 'build', `copied public folder [${stopTimer(timer.public)}]`);
+        info(logging, 'build', green('✔'), 'public folder copied.');
+      } else {
+        if (path.basename(pub.toString()) !== 'public') {
+          info(logging, 'tip', yellow(`! no public folder ${pub} found...`));
+        }
       }
     }
 

--- a/packages/astro/src/build/util.ts
+++ b/packages/astro/src/build/util.ts
@@ -35,9 +35,9 @@ export function getDistPath(specifier: string, { astroConfig, srcPath }: { astro
   }
 
   // if this is in public/, use that as final URL
-  const isPublicAsset = fileLoc.pathname.includes(astroConfig.public.pathname);
-  if (isPublicAsset) {
-    return fileLoc.pathname.replace(astroConfig.public.pathname, '/');
+  const pub = astroConfig.public.find((pub) => fileLoc.pathname.includes(pub.pathname));
+  if (pub) {
+    return fileLoc.pathname.replace(pub.pathname, '/');
   }
 
   // otherwise, return /_astro/* url
@@ -53,7 +53,7 @@ export function getSrcPath(distURL: string, { astroConfig }: { astroConfig: Astr
   }
 
   const possibleURLs = [
-    new URL('.' + distURL, astroConfig.public), // public asset
+    ...astroConfig.public.map((pub) => new URL('.' + distURL, pub)), // public asset
     new URL('.' + distURL.replace(/([^\/])+\/d+\/index.html/, '$$1.astro'), astroConfig.pages), // collection page
     new URL('.' + distURL.replace(/\/index\.html$/, '.astro'), astroConfig.pages), // page
     // TODO: Astro pages (this isn’t currently used for that lookup)

--- a/packages/astro/src/config.ts
+++ b/packages/astro/src/config.ts
@@ -13,7 +13,7 @@ function validateConfig(config: any): void {
   if (typeof config !== 'object') throw new Error(`[config] Expected object, received ${typeof config}`);
 
   // strings
-  for (const key of ['projectRoot', 'pages', 'dist', 'public']) {
+  for (const key of ['projectRoot', 'pages', 'dist']) {
     if (config[key] !== undefined && config[key] !== null && typeof config[key] !== 'string') {
       throw new Error(`[config] ${key}: ${JSON.stringify(config[key])}\n  Expected string, received ${type(config[key])}.`);
     }
@@ -24,6 +24,11 @@ function validateConfig(config: any): void {
     if (config[key] !== undefined && config[key] !== null && typeof config[key] !== 'boolean') {
       throw new Error(`[config] ${key}: ${JSON.stringify(config[key])}\n  Expected boolean, received ${type(config[key])}.`);
     }
+  }
+
+  // public directories
+  if (config['public'] != undefined && config['public'] != null && typeof config['public'] !== 'string' && !Array.isArray(config['public'])) {
+    throw new Error(`[config] public: ${JSON.stringify(config['public'])}\n Expected string or array, recieved ${type(config['public'])}'`);
   }
 
   // buildOptions
@@ -78,7 +83,7 @@ function normalizeConfig(userConfig: any, root: string): AstroConfig {
   config.projectRoot = new URL(config.projectRoot + '/', fileProtocolRoot);
   config.src = new URL(config.src + '/', fileProtocolRoot);
   config.pages = new URL(config.pages + '/', fileProtocolRoot);
-  config.public = new URL(config.public + '/', fileProtocolRoot);
+  config.public = !Array.isArray(config.public) ? [new URL(config.public + '/', fileProtocolRoot)] : config.public.map((dir: String) => new URL(dir + '/', fileProtocolRoot));
 
   return config as AstroConfig;
 }

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -284,7 +284,13 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
   };
 
   const mountOptions = {
-    ...(existsSync(astroConfig.public) ? { [fileURLToPath(astroConfig.public)]: '/' } : {}),
+    ...astroConfig.public.reduce(
+      (mounts, pub) => ({
+        ...mounts,
+        ...(existsSync(pub) ? { [fileURLToPath(pub)]: '/' } : {}),
+      }),
+      {}
+    ),
     [fileURLToPath(frontendPath)]: '/_astro_frontend',
     [fileURLToPath(src)]: '/_astro/src', // must be last (greediest)
   };


### PR DESCRIPTION
## Changes

Allow configuring multiple public asset directories in `astro.config.mjs`.

The use case:

There can be static assets which we want to commit together with the projects. But a separate build step could generate assets which are not to be committed to version control. If there is a single public directory a compromise needs to be made. Either

- new assets are generated  in a folder which is actually under version control and try to ignore generated files, or
- the checked in files are copied into a separate build directory while manually listening for file changes to trigger a sync. 

Both have their drawbacks. With the ability to configure more directories, one directory can contain assets which are commited to version control, while a second directory could point to content generated by an external process.

## Testing

I was not able to do any real testing, mainly because I don't know how to. I have installed the build project in a separate directory, but there I have used the collections api (files with `$sometihng.astro`), and it seems there was a switch to dynamic routing.

I could run `yarn build:all` and `yarn test` which worked fine, but I don't know how to go from there. I'm not sure how to test this. I did find `./packages/astro/test/astro-assets.test.js`, but I'm not sure how to extend that.

## Docs

The comment in `./docs/src/pages/reference/configuration-reference.md` has been updated to indicate an array is also allowed




ps: This pull request is probably incomplete, and needs work. I'm hoping that someone can give me some help and pointers to work through the rest of the process, or perhaps tell me this in entierly pointless, ...