### PR TITLE
Nightly stats: don't count PRs as issues

### DIFF
--- a/scripts/stats/index.js
+++ b/scripts/stats/index.js
@@ -81,7 +81,7 @@ export async function run() {
     // Pull requests
     pulls.length,
     // Open Issues
-    issues.length,
+    issues.length - pulls.length,
     // Bugs: Needs Triage
     (await countCards(COLUMN_ID_BUGS_NEEDS_TRIAGE)).length,
     // Bugs: Accepted

--- a/scripts/stats/stats.csv
+++ b/scripts/stats/stats.csv
@@ -1,2 +1,2 @@
 Date,Commits (24hr),Open PRs,Open Issues,Bugs: Needs Triage,Bugs: Accepted,RFC: Needs Discussion,RFC: In Progress,RFC: Accepted,Date (ISO)
-"Wednesday, September 1, 2021",10,10,182,3,64,15,18,12,"2021-09-01T12:04:47.572Z"
+"Wednesday, September 1, 2021",10,10,172,3,64,15,18,12,"2021-09-01T12:04:47.572Z"


### PR DESCRIPTION
## Changes

- GH considers PRs to be issues.
- For our collection we want to differentiate issues from PRs. This subtracts PRs from issues to get the number we are trying to track.

## Testing

N/A

## Docs

N/A