### PR TITLE
Delete docs text about removed Collections API

### DIFF
--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -9,7 +9,7 @@ The `Astro` global is available in all contexts in `.astro` files. It has the fo
 
 ### `Astro.fetchContent()`
 
-`Astro.fetchContent()` is a way to load local `*.md` files into your static site setup. You can either use this on its own, or when configuring [Routing](/core-concepts/routing).
+`Astro.fetchContent()` is a way to load local `*.md` files into your static site setup.
 
 ```jsx
 // ./src/components/my-component.astro


### PR DESCRIPTION
## Changes

- Documentation update

## Testing

- N/A

## Docs

- Delete text referring to old (and now removed) Collections API

Fixes #1258 