### PR TITLE
Portfolio example fix

### DIFF
--- a/examples/portfolio/src/pages/project/mars-rover.md
+++ b/examples/portfolio/src/pages/project/mars-rover.md
@@ -2,7 +2,7 @@
 layout: ../../layouts/project.astro
 title: Mars Rover
 client: Self
-published_at: 2020-03-02 00:00:00
+publishDate: 2020-03-02 00:00:00
 img: https://images.unsplash.com/photo-1547234935-80c7145ec969?fit=crop&w=1400&h=700&q=75
 description: |
   We built an unofficial Mars Rover Landing site in celebration of NASA’s Perseverance Rover.

--- a/examples/portfolio/src/pages/project/nested/lunar-eclipse.md
+++ b/examples/portfolio/src/pages/project/nested/lunar-eclipse.md
@@ -2,7 +2,7 @@
 layout: ../../../layouts/project.astro
 title: Lunar Eclipse
 client: Self
-published_at: 2020-03-04 00:00:00
+publishDate: 2020-03-04 00:00:00
 img: https://images.unsplash.com/photo-1548391350-1a529f6ea42d?fit=crop&w=1400&h=700&q=75
 description: |
   We took some cool pictures of the moon and made a website about it.

--- a/examples/portfolio/src/pages/projects.astro
+++ b/examples/portfolio/src/pages/projects.astro
@@ -8,7 +8,7 @@ interface MarkdownFrontmatter {
   publishDate: number;
 }
 
-const projects = Astro.fetchContent<MarkdownFrontmatter>('./project/*.md')
+const projects = Astro.fetchContent<MarkdownFrontmatter>('./project/**/*.md')
   .filter(({ publishDate }) => !!publishDate)
   .sort((a, b) => new Date(b.publishDate).valueOf() - new Date(a.publishDate).valueOf());
 ---


### PR DESCRIPTION
## Changes
Project page (`/projects`) of portfolio example wasn't displaying any projects.

- changed `published_at` in front matter to match `publishDate` in the [template's filter](https://github.com/snowpackjs/astro/blob/2293fa05305d5767a53f15db85fa7c3132dd1f3c/examples/portfolio/src/pages/projects.astro#L12)
- fixed the `fetchContent` pattern to find nested files

Both projects are displayed now.

## Testing
Copied and built the example to check changes.

## Docs
Bug fix only.
