### PR TITLE
Remove reference/link to Collections

### DIFF
--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -9,7 +9,7 @@ The `Astro` global is available in all contexts in `.astro` files. It has the fo
 
 ### `Astro.fetchContent()`
 
-`Astro.fetchContent()` is a way to load local `*.md` files into your static site setup. You can either use this on its own, or within [Astro Collections](/core-concepts/collections).
+`Astro.fetchContent()` is a way to load local `*.md` files into your static site setup.
 
 ```jsx
 // ./src/components/my-component.astro

--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -9,7 +9,7 @@ The `Astro` global is available in all contexts in `.astro` files. It has the fo
 
 ### `Astro.fetchContent()`
 
-`Astro.fetchContent()` is a way to load local `*.md` files into your static site setup.
+`Astro.fetchContent()` is a way to load local `*.md` files into your static site setup. You can either use this on its own, or when configuring [Routing](/core-concepts/routing).
 
 ```jsx
 // ./src/components/my-component.astro


### PR DESCRIPTION
## Changes
Minor update to api-reference.md
- Remove line that refers to 'Core Concepts - Collections' given these is now deprecated and the link returns a 404.


## Testing
Tested using local dev/build.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
This is purely an update to the docs. 
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
