### PR TITLE
Docs: Add READMEs for renderers

### DIFF
--- a/.changeset/blue-birds-pretend.md
+++ b/.changeset/blue-birds-pretend.md
@@ -1,0 +1,10 @@
+---
+'@astrojs/renderer-lit': patch
+'@astrojs/renderer-preact': patch
+'@astrojs/renderer-react': patch
+'@astrojs/renderer-solid': patch
+'@astrojs/renderer-svelte': patch
+'@astrojs/renderer-vue': patch
+---
+
+Update READMEs for all renderers

--- a/packages/renderers/README.md
+++ b/packages/renderers/README.md
@@ -1,0 +1,11 @@
+# Astro Renderers
+
+Astro is designed to support your favorite UI frameworks. [React][react], [Svelte][svelte], [Vue][vue], and [Preact][preact] are all built-in to Astro and supported out of the box. No configuration is needed to enable these.
+
+For adding additional frameworks (or your own custom one), please refer to [the full documentation][renderer-docs].
+
+[preact]: https://npm.im/@astrojs/renderer-preact
+[react]: https://npm.im/@astrojs/renderer-react
+[renderer-docs]: https://docs.astro.build/reference/renderer-reference
+[svelte]: https://npm.im/@astrojs/renderer-svelte
+[vue]: https://npm.im/@astrojs/renderer-vue

--- a/packages/renderers/renderer-lit/readme.md
+++ b/packages/renderers/renderer-lit/readme.md
@@ -78,3 +78,10 @@ import '../components/my-element.js';
 ```
 
 The above will only load the element's JavaScript when the user has scrolled it into view. Since it is server rendered they will not see any jank; it will load and hydrate transparently.
+
+## More Documentation
+
+[Astro Renderer Documentation][renderer-docs]
+
+[astro]: https://astro.build
+[renderer-docs]: https://docs.astro.build/reference/renderer-reference

--- a/packages/renderers/renderer-preact/README.md
+++ b/packages/renderers/renderer-preact/README.md
@@ -1,0 +1,31 @@
+# @astrojs/renderer-preact
+
+This is a plugin for [Astro][astro] apps that enables server-side rendering of Preact components.
+
+## Installation
+
+Install `@astrojs/renderer-preact` and then add it to your `astro.config.mjs` in the `renderers` property:
+
+```
+npm install @astrojs/renderer-preact
+```
+
+__astro.config.mjs__
+
+```js
+export default {
+  // ...
+
+  renderers: [
+    // ...
+    '@astrojs/renderer-preact'
+  ]
+}
+```
+
+## Documentation
+
+[Astro Renderer Documentation][renderer-docs]
+
+[astro]: https://astro.build
+[renderer-docs]: https://docs.astro.build/reference/renderer-reference

--- a/packages/renderers/renderer-react/README.md
+++ b/packages/renderers/renderer-react/README.md
@@ -1,0 +1,31 @@
+# @astrojs/renderer-react
+
+This is a plugin for [Astro][astro] apps that enables server-side rendering of React components.
+
+## Installation
+
+Install `@astrojs/renderer-react` and then add it to your `astro.config.mjs` in the `renderers` property:
+
+```
+npm install @astrojs/renderer-react
+```
+
+__astro.config.mjs__
+
+```js
+export default {
+  // ...
+
+  renderers: [
+    // ...
+    '@astrojs/renderer-react'
+  ]
+}
+```
+
+## Documentation
+
+[Astro Renderer Documentation][renderer-docs]
+
+[astro]: https://astro.build
+[renderer-docs]: https://docs.astro.build/reference/renderer-reference

--- a/packages/renderers/renderer-solid/README.md
+++ b/packages/renderers/renderer-solid/README.md
@@ -1,0 +1,31 @@
+# @astrojs/renderer-solid
+
+This is a plugin for [Astro][astro] apps that enables server-side rendering of SolidJS components.
+
+## Installation
+
+Install `@astrojs/renderer-solid` and then add it to your `astro.config.mjs` in the `renderers` property:
+
+```
+npm install @astrojs/renderer-solid
+```
+
+__astro.config.mjs__
+
+```js
+export default {
+  // ...
+
+  renderers: [
+    // ...
+    '@astrojs/renderer-solid'
+  ]
+}
+```
+
+## Documentation
+
+[Astro Renderer Documentation][renderer-docs]
+
+[astro]: https://astro.build
+[renderer-docs]: https://docs.astro.build/reference/renderer-reference

--- a/packages/renderers/renderer-svelte/README.md
+++ b/packages/renderers/renderer-svelte/README.md
@@ -1,0 +1,31 @@
+# @astrojs/renderer-svelte
+
+This is a plugin for [Astro][astro] apps that enables server-side rendering of Svelte components.
+
+## Installation
+
+Install `@astrojs/renderer-svelte` and then add it to your `astro.config.mjs` in the `renderers` property:
+
+```
+npm install @astrojs/renderer-svelte
+```
+
+__astro.config.mjs__
+
+```js
+export default {
+  // ...
+
+  renderers: [
+    // ...
+    '@astrojs/renderer-svelte'
+  ]
+}
+```
+
+## Documentation
+
+[Astro Renderer Documentation][renderer-docs]
+
+[astro]: https://astro.build
+[renderer-docs]: https://docs.astro.build/reference/renderer-reference

--- a/packages/renderers/renderer-vue/README.md
+++ b/packages/renderers/renderer-vue/README.md
@@ -1,0 +1,31 @@
+# @astrojs/renderer-vue
+
+This is a plugin for [Astro][astro] apps that enables server-side rendering of Vue 3.x components.
+
+## Installation
+
+Install `@astrojs/renderer-vue` and then add it to your `astro.config.mjs` in the `renderers` property:
+
+```
+npm install @astrojs/renderer-vue
+```
+
+__astro.config.mjs__
+
+```js
+export default {
+  // ...
+
+  renderers: [
+    // ...
+    '@astrojs/renderer-vue'
+  ]
+}
+```
+
+## Documentation
+
+[Astro Renderer Documentation][renderer-docs]
+
+[astro]: https://astro.build
+[renderer-docs]: https://docs.astro.build/reference/renderer-reference


### PR DESCRIPTION
## Changes

Just adds a stub in the `packages/renderers/` folder pointing to the full documentation, as well as stubs in the renderer packages themselves linking to the documentation.

Matthew wrote such good docs for renderer-lit! I didn’t do the same for the rest; just wanted to get these started.

## Testing

No tests needed.

## Docs

Docs change only.
