### PR TITLE
skip 404.html pages in sitemap generation

### DIFF
--- a/.changeset/few-lies-march.md
+++ b/.changeset/few-lies-march.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Sitemaps will not create entries for 404.html pages

--- a/packages/astro/src/build/sitemap.ts
+++ b/packages/astro/src/build/sitemap.ts
@@ -11,7 +11,7 @@ export function generateSitemap(buildState: BuildOutput, site: string): string {
   // look through built pages, only add HTML
   for (const id of Object.keys(buildState)) {
     if (buildState[id].contentType !== 'text/html') continue;
-    if (id.startsWith('404.html')) continue;
+    if (id === '/404.html') continue;
     uniqueURLs.add(canonicalURL(id, site).href);
   }
 

--- a/packages/astro/src/build/sitemap.ts
+++ b/packages/astro/src/build/sitemap.ts
@@ -1,5 +1,4 @@
 import type { BuildOutput } from '../@types/astro';
-
 import { canonicalURL } from './util.js';
 
 /** Construct sitemap.xml given a set of URLs */
@@ -7,11 +6,12 @@ export function generateSitemap(buildState: BuildOutput, site: string): string {
   const uniqueURLs = new Set<string>();
 
   // TODO: find way to respect <link rel="canonical"> URLs here
-  // TODO: find way to exclude pages from sitemap
+  // TODO: find way to exclude pages from sitemap (currently only skips 404 pages)
 
   // look through built pages, only add HTML
   for (const id of Object.keys(buildState)) {
     if (buildState[id].contentType !== 'text/html') continue;
+    if (id.startsWith('404.html')) continue;
     uniqueURLs.add(canonicalURL(id, site).href);
   }
 

--- a/packages/astro/test/fixtures/astro-rss/src/pages/404.astro
+++ b/packages/astro/test/fixtures/astro-rss/src/pages/404.astro
@@ -1,0 +1,10 @@
+---
+---
+<html>
+  <head>
+    <title>404</title>
+  </head>
+  <body>
+    404
+  </body>
+</html>


### PR DESCRIPTION
## Changes
- Sitemap generation skips `404.html` page (used for routes not otherwise found for the site).

## Testing
- Updated sitemap test fixture (`astro-rss`) to include a `404.astro` page that should not be included in the sitemap output.

## Docs
- Nothing to update in docs
