### PR TITLE
Fix resolution of Astro.resolve in nested components

### DIFF
--- a/.changeset/violet-crabs-deny.md
+++ b/.changeset/violet-crabs-deny.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Makes sure Astro.resolve works in nested component folders

--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -169,10 +169,6 @@ async function __render(props, ...children) {
       value: (props[__astroInternal] && props[__astroInternal].isPage) || false,
       enumerable: true
     },
-    resolve: {
-      value: (props[__astroContext] && props[__astroContext].resolve) || {},
-      enumerable: true
-    },
     request: {
       value: (props[__astroContext] && props[__astroContext].request) || {},
       enumerable: true
@@ -201,7 +197,6 @@ export async function __renderPage({request, children, props, css}) {
       value: {
         pageCSS: css,
         request,
-        resolve: __TopLevelAstro.resolve,
         createAstroRootUID(seed) { return seed + astroRootUIDCounter++; },
       },
       writable: false,

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -48,6 +48,7 @@ Global('Astro.resolve in development', async (context) => {
   const html = result.contents;
   const $ = doc(html);
   assert.equal($('img').attr('src'), '/_astro/src/images/penguin.png');
+  assert.equal($('#inner-child img').attr('src'), '/_astro/src/components/nested/images/penguin.png');
 });
 
 Global.run();

--- a/packages/astro/test/fixtures/astro-global/src/components/nested/InnerChild.astro
+++ b/packages/astro/test/fixtures/astro-global/src/components/nested/InnerChild.astro
@@ -1,0 +1,6 @@
+---
+const penguinUrl = Astro.resolve('./images/penguin.png');
+---
+<div id="inner-child">
+  <img src={penguinUrl} />
+</div>

--- a/packages/astro/test/fixtures/astro-global/src/pages/resolve.astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/resolve.astro
@@ -1,5 +1,6 @@
 ---
 import Child from '../components/ChildResolve.astro';
+import InnerChild from '../components/nested/InnerChild.astro';
 ---
 
 <html>
@@ -8,5 +9,6 @@ import Child from '../components/ChildResolve.astro';
 </head>
 <body>
   <Child />
+  <InnerChild />
 </body>
 </html>


### PR DESCRIPTION
Fixes #1211
## Changes

Previously `Astro.resolve` was being passed down from the page to child components, causing it to always resolve from the page. Since that's not the behavior we want, I removed that code.

## Testing

Components were already tested, but nested components were not, which is why this bug was not caught in implementation.

## Docs

Bug fix only.
