### PR TITLE
Adding codesandbox config files to templates

### DIFF
--- a/examples/blog-multiple-authors/sandbox.config.json
+++ b/examples/blog-multiple-authors/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/blog/sandbox.config.json
+++ b/examples/blog/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/docs/sandbox.config.json
+++ b/examples/docs/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-lit/sandbox.config.json
+++ b/examples/framework-lit/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-multiple/sandbox.config.json
+++ b/examples/framework-multiple/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-preact/sandbox.config.json
+++ b/examples/framework-preact/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-react/sandbox.config.json
+++ b/examples/framework-react/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-solid/sandbox.config.json
+++ b/examples/framework-solid/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-vue/sandbox.config copy.json
+++ b/examples/framework-vue/sandbox.config copy.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-vue/sandbox.config.json
+++ b/examples/framework-vue/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/minimal/sandbox.config.json
+++ b/examples/minimal/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/portfolio/sandbox.config.json
+++ b/examples/portfolio/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/snowpack/sandbox.config.json
+++ b/examples/snowpack/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/with-markdown-plugins/sandbox.config.json
+++ b/examples/with-markdown-plugins/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/with-markdown/sandbox.config.json
+++ b/examples/with-markdown/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/with-nanostores/sandbox.config.json
+++ b/examples/with-nanostores/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/with-tailwindcss/sandbox.config.json
+++ b/examples/with-tailwindcss/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}


### PR DESCRIPTION
## Changes

Adding codesandbox.io configuration file :  `sandbox.config.json` to the root of each template located in the `astro/examples/` directory. This is to enable codesandbox to deploy the correct sandbox enviroment when porting from github. Allowing their enviroment to work with Astro, so it can display the templates as online demonstrations. 
 This is the following configuration that is used. 
```json
{
    "infiniteLoopProtection": true,
    "hardReloadOnChange": false,
    "view": "browser",
    "template": "node",
    "container": {
      "port": 3000,
      "startScript": "start",
      "node": "14"
    }
}
```
