### PR TITLE
Show Astro Version in the documentation

### DIFF
--- a/docs/src/components/RightSidebar/MoreMenu.astro
+++ b/docs/src/components/RightSidebar/MoreMenu.astro
@@ -1,6 +1,7 @@
 ---
 import ThemeToggleButton from './ThemeToggleButton.jsx';
 const {editHref} = Astro.props;
+const astroVersion = process.env.npm_package_devDependencies_astro.replace("^", "");
 ---
 <style>
   .edit-on-github {
@@ -66,3 +67,4 @@ const {editHref} = Astro.props;
 <div style="margin: 2rem 0; text-align: center;">
   <ThemeToggleButton client:visible />
 </div>
+<div style="text-align: center;"><b>v{astroVersion}</b></div>


### PR DESCRIPTION
My intentions with this PR is to show which version of Astro is being shown on the documentation website.
There is already a warning in the documentation that tells us developers that the documentation is about the last Astro version but for people that do not follow or receive the notifications of a new version release is hard to known which version is the documentation about.

## Changes

- Show Astro version on the bottom of the right bar menu.


## Testing

- Tested with `astro dev`;
- Tested after `npm run build` and used python http server to serve dist files.


## Docs

- No need to update the existing documentation.