### PR TITLE
Improve stats logging to use `pretty-bytes` so that 20B doesn't get o…

### DIFF
--- a/.changeset/tame-rabbits-behave.md
+++ b/.changeset/tame-rabbits-behave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve stats logging to use `pretty-bytes` so that 20B doesn't get output as 0kB, which is accurate, but confusing

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -85,6 +85,7 @@
     "picomatch": "^2.2.3",
     "postcss": "^8.2.15",
     "postcss-icss-keyframes": "^0.2.1",
+    "pretty-bytes": "^5.6.0",
     "prismjs": "^1.23.0",
     "resolve": "^1.20.0",
     "rollup": "^2.43.1",

--- a/packages/astro/src/build/stats.ts
+++ b/packages/astro/src/build/stats.ts
@@ -4,6 +4,7 @@ import type { LogOptions } from '../logger';
 import { info, table } from '../logger.js';
 import { underline, bold } from 'kleur/colors';
 import gzipSize from 'gzip-size';
+import prettyBytes from 'pretty-bytes';
 
 interface BundleStats {
   size: number;
@@ -85,8 +86,7 @@ export function logURLStats(logging: LogOptions, urlStats: URLStatsMap) {
         .get(url)
         ?.stats.map((s) => s.gzipSize)
         .reduce((a, b) => a + b, 0) || 0;
-    const kb = (bytes * 0.001).toFixed(2);
-    const sizePart = kb + ' kB';
+    const sizePart = prettyBytes(bytes, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
     log(info, urlPart, sizePart);
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8577,6 +8577,11 @@ prettier@^2.2.1, prettier@^2.3.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
+pretty-bytes@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
+  integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
+
 pretty-format@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"


### PR DESCRIPTION
…utput as 0kB, which is accurate, but confusing

## Changes

- `packages/astro/src/build/stats.ts`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I wasn't able to find any integration tests for the stats.. maybe there should be some? It looks like any URL that gets output as `/index.html` resolves to having a size of zero? I'd also like to add a fix to the bundlesize -> pagesize script :/

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
