### PR TITLE
Add v20 documentation for bundling assets

### DIFF
--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -161,7 +161,7 @@ As an alternative to `src/styles/global.css`, You may also add Tailwind utilitie
 
 #### v20 Tweaks to the tailwind import
 As of [Version 20](https://github.com/snowpackjs/astro/releases/tag/astro%400.20.0), Astro will no longer bundle, build and process public files. You now need to move your styles into the `src` directory and import them like so, making use of [Astro Resolve](http://localhost:3000/reference/api-reference#astroresolve): 
-```html
+```astro
   <link 
     rel="stylesheet" 
     href={Astro.resolve("../styles/global.css")} 

--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -160,7 +160,7 @@ Now you're ready to write Tailwind! Our recommended approach is to create a `src
 As an alternative to `src/styles/global.css`, You may also add Tailwind utilities to individual `pages/*.astro` components in `<style>` tags, but be mindful of duplication! If you end up creating multiple Tailwind-managed stylesheets for your site, make sure you're not sending the same CSS to users over and over again in separate CSS files.
 
 #### v20 Tweaks to the tailwind import
-As of [Version 20](https://github.com/snowpackjs/astro/releases/tag/astro%400.20.0), Astro will no longer bundle, build and process public files. You now need to move your styles into the `src` directory and import them like so, making use of [Astro Resolve](http://localhost:3000/reference/api-reference#astroresolve): 
+As of [Version 20](https://github.com/snowpackjs/astro/releases/tag/astro%400.20.0), Astro will no longer bundle, build and process public files. You now need to move your styles into the `src` directory and import them like so, making use of [Astro Resolve](/reference/api-reference#astroresolve): 
 ```astro
   <link 
     rel="stylesheet" 

--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -159,12 +159,14 @@ Now you're ready to write Tailwind! Our recommended approach is to create a `src
 
 As an alternative to `src/styles/global.css`, You may also add Tailwind utilities to individual `pages/*.astro` components in `<style>` tags, but be mindful of duplication! If you end up creating multiple Tailwind-managed stylesheets for your site, make sure you're not sending the same CSS to users over and over again in separate CSS files.
 
-#### v20 Tweaks to the tailwind import
-As of [Version 20](https://github.com/snowpackjs/astro/releases/tag/astro%400.20.0), Astro will no longer bundle, build and process public files. You now need to move your styles into the `src` directory and import them like so, making use of [Astro Resolve](/reference/api-reference#astroresolve): 
+#### Migrating from v0.19
+
+As of [version 0.20.0](https://github.com/snowpackjs/astro/releases/tag/astro%400.20.0), Astro will no longer bundle, build and process `public/` files. Previously, we'd recommended putting your tailwind files in the `public/` directory. If you started a project with this pattern, you should move any Tailwind styles into the `src` directory and import them in your template using [Astro.resolve()](/reference/api-reference#astroresolve): 
+
 ```astro
   <link 
     rel="stylesheet" 
-    href={Astro.resolve("../styles/global.css")} 
+    href={Astro.resolve("../assets/global.css")} 
   >
 ```
 

--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -118,7 +118,10 @@ Astro also supports [Sass][sass] out-of-the-box. To enable for each framework:
 
 ### 🍃 Tailwind
 
-> Note that Astro's Tailwind support _only_ works with Tailwind JIT mode.
+> Please note the following: 
+>   Astro's Tailwind support _only_ works with Tailwind JIT mode.
+>   Astro V20 requires the styles to be in the `src` directory and implemented like so
+>   
 
 Astro can be configured to use [Tailwind][tailwind] easily! Install the dependencies:
 
@@ -158,6 +161,15 @@ Now you're ready to write Tailwind! Our recommended approach is to create a `src
 ```
 
 As an alternative to `src/styles/global.css`, You may also add Tailwind utilities to individual `pages/*.astro` components in `<style>` tags, but be mindful of duplication! If you end up creating multiple Tailwind-managed stylesheets for your site, make sure you're not sending the same CSS to users over and over again in separate CSS files.
+
+#### v20 Tweaks to the tailwind import
+As of [Version 20](https://github.com/snowpackjs/astro/releases/tag/astro%400.20.0), Astro will no longer bundle, build and process public files. You now need to move your styles into the `src` directory and import them like so, making use of [Astro Resolve](http://localhost:3000/reference/api-reference#astroresolve): 
+```html
+  <link 
+    rel="stylesheet" 
+    href={`${Astro.resolve(../styles/global.css)}`} 
+  />
+```
 
 ### Importing from npm
 

--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -118,10 +118,7 @@ Astro also supports [Sass][sass] out-of-the-box. To enable for each framework:
 
 ### 🍃 Tailwind
 
-> Please note the following: 
->   Astro's Tailwind support _only_ works with Tailwind JIT mode.
->   Astro V20 requires the styles to be in the `src` directory and implemented like so
->   
+> Note that Astro's Tailwind support _only_ works with Tailwind JIT mode.
 
 Astro can be configured to use [Tailwind][tailwind] easily! Install the dependencies:
 

--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -164,8 +164,8 @@ As of [Version 20](https://github.com/snowpackjs/astro/releases/tag/astro%400.20
 ```html
   <link 
     rel="stylesheet" 
-    href={`${Astro.resolve(../styles/global.css)}`} 
-  />
+    href={Astro.resolve("../styles/global.css")} 
+  >
 ```
 
 ### Importing from npm


### PR DESCRIPTION
## Changes

Off the back of an issue raised [here](https://github.com/snowpackjs/astro/issues/1256), this PR adds a section to the tailwind styling documentation to let others know of a breaking change with bundling public styles. 

It looks like this once rendered: 
![image](https://user-images.githubusercontent.com/16897508/131242280-2cf8bdc5-4348-4b7d-a361-179901c78157.png)

### Documentation Considerations
- I've added string interpolation to the example of `Astro.Resolve()` instead of quotation marks to get the code to render correctly, quotations wont work and stray from the styling of the documentation
- I've only done this documentation directly here, because I don't doubt the team has a bigger plan for rolling this out to all aspects of Astro

## Testing

* This was tested and discussed in the attached issues
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

* This is only a doc update
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

# The documentation renders and functions like so: 
#### v20 Tweaks to the tailwind import
As of [Version 20](https://github.com/snowpackjs/astro/releases/tag/astro%400.20.0), Astro will no longer bundle, build and process public files. You now need to move your styles into the `src` directory and import them like so, making use of [Astro Resolve](http://localhost:3000/reference/api-reference#astroresolve): 
```html
  <link 
    rel="stylesheet" 
    href={`${Astro.resolve(../styles/global.css)}`} 
  />
```
