### PR TITLE
Proposal: Use astro-seo in docs example

### DIFF
--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -9,11 +9,12 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "@docsearch/react": "^1.0.0-alpha.27"
+    "@docsearch/react": "^1.0.0-alpha.27",
+    "astro-seo": "^0.3.10"
   },
   "devDependencies": {
-    "astro": "^0.20.7",
-    "@snowpack/plugin-dotenv": "^2.1.0"
+    "@snowpack/plugin-dotenv": "^2.1.0",
+    "astro": "^0.20.7"
   },
   "snowpack": {
     "alias": {

--- a/examples/docs/src/components/HeadSEO.astro
+++ b/examples/docs/src/components/HeadSEO.astro
@@ -1,5 +1,6 @@
 ---
 import {SITE, OPEN_GRAPH} from '../config.ts';
+import { SEO } from 'astro-seo';
 export interface Props {
   content: any,
   site: any,
@@ -11,26 +12,29 @@ const imageSrc = content?.image?.src ?? OPEN_GRAPH.image.src;
 const canonicalImageSrc = new URL(imageSrc, Astro.site);
 const imageAlt = content?.image?.alt ?? OPEN_GRAPH.image.alt;
 ---
-<!-- Page Metadata -->
-<link rel="canonical" href={canonicalURL}/>
-
-<!-- OpenGraph Tags -->
-<meta property="og:title" content={formattedContentTitle}/>
-<meta property="og:type" content="article"/>
-<meta property="og:url" content={canonicalURL}/>
-<meta property="og:locale" content={content.ogLocale ?? SITE.defaultLanguage}/>
-<meta property="og:image" content={canonicalImageSrc}/>
-<meta property="og:image:alt" content={imageAlt}/>
-<meta property="og:description" content={content.description ? content.description : SITE.description}/>
-<meta property="og:site_name" content={SITE.title}/>
-
-<!-- Twitter Tags -->
-<meta name="twitter:card" content="summary_large_image"/>
-<meta name="twitter:site" content={OPEN_GRAPH.twitter}/>
-<meta name="twitter:title" content={formattedContentTitle}/>
-<meta name="twitter:description" content={content.description ? content.description : SITE.description}/>
-<meta name="twitter:image" content={canonicalImageSrc}/>
-<meta name="twitter:image:alt" content={imageAlt}/>
+<SEO 
+  canonical={canonicalURL}
+  openGraph={{
+    basic: {
+      title: formattedContentTitle,
+      type: "article",
+      image: canonicalImageSrc,
+      url: canonicalURL
+    },
+    optional: {
+      description: {content.description ? content.description : SITE.description},
+      locale: {content.ogLocale ?? SITE.defaultLanguage},
+      siteName: {SITE.title},
+    },
+    image: {
+      alt: imageAlt
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: {OPEN_GRAPH.twitter}
+    }
+  }}
+/>
 
 <!-- 
   TODO: Add json+ld data, maybe https://schema.org/APIReference makes sense? 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2548,6 +2548,11 @@ astring@^1.7.4:
   resolved "https://registry.yarnpkg.com/astring/-/astring-1.7.5.tgz#a7d47fceaf32b052d33a3d07c511efeec67447ca"
   integrity sha512-lobf6RWXb8c4uZ7Mdq0U12efYmpD1UFnyOWVJPTa3ukqZrMopav+2hdNu0hgBF0JIBFK9QgrBDfwYvh3DFJDAA==
 
+astro-seo@^0.3.10:
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/astro-seo/-/astro-seo-0.3.10.tgz#aedc53e445f100b8d2a114e3fefecea30b82401b"
+  integrity sha512-Sz1SrfBKGqAPvQ1gVTL3JW/rMyjBGGwdK7c4p/vJ9bRawqAgrv0tNLXsjaShTkQANiVLu+xH+6EMUQUfBf9Zaw==
+
 async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"


### PR DESCRIPTION
## Changes

Hey, this PR is a proposal to use Astro SEO in the HeadSEO component of the docs example. Especially since the comments in the HeadSEO component sound like there are plans to implement a lot of the stuff I'm planning for Astro SEO as well, I thought it might make sense to centralize these efforts across the ecosystem. Though I'd understand if you would like to keep dependencies to a minimum as well.

## Testing

## Docs

