### PR TITLE
update code to match description

### DIFF
--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -166,7 +166,7 @@ As of [version 0.20.0](https://github.com/snowpackjs/astro/releases/tag/astro%40
 ```astro
   <link
     rel="stylesheet"
-    href={Astro.resolve("../assets/global.css")}
+    href={Astro.resolve("../styles/global.css")}
   >
 ```
 


### PR DESCRIPTION
## Changes

Updating tailwind code example to match description.

## Testing

N/A documentation change only.


## Docs

Breaking change 0.19 to 0.20 documentation references `src` as the proper path but the code example below it uses `assets`. Updated the code to match the documentation.
