### PR TITLE
Fix CI release on merge to next

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -19,7 +19,10 @@ jobs:
       - # 2. discard examples/docs/www changes (just in case)
         run: git checkout -- examples/ docs/ www/
       - # 3: use compiler--next renderers (but don’t commit)
-        run: cd packages/astro && yarn add @astrojs/renderer-preact@next--compiler @astrojs/renderer-react@next--compiler @astrojs/renderer-svelte@next--compiler @astrojs/renderer-vue@next--compiler && cd ../..
+        run: |
+          cd packages/astro
+          yarn add @astrojs/renderer-preact@next--compiler @astrojs/renderer-react@next--compiler @astrojs/renderer-svelte@next--compiler @astrojs/renderer-vue@next--compiler
+          cd ../..
       - # 4: auth
         run: echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN  }}' > ${{ github.workspace }}/.npmrc
       - # 5: publish!

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -47,7 +47,7 @@
     "@astrojs/renderer-svelte": "^0.1.2",
     "@astrojs/renderer-vue": "^0.1.8",
     "@babel/core": "^7.15.5",
-    "@web/rollup-plugin-html": "^1.9.1",
+    "@web/rollup-plugin-html": "^1.10.1",
     "astring": "^1.7.5",
     "cheerio": "^1.0.0-rc.10",
     "ci-info": "^3.2.0",

--- a/packages/astro/src/build/index.ts
+++ b/packages/astro/src/build/index.ts
@@ -131,7 +131,7 @@ class AstroBuilder {
         rollupPluginHTML({
           input,
           extractAssets: false,
-        }),
+        }) as any, // CI fix: ignore typing of this plugin
         ...(viteConfig.plugins || []),
       ],
       publicDir: viteConfig.publicDir,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2082,7 +2082,7 @@
     "@types/parse5" "^6.0.1"
     parse5 "^6.0.1"
 
-"@web/rollup-plugin-html@^1.9.1":
+"@web/rollup-plugin-html@^1.10.1":
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/@web/rollup-plugin-html/-/rollup-plugin-html-1.10.1.tgz#7995d3aff436f6b5c1a365830a9ff525388b40d8"
   integrity sha512-XYJxHtdllwA5l4X8wh8CailrOykOl3YY+BRqO8+wS/I1Kq0JFISg3EUHdWAyVcw0TRDnHNLbOBJTm2ptAM+eog==


### PR DESCRIPTION
## Changes

On merge to `next`, a GitHub action publishes a snapshot release. Something about the `yarn` command in that context installs a slightly-different version of Rollup, or TypeScript, or something. Because there’s a type error about `@web/rollup-plugin-html` that prevented a CI build.

## Testing

(can be tested on merge to `next`)

## Docs

no docs necessary