### PR TITLE
fix outdated lockfile issue

### DIFF
--- a/.github/workflows/stat.yml
+++ b/.github/workflows/stat.yml
@@ -18,9 +18,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           version: 14
-      - run: npm install @octokit/action
-      # Node.js script can be anywhere. A good convention is to put local GitHub Actions
-      # into the `.github/actions` folder
+      - run: yarn install --frozen-lockfile --ignore-engines --ignore-scripts
       - run: node scripts/stats/index.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- We tried to do an npm install instead of a yarn install to speed it up
- npm decided to change our package.json, and then we would commit that change, causing the yarn.lock file to be outdated
- See example: https://github.com/snowpackjs/astro/commit/e758060e3bdf0a0a17188d6bb30b4371690c855a