### PR TITLE
Build pages in series to avoid excess open file handles

### DIFF
--- a/packages/astro/src/build.ts
+++ b/packages/astro/src/build.ts
@@ -212,16 +212,19 @@ ${stack}
 
     // write to disk and free up memory
     timer.write = performance.now();
-    await Promise.all(
-      Object.keys(buildState).map(async (id) => {
-        const outPath = new URL(`.${id}`, astroConfig.dist);
-        const parentDir = path.dirname(fileURLToPath(outPath));
-        await fs.promises.mkdir(parentDir, { recursive: true });
-        await fs.promises.writeFile(outPath, buildState[id].contents, buildState[id].encoding);
-        delete buildState[id];
-        delete depTree[id];
-      })
-    );
+    for (const id of Object.keys(buildState)) {
+      const outPath = new URL(`.${id}`, astroConfig.dist);
+      const parentDir = path.dirname(fileURLToPath(outPath));
+      const handle = await fs.promises.open(outPath, "w")
+      await fs.promises.mkdir(parentDir, {recursive: true});
+      await fs.promises.writeFile(handle, buildState[id].contents, buildState[id].encoding);
+
+      // Ensure the file handle is not left hanging
+      await handle.close();
+
+      delete buildState[id];
+      delete depTree[id];
+    };
     debug(logging, 'build', `wrote files to disk [${stopTimer(timer.write)}]`);
 
     /**


### PR DESCRIPTION
## Changes

- Changes the parallel pages build to run in series instead (it used Promise.all() which didn't close handles soon enough for each async job)
- Only one file is being written at a time
- The file handle is freed after one page has been created so there are no dangling handles

## Testing

NOTE: Tested only on Node14 on Windows, seems like the CI tests fail so sorry!

The previously failing build process was fixed and it does not fail when creating 10000 pages ([see the example repo](https://github.com/kometbomb/astro-file-handle-bug)). `yarn test` completed successfully in the astro repo.

It might be tricky to write a test to check the error doesn't reappear due to environment differences in maximum simultaneous open files.

## Docs

No changes to documentation.