### PR TITLE
Debug component importation

### DIFF
--- a/docs/src/pages/reference/builtin-components.md
+++ b/docs/src/pages/reference/builtin-components.md
@@ -37,7 +37,7 @@ See the [list of languages supported by Prism](https://prismjs.com/#supported-la
 
 ```astro
 ---
-import { Debug } from 'astro/debug';
+import Debug from 'astro/debug';
 const serverObject = {
   a: 0,
   b: "string",


### PR DESCRIPTION
## Probleme

by using `import { Debug } from 'astro/debug'` to import the debug component we have :

> Error: Unable to render Debug because it is undefined! Did you forget to import the component or is it possible there is a typo?

because Debug = undefined

## Explanation

that hapend because of this ligne in astero's package.json :

```
  "exports": {
    ...
    "./debug": "./components/Debug.astro",
    ...
  },
```

it means that `'astro/debug'` point directly to the component and we have to import it like a normal component :
```js
import SomeComponent from './SomeComponent.astro';
```

## Changes

So in the exemple we have to importe the component like that
```js
import Debug from 'astro/debug';
```

## Testing

with
```
---
import Debug from 'astro/debug';
const serverObject = {
  a: 0,
  b: "string",
  c: {
    nested: "object"
  }
}
---
<Debug {serverObject} />
```
i have
```
Debug"serverObject"
▼ {a,b,c}
a:0
b:"string"
▶ c: {nested}
```
