### PR TITLE
Update deployment docs for Netlify deployment

### DIFF
--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -182,12 +182,13 @@ jobs:
 
 ## Netlify
 
-You can configure your deploy in two ways, via the Netlify website or with the `netlify.toml` file.
+**Note:** If you are using an older [build image](https://docs.netlify.com/configure-builds/get-started/#build-image-selection) on Netlify, make sure that you set your Node.js version in either a [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file (example: `node v14.17.6`) or a `NODE_VERSION` environment variable. This step is no longer required by default.
 
-## `netlify.toml` file
+You can configure your deployment in two ways, via the Netlify website or with a local project `netlify.toml` file.
 
+### `netlify.toml` file
 
-Create a new `netlify.toml` file it at the top level of your project repository with the following settings:
+Create a new `netlify.toml` file at the top level of your project repository with the following settings:
 
 ```toml
 [build]
@@ -195,17 +196,14 @@ Create a new `netlify.toml` file it at the top level of your project repository 
   publish = "dist"
 ```
 
-Push the new `netlify.toml` file up to to your hosted git repository. Then, set up a new project on [Netlify](https://netlify.com) using you project repo.
+Push the new `netlify.toml` file up to your hosted git repository. Then, set up a new project on [Netlify](https://netlify.com) using you project repo. Netlify will read this file and automatically configure your deployment.
 
-## Netlify Website UI
+### Netlify Website UI
 
-You can skip the `netlify.toml` file and go directly to [Netlify](https://netlify.com) to configure your project. Netlify should now detect Astro projects automatically and pre-fill the configuration for you. Make sure that the the following settings are entered before hitting the "Deploy" button:
+You can skip the `netlify.toml` file and go directly to [Netlify](https://netlify.com) to configure your project. Netlify should now detect Astro projects automatically and pre-fill the configuration for you. Make sure that the following settings are entered before hitting the "Deploy" button:
 
 - **Build Command:** `astro build` or `npm run build`
 - **Publish directory:** `dist`
-
-**Note:** If using an older build image, make sure that you have a [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file with `node v14.15.1` in it. This step is no longer required by default.
-
 
 ## Google Firebase
 

--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -184,9 +184,10 @@ jobs:
 
 You can configure your deploy in two ways, via the Netlify website or with the `netlify.toml` file.
 
-Note: If you are using [an older build image](https://docs.netlify.com/configure-builds/get-started/#build-image-selection), make sure you have a [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file with Node `v14.15.1` in it at the top level of your codebase. If you use the default build image, you don't need to include this.
+## `netlify.toml` file
 
-With the `netlify.toml` file, add it at the top level of your project with the following settings:
+
+Create a new `netlify.toml` file it at the top level of your project repository with the following settings:
 
 ```toml
 [build]
@@ -194,14 +195,17 @@ With the `netlify.toml` file, add it at the top level of your project with the f
   publish = "dist"
 ```
 
-Then, set up a new project on [Netlify](https://netlify.com) from your chosen Git provider.
+Push the new `netlify.toml` file up to to your hosted git repository. Then, set up a new project on [Netlify](https://netlify.com) using you project repo.
 
-If you don't want to use the `netlify.toml`, when you go to [Netlify](https://netlify.com) and set up a new project from Git, input the following settings:
+## Netlify Website UI
+
+You can skip the `netlify.toml` file and go directly to [Netlify](https://netlify.com) to configure your project. Netlify should now detect Astro projects automatically and pre-fill the configuration for you. Make sure that the the following settings are entered before hitting the "Deploy" button:
 
 - **Build Command:** `astro build` or `npm run build`
 - **Publish directory:** `dist`
 
-Then hit the deploy button.
+**Note:** If using an older build image, make sure that you have a [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file with `node v14.15.1` in it. This step is no longer required by default.
+
 
 ## Google Firebase
 

--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -196,7 +196,7 @@ Create a new `netlify.toml` file at the top level of your project repository wit
   publish = "dist"
 ```
 
-Push the new `netlify.toml` file up to your hosted git repository. Then, set up a new project on [Netlify](https://netlify.com) using you project repo. Netlify will read this file and automatically configure your deployment.
+Push the new `netlify.toml` file up to your hosted git repository. Then, set up a new project on [Netlify](https://netlify.com) for your git repository. Netlify will read this file and automatically configure your deployment.
 
 ### Netlify Website UI
 

--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -184,6 +184,8 @@ jobs:
 
 You can configure your deploy in two ways, via the Netlify website or with the `netlify.toml` file.
 
+Note: If you are using [an older build image](https://docs.netlify.com/configure-builds/get-started/#build-image-selection), make sure you have a [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file with Node `v14.15.1` in it at the top level of your codebase. If you use the default build image, you don't need to include this.
+
 With the `netlify.toml` file, add it at the top level of your project with the following settings:
 
 ```toml
@@ -200,8 +202,6 @@ If you don't want to use the `netlify.toml`, when you go to [Netlify](https://ne
 - **Publish directory:** `dist`
 
 Then hit the deploy button.
-
-In your codebase, make sure you have a [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file with `node v14.15.1` in it if you are using [an older build image](https://docs.netlify.com/configure-builds/get-started/#build-image-selection). By default, you don't need to include this.
 
 ## Google Firebase
 

--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -182,8 +182,6 @@ jobs:
 
 ## Netlify
 
-In your codebase, make sure you have a [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file with `node v14.15.1` in it.
-
 You can configure your deploy in two ways, via the Netlify website or with the `netlify.toml` file.
 
 With the `netlify.toml` file, add it at the top level of your project with the following settings:
@@ -202,6 +200,8 @@ If you don't want to use the `netlify.toml`, when you go to [Netlify](https://ne
 - **Publish directory:** `dist`
 
 Then hit the deploy button.
+
+In your codebase, make sure you have a [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file with `node v14.15.1` in it if you are using [an older build image](https://docs.netlify.com/configure-builds/get-started/#build-image-selection). By default, you don't need to include this.
 
 ## Google Firebase
 


### PR DESCRIPTION
## Changes

Changing directions for Netlify deployment! Details below.

## Testing

N/A

## Docs

Changing directions for Netlify deployment because of their [new build image](https://answers.netlify.com/t/all-new-sites-now-build-on-netlify-using-the-new-focal-build-image/42665), which uses Node 16 by default.