### PR TITLE
Remove caveat about `Astro.request` not being passed to components.

### DIFF
--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -58,8 +58,6 @@ const data = Astro.fetchContent('../pages/post/*.md'); // returns an array of po
 | `url`          | `URL` | The URL of the request being rendered.          |
 | `canonicalURL` | `URL` | [Canonical URL][canonical] of the current page. |
 
-⚠️ Temporary restriction: this is only accessible in top-level pages and not in sub-components.
-
 ### `Astro.resolve()`
 
 `Astro.resolve()` helps with creating URLs relative to the current Astro file, allowing you to reference files within your `src/` folder.


### PR DESCRIPTION
https://github.com/snowpackjs/astro/pull/960 was merged that allows `Astro.request` to be accessed in children components of pages, so this caveat no longer applies.