### PR TITLE
Import unified types as unified since there is no default export for …

### DIFF
--- a/.changeset/serious-icons-invent.md
+++ b/.changeset/serious-icons-invent.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-support': patch
+---
+
+Fix the importing of `unified` `Plugin` and `UnifiedPlugin` types

--- a/packages/markdown-support/src/load-plugins.ts
+++ b/packages/markdown-support/src/load-plugins.ts
@@ -1,4 +1,4 @@
-import unified from 'unified';
+import * as unified from 'unified';
 import type { Plugin, UnifiedPluginImport } from './types';
 
 async function importPlugin(p: string | UnifiedPluginImport): UnifiedPluginImport {

--- a/packages/markdown-support/src/types.ts
+++ b/packages/markdown-support/src/types.ts
@@ -1,4 +1,4 @@
-import unified from 'unified';
+import * as unified from 'unified';
 
 export type UnifiedPluginImport = Promise<{ default: unified.Plugin }>;
 export type Plugin = string | [string, any] | UnifiedPluginImport | [UnifiedPluginImport, any];


### PR DESCRIPTION
…'unified'.

## Changes

- Updates the type imports for unified in the `@astrojs/markdown-support` package, `unified` has no default export, so `import unified from "unified";` was giving me errors?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
This is a types import change, there should be no semantic code change.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
bug fix only