### PR TITLE
Expose slots to components

### DIFF
--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -155,10 +155,18 @@ ${result.getStaticPaths || ''}
 import { h, Fragment } from 'astro/dist/internal/h.js';
 const __astroInternal = Symbol('astro.internal');
 const __astroContext = Symbol.for('astro.context');
+const __astroSlotted = Symbol.for('astro.slotted');
 async function __render(props, ...children) {
   const Astro = Object.create(__TopLevelAstro, {
     props: {
       value: props,
+      enumerable: true
+    },
+    slots: {
+      value: children.reduce(
+        (slots, child) => Object.assign(slots, child.$slots),
+        {}
+      ),
       enumerable: true
     },
     pageCSS: {


### PR DESCRIPTION
## Changes

This adds the ability to see what has been slotted to a component via `Astro.slots`, similar to `Astro.props`.

This is necessary because, while we can access attributes via `Astro.props`, there is currently no way to access slotted content.

## Testing

No tests were added because this should be reviewed by responsible adults before being merged.

## Docs

This would require updates to the documentation. That burden should be on me. I’d like to know if this should be fast-tracked as a bug / missing necessity, or if it is bonafide new feature in need of a proper RFC.