### PR TITLE
Include lang="xxxx" in Prism component example

### DIFF
--- a/docs/src/pages/reference/builtin-components.md
+++ b/docs/src/pages/reference/builtin-components.md
@@ -26,10 +26,12 @@ See our [Markdown Guide](/guides/markdown-content) for more info.
 ---
 import { Prism } from 'astro/components';
 ---
-<Prism code={`const foo = 'bar';`} />
+<Prism lang="js" code={`const foo = 'bar';`} />
 ```
 
-This component provides syntax highlighting for code blocks. Since this never changes in the client it makes sense to use an Astro component (it's equally reasonable to use a framework component for this kind of thing; Astro is server-only by default for all frameworks!).
+This component provides language-specific syntax highlighting for code blocks. Since this never changes in the client it makes sense to use an Astro component (it's equally reasonable to use a framework component for this kind of thing; Astro is server-only by default for all frameworks!).
+
+See the [list of languages supported by Prism](https://prismjs.com/#supported-languages) where you can find a language's corresponding alias. And, you can also display your Astro code blocks with lang="astro"!
 
 ## `<Debug />`
 


### PR DESCRIPTION
If you don't like my text, you can change it. But, an issue was filed that our docs don't currently mention that you need to specify a language to get syntax highlighting, and the example doesn't even show a language. https://github.com/snowpackjs/astro/issues/1261

## Changes

- Docs example for Prism component changed to include lang="js" because no language was previously specified 
- Link to Prism's list of supported languages/alias
- mentioned that lang="astro" is valid, too!


## Testing

<!-- How was this change tested? -->
No tests.

## Docs

<!-- Was public documentation updated? -->
Only documentation updated, as described above, to emphasize choosing a language when using the component.
