### PR TITLE
fix a bug for highlighting of current page

### DIFF
--- a/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -24,7 +24,7 @@ const sidebarSections = SIDEBAR[langCode].reduce((col, item) => {
           <h2 class="nav-group-title">{section.text}</h2>
           <ul>
             {section.children.map(child => (
-              <li class="nav-link"><a href={`${Astro.site.pathname}${child.link}`} aria-current={`${currentPageMatch === child.link ? 'page' : 'false'}`}>{child.text}</a></li>
+              <li class="nav-link"><a href={`${Astro.site.pathname}${child.link}`} aria-current={`${(currentPageMatch === child.link || currentPageMatch === child.link + '/') ? 'page' : 'false'}`}>{child.text}</a></li>
             ))}
           </ul>
         </div>

--- a/docs/src/components/PageContent/PageContent.astro
+++ b/docs/src/components/PageContent/PageContent.astro
@@ -35,6 +35,7 @@ import TableOfContents from '../RightSidebar/TableOfContents.tsx';
         </nav>
         <slot />
     </section>
+    {Astro.request.url.pathname}
     <nav class="block sm:hidden">
         <MoreMenu editHref={githubEditUrl}/>
     </nav>

--- a/docs/src/components/PageContent/PageContent.astro
+++ b/docs/src/components/PageContent/PageContent.astro
@@ -35,7 +35,6 @@ import TableOfContents from '../RightSidebar/TableOfContents.tsx';
         </nav>
         <slot />
     </section>
-    {Astro.request.url.pathname}
     <nav class="block sm:hidden">
         <MoreMenu editHref={githubEditUrl}/>
     </nav>


### PR DESCRIPTION
## Changes

- A dirty fix for https://github.com/snowpackjs/astro/issues/1307

There might be a bug somewhere, as the value of `Astro.request.url.pathname` is `/getting-started/` when I open https://docs.astro.build/getting-started.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No tests for docs as far as I can see.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
