### PR TITLE
Updated srcset checking

### DIFF
--- a/packages/astro/src/build.ts
+++ b/packages/astro/src/build.ts
@@ -30,6 +30,19 @@ function isRemoteOrEmbedded(url: string) {
   return url.startsWith('http://') || url.startsWith('https://') || url.startsWith('//') || url.startsWith('data:');
 }
 
+/**
+ * This function taken from https://github.com/molefrog/srcset-parse as unable
+ * to add it as a working dependency (don't know why.)
+ * RegExp used below also from same project.
+ */
+ const matchSrces = (str: string, regex: RegExp): RegExpExecArray[] => {
+  let match = null,
+    result = [];
+
+  while ((match = regex.exec(str)) !== null) result.push(match);
+  return result;
+};
+
 /** The primary build action */
 export async function build(astroConfig: AstroConfig, logging: LogOptions = defaultLogging): Promise<0 | 1> {
   const { projectRoot } = astroConfig;
@@ -329,11 +342,25 @@ export function findDeps(html: string, { astroConfig, srcPath }: { astroConfig: 
 
   $('img[srcset]').each((_i, el) => {
     const srcset = $(el).attr('srcset') || '';
-    const sources = srcset.split(',');
-    const srces = sources.map((s) => s.trim().split(' ')[0]);
+    // using matchSrces (see above) as built-in matchAll
+    // is not compatible with project.
+    const srces = matchSrces(srcset, /(\S*[^,\s])(\s+([\d.]+)(x|w))?/g)
     for (const src of srces) {
-      if (!isRemoteOrEmbedded(src)) {
-        pageDeps.images.add(getDistPath(src, { astroConfig, srcPath }));
+      if (!isRemoteOrEmbedded(src[1])) {
+        pageDeps.images.add(getDistPath(src[1], { astroConfig, srcPath }));
+      }
+    }
+  });
+
+  // Add in srcset check for <source>
+  $('source[srcset]').each((_i, el) => {
+    const srcset = $(el).attr('srcset') || '';
+    // using matchSrces (see above) as built-in matchAll
+    // is not compatible with project.
+    const srces = matchSrces(srcset, /(\S*[^,\s])(\s+([\d.]+)(x|w))?/g)
+    for (const src of srces) {
+      if (!isRemoteOrEmbedded(src[1])) {
+        pageDeps.images.add(getDistPath(src[1], { astroConfig, srcPath }));
       }
     }
   });

--- a/packages/astro/test/fixtures/astro-assets/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-assets/src/pages/index.astro
@@ -6,5 +6,27 @@
 <body>
   <h1>Icons</h1>
   <img src="/_astro/src/images/twitter.png" srcset="/_astro/src/images/twitter.png 1x, /_astro/src/images/twitter@2x.png 2x, /_astro/src/images/twitter@3x.png 3x" />
+  <!--
+    In Astro (0.20.4 and below) these srcsets will cause a build fail.
+    Error (for Assets Test)
+    [build] file:///astro/packages/astro/test/fixtures/astro-assets/src/pages/index.astro: could not find "/_astro/src/pages/h-300/medium_cafe_B1iTdD0C.jpg"
+  -->
+  <img srcset="https://ik.imagekit.io/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg, https://ik.imagekit.io/demo/tr:w-450,h-450/medium_cafe_B1iTdD0C.jpg 600w, https://ik.imagekit.io/demo/tr:w-600,h-600/medium_cafe_B1iTdD0C.jpg 800w">
+  <img srcset="https://ik.imagekit.io/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg, https://ik.imagekit.io/demo/tr:w-450,h-450/medium_cafe_B1iTdD0C.jpg 1.5x, https://ik.imagekit.io/demo/tr:w-600,h-600/medium_cafe_B1iTdD0C.jpg 2x">
+  <!--
+    A srcset in <source> does not trigger an error in aforementioned versions
+    as no checking is done for this tag (a good way to circumvent the check.)
+  -->
+  <picture>
+    <!--
+      This will cause build fail
+      [build] file:///astro/packages/astro/test/fixtures/astro-assets/src/pages/index.astro: could not find "/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg"
+    -->
+    <!-- <source srcset="/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg, /demo/tr:w-450,h-450/medium_cafe_B1iTdD0C.jpg 600w, /demo/tr:w-600,h-600/medium_cafe_B1iTdD0C.jpg 800w"> -->
+    <!--
+      This will pass
+    -->
+    <source srcset="https://ik.imagekit.io/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg, https://ik.imagekit.io/demo/tr:w-450,h-450/medium_cafe_B1iTdD0C.jpg 600w, https://ik.imagekit.io/demo/tr:w-600,h-600/medium_cafe_B1iTdD0C.jpg 800w">
+  </picture>
 </body>
 </html>


### PR DESCRIPTION
Utilised function from [srcset-parse](https://github.com/molefrog/srcset-parse) as couldn't find a way to integrate the package.


## Changes

- Improved functionality of `<img>` `srcset` checking as original failed when URL contained a comma ( `,` ).
- Added `srcset` checking for `<source>`

## Testing

- Added test to current assets test (`packages/astro/test/fixtures/astro-assets/src/pages/index.astro`) rather than create a separate one 

## Docs

Do not believe documentation need updating.
