### PR TITLE
feat: Add `filename` available to astro components

### DIFF
--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -176,6 +176,10 @@ async function __render(props, ...children) {
       value: (props[__astroInternal] && props[__astroInternal].isPage) || false,
       enumerable: true
     },
+    filename: {
+      value: (props[__astroInternal] && props[__astroInternal].filename) || '${filename}',
+      enumerable: true
+    },
     request: {
       value: (props[__astroContext] && props[__astroContext].request) || {},
       enumerable: true
@@ -214,7 +218,8 @@ export async function __renderPage({request, children, props, css, scripts}) {
 
   Object.defineProperty(props, __astroInternal, {
     value: {
-      isPage: !isLayout
+      isPage: !isLayout,
+      filename: '${filename}',
     },
     writable: false,
     enumerable: false

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -17,6 +17,32 @@ Global('Astro.request.url', async (context) => {
   assert.equal($('#nested-child-pathname').text(), '/');
 });
 
+Global('Astro.filename', async (context) => {
+  const result = await context.runtime.load('/filename');
+  assert.ok(!result.error, `build error: ${result.error}`);
+
+  const $ = doc(result.contents);
+  assert.match($('#filename').text(), 'test/fixtures/astro-global/src/pages/filename.astro');
+  assert.match($('#child-filename').text(), '/test/fixtures/astro-global/src/components/Child.astro');
+  assert.match($('#nested-child-filename').text(), '/test/fixtures/astro-global/src/components/NestedChild.astro');
+});
+
+Global('Astro.filename with getStaticPaths', async (context) => {
+  // given a URL, expect the following astro filename
+  const urls = {
+    '/': 'index.astro',
+    '/post/post': 'layouts/post.astro',
+    '/posts/1': 'posts/[page].astro',
+    '/posts/2': 'posts/[page].astro',
+  };
+
+  for (const [url, astroFilename] of Object.entries(urls)) {
+    const result = await context.runtime.load(url);
+    const $ = doc(result.contents);
+    assert.match($('#filename').text(), astroFilename);
+  }
+});
+
 Global('Astro.request.canonicalURL', async (context) => {
   // given a URL, expect the following canonical URL
   const canonicalURLs = {

--- a/packages/astro/test/fixtures/astro-global/src/components/Child.astro
+++ b/packages/astro/test/fixtures/astro-global/src/components/Child.astro
@@ -2,4 +2,5 @@
 import NestedChild from './NestedChild.astro';
 ---
 <div id="child-pathname">{Astro.request.url.pathname}</div>
+<div id="child-filename">{Astro.filename}</div>
 <NestedChild />

--- a/packages/astro/test/fixtures/astro-global/src/components/NestedChild.astro
+++ b/packages/astro/test/fixtures/astro-global/src/components/NestedChild.astro
@@ -1,1 +1,2 @@
 <div id="nested-child-pathname">{Astro.request.url.pathname}</div>
+<div id="nested-child-filename">{Astro.filename}</div>

--- a/packages/astro/test/fixtures/astro-global/src/layouts/post.astro
+++ b/packages/astro/test/fixtures/astro-global/src/layouts/post.astro
@@ -7,6 +7,7 @@ const { content } = Astro.props;
     <link rel="canonical" href={Astro.request.canonicalURL.href}>
   </head>
   <body>
+    <div id="filename">{Astro.filename}</div>
     <slot></slot>
   </body>
 </html>

--- a/packages/astro/test/fixtures/astro-global/src/pages/filename.astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/filename.astro
@@ -1,0 +1,12 @@
+---
+import Child from '../components/Child.astro';
+---
+<html>
+<head>
+  <title>Test Astro.filename</title>
+</head>
+<body>
+  <a id="filename" href={Astro.request.canonicalURL.href}>{Astro.filename}</a>
+  <Child />
+</body>
+</html>

--- a/packages/astro/test/fixtures/astro-global/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/index.astro
@@ -7,6 +7,8 @@ import Child from '../components/Child.astro';
   <link rel="canonical" href={Astro.request.canonicalURL.href}>
 </head>
 <body>
+  <div id="filename">{Astro.filename}</div>
+  
   <div id="pathname">{Astro.request.url.pathname}</div>
   <a id="site" href={Astro.site}>Home</a>
 

--- a/packages/astro/test/fixtures/astro-global/src/pages/posts/[page].astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/posts/[page].astro
@@ -13,6 +13,8 @@ const { params, canonicalURL} = Astro.request;
     <link rel="canonical" href={canonicalURL.href} />
   </head>
   <body>
+    <div id="filename">{Astro.filename}</div>
+
     {page.data.map((data) => (
       <div>
         <h1>{data.title}</h1>


### PR DESCRIPTION
## Changes

- Export the absolute path of the astro component, called `Astro.filename`
- Add Unit test for `Astro.filename` property.

## Testing

Added new UT case for `Astro.filename` in the `astro-global` test.
 
## Docs

