### PR TITLE
Disclaimer for Github pages / jekyll quirk

### DIFF
--- a/.changeset/serious-fishes-lay.md
+++ b/.changeset/serious-fishes-lay.md
@@ -1,0 +1,5 @@
+---
+'docs': patch
+---
+
+Github pages disclaimer

--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -32,7 +32,7 @@ By default, the build output will be placed at `dist/`. You may deploy this `dis
 ## GitHub Pages
 
 
-> By default, github pages will deny access to the `_astro/` directory, this will cause most Astro sites to break. To fix it yourself, you just have to add an empty `.nojekyll` file in the `public` folder of your site.    
+> By default, Github Pages will deny access to the `_astro/` directory, this will cause most Astro sites to break. To fix it yourself, you just have to add an empty `.nojekyll` file in the `public` folder of your site.    
 > If you are using any of the scripts provided below, this will **not** be an issue. 
 
 1. Set the correct `buildOptions.site` in `astro.config.mjs`.

--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -32,7 +32,8 @@ By default, the build output will be placed at `dist/`. You may deploy this `dis
 ## GitHub Pages
 
 
-> By default, github pages will deny access to the `_astro/` directory. Add an empty `.nojekyll` file in the `public` folder for your site to function properly.
+> By default, github pages will deny access to the `_astro/` directory, this will cause most Astro sites to break. To fix it yourself, you just have to add an empty `.nojekyll` file in the `public` folder of your site.    
+> If you are using any of the scripts provided below, this will **not** be an issue. 
 
 1. Set the correct `buildOptions.site` in `astro.config.mjs`.
 1. Inside your project, create `deploy.sh` with the following content (uncommenting the appropriate lines), and run it to deploy:

--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -31,6 +31,9 @@ By default, the build output will be placed at `dist/`. You may deploy this `dis
 
 ## GitHub Pages
 
+
+> By default, github pages will deny access to the `_astro/` directory. Add an empty `.nojekyll` file in the `public` folder for your site to function properly.
+
 1. Set the correct `buildOptions.site` in `astro.config.mjs`.
 1. Inside your project, create `deploy.sh` with the following content (uncommenting the appropriate lines), and run it to deploy:
 

--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -31,9 +31,7 @@ By default, the build output will be placed at `dist/`. You may deploy this `dis
 
 ## GitHub Pages
 
-
-> By default, Github Pages will deny access to the `_astro/` directory, this will cause most Astro sites to break. To fix it yourself, you just have to add an empty `.nojekyll` file in the `public` folder of your site.    
-> If you are using any of the scripts provided below, this will **not** be an issue. 
+> **Warning:** By default, Github Pages will break the `_astro/` directory of your deployed website. To disable this behavior and fix your this issue, make sure that you use the `deploy.sh` script below or manually add an empty `.nojekyll` file to your `public/` site directory.
 
 1. Set the correct `buildOptions.site` in `astro.config.mjs`.
 1. Inside your project, create `deploy.sh` with the following content (uncommenting the appropriate lines), and run it to deploy:


### PR DESCRIPTION
## Changes

- Adds a disclaimer+workaround to Github pages deploy guide
  - > By default, github pages will deny access to the `_astro/` directory. Add an empty `.nojekyll` file in the `public` folder for your site to function properly.
  - Am open to feedback about rewording/reformattimg the disclaimer

References:
https://discord.com/channels/830184174198718474/887002135403827240/ (help thread where this came up)
https://github.com/mpetrovich/stylemark/issues/65 (another issue with the fix)

## Testing
No testing, only docs changed.

## Docs
Documentation updated
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
