### PR TITLE
Expose slots to components

### DIFF
--- a/.changeset/pink-toes-shake.md
+++ b/.changeset/pink-toes-shake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Expose slots to components

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -55,8 +55,8 @@ const data = Astro.fetchContent('../pages/post/*.md'); // returns an array of po
 
 ```js
 const {
-  heading as headingSlot, // content wrapped in elements with a `[slot="heading"]` attribute (`<* slot="heading">`)
-  default as defaultSlot, // content wrapped in elements with a `[slot]` attribute (`<* slot=*>`)
+  heading as headingSlot, // true or undefined, based on whether `<* slot="heading">` was used.
+  default as defaultSlot, // true or undefined, based on whether `<* slot>` or `<* default>` was used.
 } = Astro.slots;
 ```
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -49,6 +49,17 @@ const data = Astro.fetchContent('../pages/post/*.md'); // returns an array of po
   }[]
 ```
 
+### `Astro.slots`
+
+`Astro.slots` returns an object with any slotted regions passed into the current Astro file.
+
+```js
+const {
+  heading as headingSlot, // content wrapped in elements with a `[slot="heading"]` attribute (`<* slot="heading">`)
+  default as defaultSlot, // content wrapped in elements with a `[slot]` attribute (`<* slot=*>`)
+} = Astro.slots;
+```
+
 ### `Astro.request`
 
 `Astro.request` returns an object with the following properties:

--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -86,6 +86,17 @@ const path = Astro.site.pathname;
 <h1>Welcome to {path}</h1>
 ```
 
+### `Astro.slots`
+
+`Astro.slots` returns an object with any slotted regions passed into the current Astro file.
+
+```js
+const {
+  heading as headingSlot, // content wrapped in elements with a `[slot="heading"]` attribute (`<* slot="heading">`)
+  default as defaultSlot, // content wrapped in elements with a `[slot]` attribute (`<* slot=*>`)
+} = Astro.slots;
+```
+
 ## `getStaticPaths()`
 
 If a page uses dynamic params in the filename, that component will need to export a `getStaticPaths()` function.

--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -92,8 +92,8 @@ const path = Astro.site.pathname;
 
 ```js
 const {
-  heading as headingSlot, // content wrapped in elements with a `[slot="heading"]` attribute (`<* slot="heading">`)
-  default as defaultSlot, // content wrapped in elements with a `[slot]` attribute (`<* slot=*>`)
+  heading as headingSlot, // true or undefined, based on whether `<* slot="heading">` was used.
+  default as defaultSlot, // true or undefined, based on whether `<* slot>` or `<* default>` was used.
 } = Astro.slots;
 ```
 

