### PR TITLE
fix: use src from astroConfig for snowpack mounts

### DIFF
--- a/.changeset/seven-tools-begin.md
+++ b/.changeset/seven-tools-begin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+use src from astroConfig for snowpack mounts

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -257,7 +257,7 @@ interface CreateSnowpackOptions {
 
 /** Create a new Snowpack instance to power Astro */
 async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackOptions) {
-  const { projectRoot, src } = astroConfig;
+  const { projectRoot, src, pages } = astroConfig;
   const { mode, logging, resolvePackageUrl } = options;
 
   const frontendPath = new URL('./frontend/', import.meta.url);
@@ -286,7 +286,8 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
   const mountOptions = {
     ...(existsSync(astroConfig.public) ? { [fileURLToPath(astroConfig.public)]: { url: '/', static: true, resolve: false } } : {}),
     [fileURLToPath(frontendPath)]: '/_astro_frontend',
-    [fileURLToPath(src)]: `/_astro/${fileURLToPath(src).slice(fileURLToPath(projectRoot).length - 1)}`, // must be last (greediest)
+    [fileURLToPath(src)]: `/_astro/${src.pathname.slice(projectRoot.pathname.length - 1)}`, // must be last (greediest)
+    [fileURLToPath(pages)]: `/_astro/${pages.pathname.slice(projectRoot.pathname.length - 1)}`
   };
 
   // Tailwind: IDK what this does but it makes JIT work 🤷‍♂️

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -286,7 +286,7 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
   const mountOptions = {
     ...(existsSync(astroConfig.public) ? { [fileURLToPath(astroConfig.public)]: { url: '/', static: true, resolve: false } } : {}),
     [fileURLToPath(frontendPath)]: '/_astro_frontend',
-    [fileURLToPath(src)]: '/_astro/src', // must be last (greediest)
+    [fileURLToPath(src)]: `/_astro/${fileURLToPath(src).slice(fileURLToPath(projectRoot).length - 1)}`, // must be last (greediest)
   };
 
   // Tailwind: IDK what this does but it makes JIT work 🤷‍♂️


### PR DESCRIPTION
Helps to mitigate #674 

## Changes

This replaces a hardcoded src/ dir, which wasn't working when the user sets a custom src/ in astro.config.mjs

This still requires the pages/ dir to be both inside the custom src/ as well as to be specified inside astro.config.mjs. I will investigate this further once I have the time.

## Testing

I wasn't entirely sure how to add tests yet and wanted to get something out before I have to stop for today, since based on #674 this seems to be blocking for some people (including myself!) Also, no existing tests broke.

## Docs

bug fix only
