### PR TITLE
Fix URL to "starter templates" link

### DIFF
--- a/docs/src/pages/installation.md
+++ b/docs/src/pages/installation.md
@@ -25,7 +25,7 @@ npm init astro
 yarn create astro
 ```
 
-[`create-astro`](https://github.com/snowpackjs/astro/tree/main/packages/create-astro) wizard lets you choose from a set of [starter templates](/examples) or alternatively, you could import your own Astro project directly from GitHub.
+[`create-astro`](https://github.com/snowpackjs/astro/tree/main/packages/create-astro) wizard lets you choose from a set of [starter templates](https://github.com/snowpackjs/astro/tree/main/examples) or alternatively, you could import your own Astro project directly from GitHub.
 
 ```bash
 # Note: Replace "my-astro-project" with the name of your project.


### PR DESCRIPTION
## Changes

The `starter templates` link on [Installation](https://docs.astro.build/installation#create-astro) page is currently pointed at 404 page: https://docs.astro.build/examples.

This fix, simply replace the URL with: https://github.com/snowpackjs/astro/tree/main/examples

## Testing

No tests were added. Documentation fix only.

## Docs

The documentation was updated.
