### PR TITLE
Fix project page in portfolio example

### DIFF
--- a/examples/portfolio/src/pages/project/mars-rover.md
+++ b/examples/portfolio/src/pages/project/mars-rover.md
@@ -2,7 +2,7 @@
 layout: ../../layouts/project.astro
 title: Mars Rover
 client: Self
-published_at: 2020-03-02 00:00:00
+publishDate: 2020-03-02 00:00:00
 img: https://images.unsplash.com/photo-1547234935-80c7145ec969?fit=crop&w=1400&h=700&q=75
 description: |
   We built an unofficial Mars Rover Landing site in celebration of NASA’s Perseverance Rover.


### PR DESCRIPTION
## Changes

`examples/portfolio` now displays projects in `/projects` route. (It wasn't displaying any projects before fix.)

(Projects list was blank because template filter uses `publishDate` but front matter uses `published_at`. Changed front matter to `publishDate`.)


## Testing
Copied and built example post fix to check it's working.

## Docs
Bug fix in example.

