### PR TITLE
Add interfaces for built-in components

### DIFF
--- a/.changeset/perfect-kids-occur.md
+++ b/.changeset/perfect-kids-occur.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds interfaces for built-in components

--- a/packages/astro/components/Markdown.astro
+++ b/packages/astro/components/Markdown.astro
@@ -1,7 +1,16 @@
 ---
 import { renderMarkdown } from '@astrojs/markdown-support';
 
-const { content, $scope } = Astro.props;
+export interface Props {
+  content?: string;
+}
+
+// Internal props that should not be part of the external interface.
+interface InternalProps extends Props {
+  $scope: string;
+}
+
+const { content, $scope } = Astro.props as InternalProps;
 let html = null;
 
 // This flow is only triggered if a user passes `<Markdown content={content} />`

--- a/packages/astro/components/Prism.astro
+++ b/packages/astro/components/Prism.astro
@@ -3,7 +3,14 @@ import Prism from 'prismjs';
 import { addAstro } from '@astrojs/prism';
 import loadLanguages from 'prismjs/components/index.js';
 
-const { class: className, lang, code } = Astro.props;
+export interface Props {
+  class?: string;
+  lang?: string;
+  code: string;
+}
+
+const { class: className, lang, code } = Astro.props as Props;
+
 let classLanguage = `language-${lang}`
 
 const languageMap = new Map([


### PR DESCRIPTION
## Changes

- Adds interfaces for the `Prism` and `Markdown` component.

## Testing

N/A

## Docs

N/A
