### PR TITLE
Fix parsing of an empty literal `<pre></pre>` in markdown source

### DIFF
--- a/.changeset/four-plums-train.md
+++ b/.changeset/four-plums-train.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/markdown-support': patch
+---
+
+Fix parsing of an empty `<pre></pre>` tag in markdown files, which expected the pre tag to have a child

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -35,6 +35,17 @@ Markdown('Runs code blocks through syntax highlighter', async ({ runtime }) => {
   assert.ok($el.length > 0, 'There are child spans in code blocks');
 });
 
+Markdown('Empty code blocks do not fail', async ({ runtime }) => {
+  const result = await runtime.load('/empty-code');
+  assert.ok(!result.error, `build error: ${result.error}`);
+
+  const $ = doc(result.contents);
+  
+  const $el = $('pre');
+  assert.ok($el[0].children.length === 1, "There is not a `<code>` in the codeblock");
+  assert.ok($el[1].children.length === 0, "The empty `<pre>` failed to render");
+});
+
 Markdown('Scoped styles should not break syntax highlight', async ({ runtime }) => {
   const result = await runtime.load('/scopedStyles-code');
   assert.ok(!result.error, `build error: ${result.error}`);

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/empty-code.md
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/empty-code.md
@@ -1,0 +1,20 @@
+---
+title: My Blog Post
+layout: ../layouts/content.astro
+---
+
+## Title
+
+Hello world
+
+With this in the body ---
+
+## Another
+
+more content
+
+```
+
+```
+
+<pre></pre>

--- a/packages/markdown-support/src/codeblock.ts
+++ b/packages/markdown-support/src/codeblock.ts
@@ -35,6 +35,7 @@ export function rehypeCodeBlock() {
       }
 
       if (node.tagName !== 'pre') return;
+      if (!node.children[0]) return;
       const code = node.children[0];
       if (code.type !== 'element' || code.tagName !== 'code') return;
       node.properties = { ...code.properties };


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Added a test at `packages/astro/test/astro-markdown.test.js`, I felt like it belonged in markdown-support, but it looks like that package doesn't have testing setup..

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
