### PR TITLE
Copy files starting with `.` in `public/`

### DIFF
--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -296,7 +296,7 @@ async function createSnowpack(astroConfig: AstroConfig, options: CreateSnowpackO
   };
 
   const mountOptions = {
-    ...(existsSync(astroConfig.public) ? { [fileURLToPath(astroConfig.public)]: { url: '/', static: true, resolve: false } } : {}),
+    ...(existsSync(astroConfig.public) ? { [fileURLToPath(astroConfig.public)]: { url: '/', static: true, resolve: false, dot: true } } : {}),
     [fileURLToPath(frontendPath)]: '/_astro_frontend',
     [fileURLToPath(src)]: '/_astro/src', // must be last (greediest)
   };


### PR DESCRIPTION
## Changes

Users have reported that files starting with `.` like `.nojekyll` were not being copied over. Turns out we never set the [`mount.dot`](https://www.snowpack.dev/reference/configuration#mount) option to true!

## Testing

Manually tested

## Docs

Bug fix only
