### PR TITLE
docs: set +/- prefix to non-selectable

### DIFF
--- a/docs/public/code.css
+++ b/docs/public/code.css
@@ -4,6 +4,10 @@
   color: #fd9170;
 }
 
+.language-diff .token.prefix.deleted,.language-diff .token.prefix.inserted {
+  user-select: none
+}
+
 [class*='language-'] .namespace {
   opacity: 0.7;
 }


### PR DESCRIPTION
## Changes

- Add some css rules to prevent users from selecting `+` `-` characters in `diff` block.

Currently I can select the `+` `-`:

![](https://user-images.githubusercontent.com/1091472/132123340-ded53295-548c-4804-af88-f2fa0c532bfa.png)

Which means after I paste the selection into my `package.json` file, I have to delete the `+` to make it work.

With `user-select` set to `none`, we won't have such a problem.


## Testing

Not needed.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

None.

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
