### PR TITLE
Fix typos in Netlify sponsorship announcement blog post

### DIFF
--- a/www/src/pages/blog/netlify-astro-hosting-sponsorship.astro
+++ b/www/src/pages/blog/netlify-astro-hosting-sponsorship.astro
@@ -10,7 +10,7 @@ import Shell from '../../components/Shell.astro';
 import { mediaQueries } from '../../config.js';
 
 let title = "Netlify Becomes Astro's Official Hosting Partner";
-let description = `We are happy to announce that Netlify has become Astro’s first corporate sponsor and exclusive hosting parter, donating $2,500 each month towards the ongoing open source maintenance and development of Astro.`;
+let description = `We are happy to announce that Netlify has become Astro’s first corporate sponsor and exclusive hosting partner, donating $2,500 each month towards the ongoing open source maintenance and development of Astro.`;
 let publishDate = 'Thursday, September 9 2021';
 let heroImage = '/assets/blog/astro-netlify-social.jpg';
 let lang = 'en';
@@ -32,7 +32,7 @@ let lang = 'en';
         <Markdown>
 
           We are thrilled to announce that [Netlify](https://www.netlify.com/?utm_campaign=devex-jl&utm_source=astro&utm_medium=blog
-          ) has become Astro's first corporate sponsor and official hosting parter, donating [$2,500 each month](https://opencollective.com/astrodotbuild) towards the ongoing open source maintenance and development of Astro.
+          ) has become Astro's first corporate sponsor and official hosting partner, donating [$2,500 each month](https://opencollective.com/astrodotbuild) towards the ongoing open source maintenance and development of Astro.
 
           Netlify is the company responsible for kicking off the modern [Jamstack](https://jamstack.org/) movement. Today, their hosting + serverless platform is loved by developers around the world. [Astro](http://astro.build/) can build you a blazing-fast website, but you'll always need a great host like Netlify to deliver that snappy experience to your users.
 
@@ -43,9 +43,9 @@ let lang = 'en';
             <br>-- [Jason Lengstorf](https://twitter.com/jlengstorf), VP of Developer Experience, Netlify
           </Note>
 
-          Astro is honored and excited to have Netlify as our first official corporate sponsor. We are grateful for the support of Jason Lengstorf, Cassidy Williams, and the entire Netlify team for their help and evangelism. It's because of support from companies like Netlify that we are able to recieve ongoing maintenance and keep developing Astro in an open, financially-sustainable way.
+          Astro is honored and excited to have Netlify as our first official corporate sponsor. We are grateful for the support of Jason Lengstorf, Cassidy Williams, and the entire Netlify team for their help and evangelism. It's because of support from companies like Netlify that we are able to receive ongoing maintenance and keep developing Astro in an open, financially-sustainable way.
 
-          Our first integration with Netlify we will be to add the ["Deploy with Netlify"](https://www.netlify.com/blog/2016/11/29/introducing-the-deploy-to-netlify-button/) button to our official Astro starter templates. This will make it even easier to create new, hosted Astro websites in just a few clicks. Check out all of our batteries-included starter templates in the brand new [Astro Theme Showcase.](https://docs.astro.build/themes)
+          Our first integration with Netlify will be to add the ["Deploy with Netlify"](https://www.netlify.com/blog/2016/11/29/introducing-the-deploy-to-netlify-button/) button to our official Astro starter templates. This will make it even easier to create new, hosted Astro websites in just a few clicks. Check out all of our batteries-included starter templates in the brand new [Astro Theme Showcase.](https://docs.astro.build/themes)
 
           Thanks, Netlify!
 


### PR DESCRIPTION
## Changes

- Fixing typos in the blog post announcing the Netlify sponsorship of Astro.

## Docs

Only typo fixes. No semantic or structural changes were made.

P.S.: Congrats on the funding. :smiley: 