### PR TITLE
Fix B#1156 typo in v0.19.0 blog post

### DIFF
--- a/www/src/pages/blog/astro-019.astro
+++ b/www/src/pages/blog/astro-019.astro
@@ -167,7 +167,7 @@ let lang = 'en';
 
           Chances are, your company benefits from open source software. Invest in the technologies that power your business by sponsoring Astro and any other open source projects that you use. **Bonus:** thousands of developers will see your logo on our README and the [astro.build homepage](https://astro.build), every day. 
 
-          1005 of funds raised are invested directly back into the project and our community. You can read more about how funds are distributed by reading our [FUNDING.md](https://github.com/snowpackjs/astro/blob/main/FUNDING.md) doc on GitHub.
+          100% of funds raised are invested directly back into the project and our community. You can read more about how funds are distributed by reading our [FUNDING.md](https://github.com/snowpackjs/astro/blob/main/FUNDING.md) doc on GitHub.
           
           We'll be tweeting out personal "thank you" messages to every person and company who hits the ["Sponsor"](https://opencollective.com/astrodotbuild) button in the next 48 hours. Our first, very special THANK YOU goes out to [Chris Jennings](https://twitter.com/ckj), CCO and co-founder of [Sentry](https://sentry.io/), for being our first official sponsor! 🎉
 


### PR DESCRIPTION
Thanks for catching this typo @bLaCkwEw!

## Changes

Docs only, fixes a typo in the 0.19 blog post

## Testing

None, gotta love one character fixes!

## Docs

Fixes typo in the blog post, "1005" -> "100%"
