### PR TITLE
Make build stats prettier

### DIFF
--- a/.changeset/five-phones-draw.md
+++ b/.changeset/five-phones-draw.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix pretty byte output in build stats

--- a/packages/astro/src/build/stats.ts
+++ b/packages/astro/src/build/stats.ts
@@ -86,7 +86,7 @@ export function logURLStats(logging: LogOptions, urlStats: URLStatsMap) {
         .get(url)
         ?.stats.map((s) => s.gzipSize)
         .reduce((a, b) => a + b, 0) || 0;
-    const sizePart = prettyBytes(bytes, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    const sizePart = prettyBytes(bytes);
     log(info, urlPart, sizePart);
   });
 }


### PR DESCRIPTION
## Changes

- 13b instead of 0kb, if the number is small
- 13Mb instead of 13949kb, if the number is large

## Testing

- Not output tests currently

## Docs

- None needed