### PR TITLE
📘 DOC: show how to pass props

### DIFF
--- a/docs/src/pages/core-concepts/astro-components.md
+++ b/docs/src/pages/core-concepts/astro-components.md
@@ -184,6 +184,15 @@ const { greeting = 'Hello', name } = Astro.props;
 </div>
 ```
 
+You can then pass the component props like this:
+
+```astro
+---
+let firstName = "world!"
+---
+<SomeComponent name={firstName}/>
+```
+
 ### Slots
 
 `.astro` files use the [`<slot>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot) tag to enable component composition. Coming from React or Preact, this is the same concept as `children`. You can think of the `<slot>` element as a placeholder for markup which will be passed in from outside of the component.

--- a/docs/src/pages/core-concepts/astro-components.md
+++ b/docs/src/pages/core-concepts/astro-components.md
@@ -188,7 +188,9 @@ You can then pass the component props like this:
 
 ```astro
 ---
-let firstName = "world!"
+// SomeOtherComponent.astro
+import SomeComponent from "./SomeComponent.astro";
+let firstName = "world!";
 ---
 <SomeComponent name={firstName}/>
 ```


### PR DESCRIPTION
In the current documentation it is only shown how to receive props but not how to pass a component said props.


## Changes

This adds a bit of example code which shows how to pass props to a component.

## Testing

No tests needed.

## Docs

The change was for the documentation.
