### PR TITLE
Use title, with site title as the fallback

### DIFF
--- a/docs/src/components/HeadSEO.astro
+++ b/docs/src/components/HeadSEO.astro
@@ -3,15 +3,12 @@ import {SITE, OPEN_GRAPH} from '../config.ts';
 export interface Props {
   content: any,
   site: any,
-  formatTitle(content: any, SITE: any): string,
   canonicalURL: URL | string,
 };
 const { 
-        content = {}, 
-        canonicalURL, 
-        formatTitle = (content, SITE) => content.title ? `${content.title} 🚀 ${SITE.title}` : SITE.title,
+        content = {},
+        canonicalURL,
       } = Astro.props;
-const formattedContentTitle = formatTitle(content, SITE);
 const imageSrc = content?.image?.src ?? OPEN_GRAPH.image.src;
 const canonicalImageSrc = new URL(imageSrc, Astro.site);
 const imageAlt = content?.image?.alt ?? OPEN_GRAPH.image.alt;
@@ -20,7 +17,7 @@ const imageAlt = content?.image?.alt ?? OPEN_GRAPH.image.alt;
 <link rel="canonical" href={canonicalURL}/>
 
 <!-- OpenGraph Tags -->
-<meta property="og:title" content={formattedContentTitle}/>
+<meta property="og:title" content={content.title ?? SITE.title}/>
 <meta property="og:type" content="article"/>
 <meta property="og:url" content={canonicalURL}/>
 <meta property="og:locale" content={content.ogLocale ?? OPEN_GRAPH.locale}/>
@@ -32,7 +29,7 @@ const imageAlt = content?.image?.alt ?? OPEN_GRAPH.image.alt;
 <!-- Twitter Tags -->
 <meta name="twitter:card" content="summary_large_image"/>
 <meta name="twitter:site" content={OPEN_GRAPH.twitter}/>
-<meta name="twitter:title" content={formattedContentTitle}/>
+<meta name="twitter:title" content={content.title ?? SITE.title}/>
 <meta name="twitter:description" content={content.description ? content.description : SITE.description}/>
 <meta name="twitter:image" content={canonicalImageSrc}/>
 <meta name="twitter:image:alt" content={imageAlt}/>

--- a/docs/src/layouts/MainLayout.astro
+++ b/docs/src/layouts/MainLayout.astro
@@ -18,7 +18,7 @@ const formatTitle = (content, SITE) => content.title ? `${content.title} 🚀 ${
 <html dir="{content.dir ?? 'ltr'}" lang="{content.lang ?? 'en-us'}" class="initial">
   <head>
     <HeadCommon />
-    <HeadSEO {content} canonicalURL={Astro.request.canonicalURL} formatTitle={formatTitle} />
+    <HeadSEO {content} canonicalURL={Astro.request.canonicalURL} />
     <title>{formatTitle(content, SITE)}</title>
     <style>
       body {


### PR DESCRIPTION
## Changes

This changes the `HeadSEO.astro` implementation so that `og:title` uses the **title** and the **site title** as the fallback. This is to follow [`og:title` guidance](https://developers.facebook.com/docs/sharing/webmasters/), and because it helps cards look "snappier" when embedded in cards on services like 


- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

In progress...

## Docs

This makes no changes to current documentation that I know of.