### PR TITLE
including the `language-` class on Prism's `<pre>` element

### DIFF
--- a/.changeset/great-poets-pull.md
+++ b/.changeset/great-poets-pull.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Including Prism's `language-` class on code block `<pre>` tags

--- a/packages/astro/components/Prism.astro
+++ b/packages/astro/components/Prism.astro
@@ -42,4 +42,4 @@ if (grammar) {
 
 ---
 
-<pre class={className}><code class={classLanguage}>{html}</code></pre>
+<pre class={[className, classLanguage].join(' ')}><code class={classLanguage}>{html}</code></pre>

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -41,6 +41,7 @@ Markdown('Scoped styles should not break syntax highlight', async ({ runtime }) 
 
   const $ = doc(result.contents);
   assert.ok($('pre').is('[class]'), 'Pre tag has scopedStyle class passed down');
+  assert.ok($('pre').hasClass('language-js'), 'Pre tag has correct language');
   assert.ok($('code').hasClass('language-js'), 'Code tag has correct language');
   assert.ok($('code span').length > 0, 'There are child spans in code blocks');
 });


### PR DESCRIPTION
## Changes

Fixes #1179 (yes, I just filed that 2 minutes ago :laughing:)

Adds the `language-___` class back to the `<pre>` tag when rendering Prism code blocks

## Testing

Markdown code test updated to make sure the `<pre>` tag includes the correct class

## Docs

Bug fix only, no doc updates needed