### PR TITLE
fix too strict "relative link" errors in docs website

### DIFF
--- a/packages/astro/src/compiler/codegen/index.ts
+++ b/packages/astro/src/compiler/codegen/index.ts
@@ -22,7 +22,7 @@ import { transform } from '../transform/index.js';
 import { PRISM_IMPORT } from '../transform/prism.js';
 import { nodeBuiltinsSet } from '../../node_builtins.js';
 import { readFileSync } from 'fs';
-import { pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const { parse, FEATURE_CUSTOM_ELEMENT } = astroParser;
 const traverse: typeof babelTraverse.default = (babelTraverse.default as any).default;
@@ -61,6 +61,7 @@ function findHydrationAttributes(attrs: Record<string, string>): HydrationAttrib
 
 /** Retrieve attributes from TemplateNode */
 async function getAttributes(nodeName: string, attrs: Attribute[], state: CodegenState, compileOptions: CompileOptions): Promise<Record<string, string>> {
+  const isPage = state.filename.startsWith(fileURLToPath(compileOptions.astroConfig.pages));
   let result: Record<string, string> = {};
   for (const attr of attrs) {
     if (attr.type === 'Spread') {
@@ -112,8 +113,9 @@ async function getAttributes(nodeName: string, attrs: Attribute[], state: Codege
       }
       case 'Text': {
         let text = getTextFromAttribute(val);
-
-        warnIfRelativeStringLiteral(compileOptions.logging, nodeName, attr, text);
+        if (!isPage) {
+          warnIfRelativeStringLiteral(compileOptions.logging, nodeName, attr, text);
+        }
         result[attr.name] = JSON.stringify(text);
         continue;
       }

--- a/packages/astro/src/compiler/codegen/utils.ts
+++ b/packages/astro/src/compiler/codegen/utils.ts
@@ -24,7 +24,7 @@ export function isImportMetaDeclaration(declaration: VariableDeclarator, metaNam
 
 const warnableRelativeValues = new Set(['img+src', 'a+href', 'script+src', 'link+href', 'source+srcset']);
 
-const matchesRelative = /^(?![A-Za-z][+-.0-9A-Za-z]*:|\/)/;
+const matchesRelative = /^(?![A-Za-z][+-.0-9A-Za-z]*:|\/|#)/;
 
 export function warnIfRelativeStringLiteral(logging: LogOptions, nodeName: string, attr: Attribute, value: string) {
   let key = nodeName + '+' + attr.name;


### PR DESCRIPTION
## Changes

- #1085 added a "relative link" warning if a component uses a relative URL for an attribute
- this created false positive warnings for pages in the docs site:

```
[dev server] Server started in 904ms.
[dev server] Local: http://localhost:3000/
[access] /
[relative-link] This value will be resolved relative to the page: <a href="#article">
[access] /getting-started
[relative-link] This value will be resolved relative to the page: <a href="quick-start">
[relative-link] This value will be resolved relative to the page: <a href="#article">
```

- This PR removes warnings for `#hash` URLs which aren't really relative
- This PR also changes the warning to not warn on pages, since pages can assume relative URLs work. This is especially common for Markdown. In docs specifically, we use relative so that relative links continue to work regardless of what `/LANG/...` i18n collection you are inside of.