### PR TITLE
Change publishDate to published_at

### DIFF
--- a/examples/portfolio/src/pages/projects.astro
+++ b/examples/portfolio/src/pages/projects.astro
@@ -5,12 +5,12 @@ import Nav from '../components/Nav/index.jsx';
 import PortfolioPreview from '../components/PortfolioPreview/index.jsx';
 
 interface MarkdownFrontmatter {
-  publishDate: number;
+  published_at: number;
 }
 
 const projects = Astro.fetchContent<MarkdownFrontmatter>('./project/*.md')
-  .filter(({ publishDate }) => !!publishDate)
-  .sort((a, b) => new Date(b.publishDate).valueOf() - new Date(a.publishDate).valueOf());
+  .filter(({ published_at }) => !!published_at)
+  .sort((a, b) => new Date(b.published_at).valueOf() - new Date(a.published_at).valueOf());
 ---
 
 <html lang="en">

--- a/examples/portfolio/src/pages/projects.astro
+++ b/examples/portfolio/src/pages/projects.astro
@@ -8,7 +8,7 @@ interface MarkdownFrontmatter {
   published_at: number;
 }
 
-const projects = Astro.fetchContent<MarkdownFrontmatter>('./project/*.md')
+const projects = Astro.fetchContent<MarkdownFrontmatter>('./project/**/*.md')
   .filter(({ published_at }) => !!published_at)
   .sort((a, b) => new Date(b.published_at).valueOf() - new Date(a.published_at).valueOf());
 ---


### PR DESCRIPTION
In the blog posts, `published_at` is the only field!

## Changes

- Reads the correct front matter field

## Testing
![image](https://user-images.githubusercontent.com/30219253/133906922-520f7e6c-b5c9-4ac4-b6b9-8d3b3773def6.png)


After this change, both the `mars-rover` and `lunar-eclipse` project shows up!

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

bug fix only!

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
