### PR TITLE
add dev script, switch documentation from advising start to dev script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Every pull request needs to be reviewed by another contributor to the documentat
 - Clone/Fork the project
 - This project uses yarn to manage dependencies. [Make sure that you have yarn v1 installed.](https://classic.yarnpkg.com/)
 - Run `yarn install` to install latest dependencies.
-- Run `yarn start` to start the dev server.
+- Run `yarn dev` to start the dev server.
 - Run `yarn build` to build the final site for production.
 
 The environment variable `SNOWPACK_PUBLIC_GITHUB_TOKEN` must be set to a personal access token with `public_repo` permissions to prevent rate-limiting.

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.4",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
     "lint": "run-p --aggregate-output lint:linkcheck",
-    "lint:a11y": "start-test 'yarn start --silent' 3000 'yarn lint:a11y:local'",
+    "lint:a11y": "start-test 'yarn dev --silent' 3000 'yarn lint:a11y:local'",
     "lint:a11y:local": "pa11y-ci --sitemap 'http://localhost:3000/sitemap.xml' --sitemap-find 'https://docs.astro.build' --sitemap-replace 'http://localhost:3000'",
     "lint:a11y:remote": "pa11y-ci --sitemap 'https://docs.astro.build/sitemap.xml'",
-    "lint:linkcheck": "start-test 'yarn start --silent' 3000  'yarn lint:linkcheck:local'",
+    "lint:linkcheck": "start-test 'yarn dev --silent' 3000  'yarn lint:linkcheck:local'",
     "lint:linkcheck:local": "blc -ro --user-agent 'broken-link-checker/0.7.8' 'http://localhost:3000'",
     "lint:linkcheck:remote": "blc -ro --user-agent 'broken-link-checker/0.7.8' 'https://docs.astro.build/'"
   },

--- a/docs/src/pages/fi/installation.md
+++ b/docs/src/pages/fi/installation.md
@@ -60,7 +60,7 @@ Voit nyt vaihtaa oletuksena toimivan "scripts"-osion `npm init`in luomassa `pack
 ```diff
   "scripts": {
 -    "test": "echo \"Error: no test specified\" && exit 1"
-+    "start": "astro dev",
++    "dev": "astro dev",
 +    "build": "astro build"
   },
 }

--- a/docs/src/pages/fi/quick-start.md
+++ b/docs/src/pages/fi/quick-start.md
@@ -18,7 +18,7 @@ npm init astro
 npm install
 
 # aloita kehittäminen!
-npm start
+npm run dev
 
 # kun olet valmis: luo oma staattinen sivustosi hakemistoon `dist/`
 npm run build
