### PR TITLE
Make congratsbot not run in forks

### DIFF
--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   congrats:
     name: "discord:congratsbot"
-    #if: github.event.commits[0] && !github.event.commits[1]
+    if: github.repository == 'snowpackjs/astro'
     runs-on: ubuntu-latest
     steps:
       - name: Send a Discord notification when a PR is merged


### PR DESCRIPTION
## Changes

- What does this change?
Makes this workflow not run in forks, since it sends emails to me when it fails:
![image](https://user-images.githubusercontent.com/35617441/129818047-9717fc4c-c9cd-4ded-8913-a070bc0db6b5.png)

## Testing
_**I have not, and I have no idea how to test**_ 😅

I just saw this solution in an issue on https://github.com/actions/runner/, and also that most workflows use this in [quarkus.io](https://github.com/quarkusio/quarkus/tree/main/.github).
Definitely test somehow before merging! (or don't, I mean, the only effect it has is that I don't get a congratulation when the PR is merged if the code is wrong)

## Docs
No
