### PR TITLE
docs: fix mobile sidebar toggle

### DIFF
--- a/docs/src/layouts/MainLayout.astro
+++ b/docs/src/layouts/MainLayout.astro
@@ -65,7 +65,7 @@ const githubEditUrl = `https://github.com/snowpackjs/astro/blob/main/docs/${curr
       :global(.mobile-sidebar-toggle) {
         overflow: hidden;
       }
-      :global(.mobile-sidebar-toggle) #grid-left {
+      :global(.mobile-sidebar-toggle #grid-left) {
         display: block;
         top: 2rem;
       }


### PR DESCRIPTION
## Changes

Docs only, fixed a typo in the main layout that caused the mobile sidebar toggle to not work.

## Testing

Mobile sidebar toggle now works on dev environment after change.

## Docs

None added (bug fix only)
