### PR TITLE
Update /examples/docs/.../MoreMenu.astro

### DIFF
--- a/examples/docs/src/components/RightSidebar/MoreMenu.astro
+++ b/examples/docs/src/components/RightSidebar/MoreMenu.astro
@@ -40,7 +40,7 @@ const showMoreSection = (CONFIG.COMMUNITY_INVITE_URL || editHref);
   }
   {CONFIG.COMMUNITY_INVITE_URL && 
     <li class={`header-link depth-2`}>
-      <a href="https://astro.build/chat" target="_blank">
+      <a href={CONFIG.COMMUNITY_INVITE_URL} target="_blank">
         <svg
           aria-hidden="true"
           focusable="false"


### PR DESCRIPTION
## Changes

- Fixes the community link in examples/docs to actually use `CONFIG.COMMUNITY_INVITE_URL`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
