### PR TITLE
docs: update npm install command

### DIFF
--- a/docs/src/pages/installation.md
+++ b/docs/src/pages/installation.md
@@ -78,7 +78,7 @@ Astro is designed to work with the entirety of the npm package ecosystem. This i
 Following the instructions above, you should have a directory with a single `package.json` file inside of it. You can now set up Astro inside your project.
 
 ```bash
-npm install astro
+npm install astro --save-dev
 ```
 
 You can now replace the placeholder "scripts" section of your `package.json` file that `npm init` created for you with the following:


### PR DESCRIPTION
## Changes

- Fix documentation

I believe `astro` should be installed under `devDependencies` instead of `dependencies `.

## Testing

Not needed.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Not needed.

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