@@ -33,7 +33,7 @@ Astro-sivuston käyttöönotto tuotannossa vaatii `/dist`-hakemiston (joka luoda
 Siirry takaisin komentoriville ja suorita tämä komento projektin hakemistossa:
 
 ```bash
-npm start
+npm run dev
 ```
 
 Tämän jälkeen ohjelma on käynnissä osoitteessa [http://localhost:3000](http://localhost:3000). Avaa tämä URL selaimessa nähdäksesi viestin "Moi maailma!", jonka kopioimme edellisessä vaiheessa.

--- a/docs/src/pages/fr/installation.md
+++ b/docs/src/pages/fr/installation.md
@@ -85,13 +85,13 @@ Vous pouvez aussi remplacer la section "scripts" du fichier `package.json` avec 
 ```diff
   "scripts": {
 -    "test": "echo \"Error: no test specified\" && exit 1"
-+    "start": "astro dev",
++    "dev": "astro dev",
 +    "build": "astro build"
   },
 }
 ```
 
-La commande [`start`](#start-astro) démarre le serveur de développement Astro à l'adresse `http://localhost:3000`. Une fois votre projet terminé, la commande [`build`](#build-astro) produit votre site dans le dossier `dist/`. [En savoir plus sur le déploiement d'un site développé avec Astro.](/guides/deploy)
+La commande [`dev`](#start-astro) démarre le serveur de développement Astro à l'adresse `http://localhost:3000`. Une fois votre projet terminé, la commande [`build`](#build-astro) produit votre site dans le dossier `dist/`. [En savoir plus sur le déploiement d'un site développé avec Astro.](/guides/deploy)
 
 ### Créer une première page
 
@@ -133,7 +133,7 @@ Vous pouvez continuer à ajouter des fichiers dans le dossier `src/pages`, et As
 ## [Démarrer Astro](#démarrer-astro)
 
 ```bash
-npm start
+npm run dev
 ```
 
 Astro va démarrer votre site à l'adresse `http://localhost:3000`. En ouvrant cette URL dans votre navigateur, vous devriez voir s'afficher "Hello, World", ou bien la page créée précédemment.

--- a/docs/src/pages/fr/quick-start.md
+++ b/docs/src/pages/fr/quick-start.md
@@ -18,7 +18,7 @@ npm init astro
 npm install
 
 # Commencez à coder !
-npm start
+npm run dev
 
 # Quand votre site est fin prêt, compilez-en une version statique dans le dossier `dist/`
 npm run build
@@ -31,7 +31,7 @@ Si vous désirez en savoir plus sur les différentes façons d'installer Astro d
 Depuis un terminal ouvert dans votre projet, entrez la commande suivante :
 
 ```bash
-npm start
+npm run dev
 ```
 
 Astro va lancer un serveur local sur [http://localhost:3000](http://localhost:3000). Ouvrez cette adresse dans votre navigateur, et vous devriez voir le "Hello, World" d'Astro.

--- a/docs/src/pages/installation.md
+++ b/docs/src/pages/installation.md
@@ -86,13 +86,13 @@ You can now replace the placeholder "scripts" section of your `package.json` fil
 ```diff
   "scripts": {
 -    "test": "echo \"Error: no test specified\" && exit 1"
-+    "start": "astro dev",
++    "dev": "astro dev",
 +    "build": "astro build"
   },
 }
 ```
 
-The [`start`](#start-astro) command launches the Astro Dev Server on `http://localhost:3000`. Once your project is ready, the [`build`](#build-astro) command outputs your project to the `dist/` directory. [Read more about deploying Astro in the Deploy guide.](/guides/deploy)
+The [`dev`](#start-astro) command launches the Astro Dev Server on `http://localhost:3000`. Once your project is ready, the [`build`](#build-astro) command outputs your project to the `dist/` directory. [Read more about deploying Astro in the Deploy guide.](/guides/deploy)
 
 ### Create your first page
 
@@ -135,7 +135,7 @@ You can create more pages in the `src/pages` directory, and Astro will use the f
 ## [Start Astro](#start-astro)
 
 ```bash
-npm start
+npm run dev
 ```
 
 Astro will now start serving your application on `http://localhost:3000`. By opening this URL in your browser, you should see the Astro's “Hello, World”

--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -17,7 +17,7 @@ npm init astro
 npm install
 
 # start developing!
-npm start
+npm run dev
 
 # when you're ready: build your static site to `dist/`
 npm run build
@@ -30,7 +30,7 @@ If you wish to learn more about the range of methods to install and setup Astro 
 From inside your project directory, enter the following command into your terminal:
 
 ```bash
-npm start
+npm run dev
 ```
 
 Astro will now start serving your application on [http://localhost:3000](http://localhost:3000). Opening this URL in your browser, you should see the Astro's "Hello, World".

--- a/docs/src/pages/zh-CN/installation.md
+++ b/docs/src/pages/zh-CN/installation.md
@@ -91,13 +91,13 @@ npm install astro
 ```diff
   "scripts": {
 -    "test": "echo \"Error: no test specified\" && exit 1"
-+    "start": "astro dev",
++    "dev": "astro dev",
 +    "build": "astro build"
   },
 }
 ```
 
-[`start`](#start-astro) 命令在 `http://localhost:3000` 上启动 Astro 开发服务器。一旦你的项目准备好了。
+[`dev`](#start-dev) 命令在 `http://localhost:3000` 上启动 Astro 开发服务器。一旦你的项目准备好了。
 
 [`build`](#build-astro)命令将你的项目输出到 `dist/` 目录。[在部署指南中阅读更多关于部署 Astro 的内容。](/guides/deploy)
 
@@ -141,7 +141,7 @@ console.log('See me in the Terminal')
 ## [启动 Astro](#start-astro)
 
 ```bash
-npm start
+npm run dev
 ```
 
 Astro 会开启预览服务器，地址为 [http://localhost:3000](http://localhost:3000)，

--- a/docs/src/pages/zh-CN/quick-start.md
+++ b/docs/src/pages/zh-CN/quick-start.md
@@ -18,7 +18,7 @@ npm init astro
 npm install
 
 # 启动项目
-npm start
+npm run dev
 
 # 将项目打包到 dist 文件夹下
 npm run build
@@ -31,7 +31,7 @@ npm run build
 工程目录下终端输入以下命令：
 
 ```bash
-npm start
+npm run dev
 ```
 
 Astro 会开启预览服务器，地址为 [http://localhost:3000](http://localhost:3000)，

--- a/docs/src/pages/zh-TW/installation.md
+++ b/docs/src/pages/zh-TW/installation.md
@@ -87,13 +87,13 @@ npm install astro
 ```diff
   "scripts": {
 -    "test": "echo \"Error: no test specified\" && exit 1"
-+    "start": "astro dev",
++    "dev": "astro dev",
 +    "build": "astro build"
   },
 }
 ```
 
-[`start`](#start-astro) 指令在 `http://localhost:3000` 啟動 Astro 開發伺服器。一但專案已經準備好，[`build`](#build-astro) 指令將專案輸出至 `dist/` 資料夾。[在「部署指南」深入閱讀部署 Astro](/guides/deploy)。
+[`dev`](#start-astro) 指令在 `http://localhost:3000` 啟動 Astro 開發伺服器。一但專案已經準備好，[`build`](#build-astro) 指令將專案輸出至 `dist/` 資料夾。[在「部署指南」深入閱讀部署 Astro](/guides/deploy)。
 
 ### 建立第一個頁面
 
@@ -136,7 +136,7 @@ console.log('See me in the Terminal')
 ## [啟動 Astro](#start-astro)
 
 ```bash
-npm start
+npm run dev
 ```
 
 Astro 會為應用程式打開 `http://localhost:3000` 的伺服器。在瀏覽器開啟網址，就會看到 Astro 的「Hello World」。

--- a/docs/src/pages/zh-TW/quick-start.md
+++ b/docs/src/pages/zh-TW/quick-start.md
@@ -18,7 +18,7 @@ npm init astro
 npm install
 
 # 開始開發！
-npm start
+npm run dev
 
 # 做好之後：把靜態網站 build 進 `dist/`
 npm run build
@@ -31,7 +31,7 @@ npm run build
 專案目錄裡，在終端機輸入以下指令：
 
 ```bash
-npm start
+npm run dev
 ```
 
 現在，Astro 就會開啟應用程式的伺服器，位置是 [http://localhost:3000](http://localhost:3000)。在瀏覽器打開這網址，就會看到 Astro 的 「Hello, World」。

--- a/examples/blog-multiple-authors/README.md
+++ b/examples/blog-multiple-authors/README.md
@@ -43,7 +43,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm start`     | Starts local dev server at `localhost:3000` |
+| `npm run dev`   | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/blog-multiple-authors/package.json
+++ b/examples/blog-multiple-authors/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -43,7 +43,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm start`     | Starts local dev server at `localhost:3000` |
+| `npm run dev`   | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/blog/src/pages/posts/introducing-astro.md
+++ b/examples/blog/src/pages/posts/introducing-astro.md
@@ -38,7 +38,7 @@ npm init astro
 npm install
 
 # start the dev server and open your browser
-npm start
+npm run dev
 ```
 
 > To learn more about Astro and start building your first site, check out [the project README.](https://github.com/snowpackjs/astro#-guides).

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -20,7 +20,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm start`     | Starts local dev server at `localhost:3000` |
+| `npm run dev`   | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/docs/src/pages/index.md
+++ b/examples/docs/src/pages/index.md
@@ -29,7 +29,7 @@ npm init astro
 npm install
 
 # start the dev server and open your browser
-npm start
+npm run dev
 ```
 
 ### 🚀 Build & Deployment
@@ -39,7 +39,7 @@ The default Astro project has the following `scripts` in the `/package.json` fil
 ```json
 {
   "scripts": {
-    "start": "astro dev",
+    "dev": "astro dev",
     "build": "astro build"
   }
 }
@@ -48,7 +48,7 @@ The default Astro project has the following `scripts` in the `/package.json` fil
 For local development, run:
 
 ```
-npm start
+npm run dev
 ```
 
 To build for production, run the following command:

--- a/examples/framework-lit/package.json
+++ b/examples/framework-lit/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/framework-multiple/package.json
+++ b/examples/framework-multiple/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/framework-preact/package.json
+++ b/examples/framework-preact/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/framework-react/package.json
+++ b/examples/framework-react/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/framework-solid/package.json
+++ b/examples/framework-solid/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/framework-svelte/package.json
+++ b/examples/framework-svelte/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/framework-vue/package.json
+++ b/examples/framework-vue/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -26,7 +26,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm start`     | Starts local dev server at `localhost:3000` |
+| `npm run dev`   | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -13,7 +13,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm start`     | Starts local dev server at `localhost:3000` |
+| `npm run dev`   | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/portfolio/package.json
+++ b/examples/portfolio/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/snowpack/README.md
+++ b/examples/snowpack/README.md
@@ -27,7 +27,7 @@ npm install
 3. Run the Astro dev environment.
 
 ```shell
-npm start
+npm run dev
 ```
 
 4. Build the website. (Not yet working.)

--- a/examples/snowpack/package.json
+++ b/examples/snowpack/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
     "test": "jest /__test__/",

--- a/examples/snowpack/src/pages/guides/https-ssl-certificates.md
+++ b/examples/snowpack/src/pages/guides/https-ssl-certificates.md
@@ -12,7 +12,7 @@ This guide has an example repo:
 </div>
 
 ```
-npm start -- --secure
+npm run dev -- --secure
 ```
 
 Snowpack provides an easy way to use a local HTTPS server during development through the use of the `--secure` flag. When enabled, Snowpack will look for a `snowpack.key` and `snowpack.crt` file in the root directory and use that to create an HTTPS server with HTTP2 support enabled.

--- a/examples/snowpack/src/pages/tutorials/getting-started.md
+++ b/examples/snowpack/src/pages/tutorials/getting-started.md
@@ -71,7 +71,7 @@ Add the Snowpack development server to `package.json` under as the `start` scrip
 
 ```diff
   "scripts": {
-+   "start": "snowpack dev",
++   "dev": "snowpack dev",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
 
@@ -80,7 +80,7 @@ Add the Snowpack development server to `package.json` under as the `start` scrip
 Run the following on the command line to start the Snowpack development server
 
 ```
-npm start
+npm run dev
 ```
 
 If all went well, Snowpack automatically opens your site in a new browser!
@@ -205,7 +205,7 @@ Add the `snowpack build` command to package.json so it's easier to run on the co
 
 ```diff
   "scripts": {
-    "start": "snowpack dev",
+    "dev": "snowpack dev",
 +   "build": "snowpack build",
     "test": "echo \"Error: no test specified\" && exit 1"
 

--- a/examples/snowpack/src/pages/tutorials/quick-start.md
+++ b/examples/snowpack/src/pages/tutorials/quick-start.md
@@ -29,9 +29,9 @@ For long-term development, the best way to use Snowpack is with a package.json s
 
 ```js
 // Recommended: package.json scripts
-// npm start (or: "yarn run ...", "pnpm run ...")
+// npm run dev (or: "yarn run ...", "pnpm run ...")
 "scripts": {
-    "start": "snowpack dev",
+    "dev": "snowpack dev",
     "build": "snowpack build"
 }
 ```

--- a/examples/snowpack/src/pages/tutorials/react.md
+++ b/examples/snowpack/src/pages/tutorials/react.md
@@ -36,7 +36,7 @@ You can now head to the new directory and start Snowpack with the following two 
 
 ```bash
 cd react-snowpack
-npm start
+npm run dev
 ```
 
 You should see your new website up and running!

--- a/examples/snowpack/src/pages/tutorials/svelte.md
+++ b/examples/snowpack/src/pages/tutorials/svelte.md
@@ -39,7 +39,7 @@ Head to the new `svelte-snowpack` directory and start Snowpack with the followin
 
 ```bash
 cd svelte-snowpack
-npm start
+npm run dev
 ```
 
 You should see your new website up and running!
@@ -75,7 +75,7 @@ module.exports = {
   ],
 ```
 
-Restart your Snowpack dev server to run it with the new configuration. Exit the process (ctrl + c in most Windows/Linux/macOS) and start it again with `npm start`.
+Restart your Snowpack dev server to run it with the new configuration. Exit the process (ctrl + c in most Windows/Linux/macOS) and start it again with `npm run dev`.
 
 > 💡 Tip: Restart the Snowpack development server when you make configuration changes (changes to the `snowpack.config.js`).
 
@@ -192,7 +192,7 @@ The `mount` configuration changes where Snowpack scan for and builds files. Head
   </body>
 ```
 
-You'll need to restart Snowpack (stop the process in terminal and then run `npm start` again) for configuration file changes. It should look exactly as it did before, but now using your brand new project folder layout
+You'll need to restart Snowpack (stop the process in terminal and then run `npm run dev` again) for configuration file changes. It should look exactly as it did before, but now using your brand new project folder layout
 
 ## Adding an animated Svelte Logo
 

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -32,7 +32,7 @@ All commands are run from the root of the project, from a terminal:
 | Command         | Action                                      |
 |:----------------|:--------------------------------------------|
 | `npm install`   | Installs dependencies                       |
-| `npm start`     | Starts local dev server at `localhost:3000` |
+| `npm run dev`   | Starts local dev server at `localhost:3000` |
 | `npm run build` | Build your production site to `./dist/`     |
 
 ## 👀 Want to learn more?

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/with-markdown-plugins/package.json
+++ b/examples/with-markdown-plugins/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.2",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/with-markdown/package.json
+++ b/examples/with-markdown/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/with-nanostores/package.json
+++ b/examples/with-nanostores/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -185,7 +185,7 @@ export async function main() {
 
   console.log(`  ${i++}: ${bold(cyan('npm install'))} (or pnpm install, yarn, etc)`);
   console.log(`  ${i++}: ${bold(cyan('git init && git add -A && git commit -m "Initial commit"'))} (optional step)`);
-  console.log(`  ${i++}: ${bold(cyan('npm start'))} (or pnpm, yarn, etc)`);
+  console.log(`  ${i++}: ${bold(cyan('npm run dev'))} (or pnpm, yarn, etc)`);
 
   console.log(`\nTo close the dev server, hit ${bold(cyan('Ctrl-C'))}`);
   console.log('\nStuck? Visit us at https://astro.build/chat\n');

--- a/www/package.json
+++ b/www/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
+    "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build"
   },

--- a/www/src/pages/blog/introducing-astro.astro
+++ b/www/src/pages/blog/introducing-astro.astro
@@ -58,7 +58,7 @@ npm init astro
 npm install
 
 # start the dev server and open your browser
-npm start
+npm run dev
 `} />
 
           <Note>


### PR DESCRIPTION
## Changes

This updates `package.json` scripts and documentation to switch the `astro dev` process from `npm start` to `npm run dev`. while still supporting `npm start` for the time being. See #612

## Testing

This change was made programmatically, and it should be tested by others.

## Docs

This is a change to both examples and documentation. Both should be reviewed.