### PR TITLE
Fix `<script hoist src={Astro.resolve()}/>` not resolving. 

### DIFF
--- a/packages/astro/test/astro-scripts.test.js
+++ b/packages/astro/test/astro-scripts.test.js
@@ -16,8 +16,11 @@ Scripts('Moves external scripts up', async ({ runtime }) => {
   const html = result.contents;
 
   const $ = doc(html);
-  assert.equal($('head script[type="module"][data-astro="hoist"]').length, 2);
+  console.debug(result.contents)
+  assert.equal($('head script[type="module"][data-astro="hoist"]').length, 3);
+  assert.equal($(`script[src*='Astro.resolve(']`).length, 0, 'did not parse out `Astro.resolve` from `src`');
   assert.equal($('body script').length, 0);
+
 });
 
 Scripts('Moves inline scripts up', async ({ runtime }) => {
@@ -31,7 +34,7 @@ Scripts('Moves inline scripts up', async ({ runtime }) => {
   assert.equal($('body script').length, 0);
 });
 
-Scripts('Builds the scripts to a single bundle', async ({ build, readFile }) => {
+Scripts.only('Builds the scripts to a single bundle', async ({ build, readFile }) => {
   try {
     await build();
   } catch (err) {
@@ -52,7 +55,8 @@ Scripts('Builds the scripts to a single bundle', async ({ build, readFile }) => 
   /* External page */
   let external = await readFile('/external/index.html');
   $ = doc(external);
-  assert.equal($('script').length, 2, 'There are two scripts');
+  assert.equal($('script').length, 3, 'There are three scripts');
+  assert.equal($(`script[src*='Astro.resolve(']`).length, 0, 'did not parse out `Astro.resolve` from `src`');
   let el = $('script').get(1);
   entryURL = path.join('external', $(el).attr('src'));
   let externalEntryJS = await readFile(entryURL);

--- a/packages/astro/test/fixtures/astro-scripts/src/components/Widget3.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/components/Widget3.astro
@@ -1,0 +1,1 @@
+<script type="module" hoist src={Astro.resolve('../js/an_external_script_in_src.js')}/>

--- a/packages/astro/test/fixtures/astro-scripts/src/js/an_external_script_in_src.js
+++ b/packages/astro/test/fixtures/astro-scripts/src/js/an_external_script_in_src.js
@@ -1,0 +1,1 @@
+console.log('over here!');

--- a/packages/astro/test/fixtures/astro-scripts/src/pages/external.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/pages/external.astro
@@ -1,6 +1,7 @@
 ---
 import Widget from '../components/Widget.astro';
 import Widget2 from '../components/Widget2.astro';
+import Widget3 from '../components/Widget3.astro';
 ---
 
 <html lang="en">
@@ -15,5 +16,6 @@ import Widget2 from '../components/Widget2.astro';
   <Widget />
   <Widget />
   <Widget2 />
+  <Widget3 />
 </body>
 </html>


### PR DESCRIPTION
## Changes

- Fixes #1320

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Added a failing test to `astro-scripts.test.js` 

maybe it should be in `astro-globals.test.js` and `astro-globals-build.test.js`?

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

bug fix only