--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -167,7 +167,12 @@ async function __render(props, ...children) {
     },
     slots: {
       value: children.reduce(
-        (slots, child) => Object.assign(slots, child.$slots),
+        (slots, child) => {
+          for (let name in child.$slots) {
+            slots[name] = true
+          }
+          return slots
+        },
         {}
       ),
       enumerable: true

--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -158,10 +158,18 @@ import { __astro_hoisted_scripts } from 'astro/dist/internal/__astro_hoisted_scr
 const __astroScripts = __astro_hoisted_scripts([${result.components.map((n) => `typeof ${n} !== 'undefined' && ${n}`)}], ${JSON.stringify(result.hoistedScripts)});
 const __astroInternal = Symbol('astro.internal');
 const __astroContext = Symbol.for('astro.context');
+const __astroSlotted = Symbol.for('astro.slotted');
 async function __render(props, ...children) {
   const Astro = Object.create(__TopLevelAstro, {
     props: {
       value: props,
+      enumerable: true
+    },
+    slots: {
+      value: children.reduce(
+        (slots, child) => Object.assign(slots, child.$slots),
+        {}
+      ),
       enumerable: true
     },
     pageCSS: {

--- a/packages/astro/src/compiler/index.ts
+++ b/packages/astro/src/compiler/index.ts
@@ -169,7 +169,7 @@ async function __render(props, ...children) {
       value: children.reduce(
         (slots, child) => {
           for (let name in child.$slots) {
-            slots[name] = true
+            slots[name] = Boolean(child.$slots[name])
           }
           return slots
         },

--- a/packages/astro/test/astro-slots.test.js
+++ b/packages/astro/test/astro-slots.test.js
@@ -74,4 +74,42 @@ Slots('Slots work on Components', async ({ runtime }) => {
   assert.equal($('#default').children('astro-component').length, 1, 'Slotted component into default slot');
 });
 
+Slots('Slots API work on Components', async ({ runtime }) => {
+  // IDs will exist whether the slots are filled or not
+  {
+    const result = await runtime.load('/slottedapi-default');
+    assert.ok(!result.error, `build error: ${result.error}`);
+
+    const $ = doc(result.contents);
+
+    assert.equal($('#a').length, 1);
+    assert.equal($('#b').length, 1);
+    assert.equal($('#c').length, 1);
+  }
+
+  // IDs will not exist because the slots are not filled
+  {
+    const result = await runtime.load('/slottedapi-empty');
+    assert.ok(!result.error, `build error: ${result.error}`);
+
+    const $ = doc(result.contents);
+
+    assert.equal($('#a').length, 0);
+    assert.equal($('#b').length, 0);
+    assert.equal($('#c').length, 0);
+  }
+
+  // IDs will exist because the slots are filled
+  {
+    const result = await runtime.load('/slottedapi-filled');
+    assert.ok(!result.error, `build error: ${result.error}`);
+
+    const $ = doc(result.contents);
+
+    assert.equal($('#a').length, 1);
+    assert.equal($('#b').length, 1);
+    assert.equal($('#c').length, 1);
+  }
+});
+
 Slots.run();

--- a/packages/astro/test/astro-slots.test.js
+++ b/packages/astro/test/astro-slots.test.js
@@ -85,6 +85,7 @@ Slots('Slots API work on Components', async ({ runtime }) => {
     assert.equal($('#a').length, 1);
     assert.equal($('#b').length, 1);
     assert.equal($('#c').length, 1);
+    assert.equal($('#default').length, 1);
   }
 
   // IDs will not exist because the slots are not filled
@@ -97,6 +98,7 @@ Slots('Slots API work on Components', async ({ runtime }) => {
     assert.equal($('#a').length, 0);
     assert.equal($('#b').length, 0);
     assert.equal($('#c').length, 0);
+    assert.equal($('#default').length, 0);
   }
 
   // IDs will exist because the slots are filled
@@ -109,6 +111,22 @@ Slots('Slots API work on Components', async ({ runtime }) => {
     assert.equal($('#a').length, 1);
     assert.equal($('#b').length, 1);
     assert.equal($('#c').length, 1);
+
+    assert.equal($('#default').length, 0); // the default slot is not filled
+  }
+
+  // Default ID will exist because the default slot is filled
+  {
+    const result = await runtime.load('/slottedapi-default-filled');
+    assert.ok(!result.error, `build error: ${result.error}`);
+
+    const $ = doc(result.contents);
+
+    assert.equal($('#a').length, 0);
+    assert.equal($('#b').length, 0);
+    assert.equal($('#c').length, 0);
+
+    assert.equal($('#default').length, 1); // the default slot is filled
   }
 });
 

--- a/packages/astro/test/fixtures/astro-slots/src/components/SlottedAPI.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/components/SlottedAPI.astro
@@ -1,0 +1,11 @@
+{Astro.slots.a && <div id="a">
+  <slot name="a" />
+</div>}
+
+{Astro.slots.b && <div id="b">
+  <slot name="b" />
+</div>}
+
+{Astro.slots.c && <div id="c">
+  <slot name="c" />
+</div>}

--- a/packages/astro/test/fixtures/astro-slots/src/components/SlottedAPI.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/components/SlottedAPI.astro
@@ -9,3 +9,7 @@
 {Astro.slots.c && <div id="c">
   <slot name="c" />
 </div>}
+
+{Astro.slots.default && <div id="default">
+  <slot />
+</div>}

--- a/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-default-filled.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-default-filled.astro
@@ -1,0 +1,15 @@
+---
+import Slotted from '../components/SlottedAPI.astro';
+---
+
+<html>
+  <head>
+    <!-- Test Astro.slots behavior. -->
+    <!-- IDs will exist because the slots are filled -->
+  </head>
+  <body>
+    <Slotted>
+      Default
+    </Slotted>
+  </body>
+</html>

--- a/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-default.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-default.astro
@@ -1,0 +1,13 @@
+---
+import Slotted from '../components/Slotted.astro';
+---
+
+<html>
+  <head>
+    <!-- Test default slots behavior. -->
+    <!-- IDs will exist whether the slots are filled or not -->
+  </head>
+  <body>
+    <Slotted />
+  </body>
+</html>

--- a/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-empty.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-empty.astro
@@ -1,0 +1,13 @@
+---
+import Slotted from '../components/SlottedAPI.astro';
+---
+
+<html>
+  <head>
+    <!-- Test Astro.slots behavior. -->
+    <!-- IDs will not exist because the slots are not filled -->
+  </head>
+  <body>
+    <Slotted />
+  </body>
+</html>

--- a/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-filled.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-filled.astro
@@ -1,0 +1,17 @@
+---
+import Slotted from '../components/SlottedAPI.astro';
+---
+
+<html>
+  <head>
+    <!-- Test Astro.slots behavior. -->
+    <!-- IDs will exist because the slots are filled -->
+  </head>
+  <body>
+    <Slotted>
+      <span slot="a">A</span>
+      <span slot="b">B</span>
+      <span slot="c">C</span>
+    </Slotted>
+  </body>
+</html>


### PR DESCRIPTION
## Changes

This adds the ability to check whether specific slots have been used in a component via `Astro.slots`, similar to `Astro.props`.

This fulfills the approved RFC #1301.

## Testing

Tests were added to confirm the default slots behavior as well as the new `Astro.slots` functionality.

## Docs

Documentation with example usage of `Astro.slots` is added to the **API Reference** section.