### PR TITLE
Updated srcset checking

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -97,6 +97,7 @@
     "shorthash": "^0.0.2",
     "slash": "^4.0.0",
     "snowpack": "^3.8.6",
+    "srcset-parse": "^1.1.0",
     "string-width": "^5.0.0",
     "supports-esm": "^1.0.0",
     "tiny-glob": "^0.2.8",

--- a/packages/astro/src/build.ts
+++ b/packages/astro/src/build.ts
@@ -30,6 +30,19 @@ function isRemoteOrEmbedded(url: string) {
   return url.startsWith('http://') || url.startsWith('https://') || url.startsWith('//') || url.startsWith('data:');
 }
 
+/**
+ * This function taken from https://github.com/molefrog/srcset-parse as unable
+ * to add it as a working dependency (don't know why.)
+ * RegExp used below also from same project.
+ */
+ const matchSrces = (str: string, regex: RegExp): RegExpExecArray[] => {
+  let match = null,
+    result = [];
+
+  while ((match = regex.exec(str)) !== null) result.push(match);
+  return result;
+};
+
 /** The primary build action */
 export async function build(astroConfig: AstroConfig, logging: LogOptions = defaultLogging): Promise<0 | 1> {
   const { projectRoot } = astroConfig;
@@ -338,11 +351,25 @@ export function findDeps(html: string, { astroConfig, srcPath }: { astroConfig: 
 
   $('img[srcset]').each((_i, el) => {
     const srcset = $(el).attr('srcset') || '';
-    const sources = srcset.split(',');
-    const srces = sources.map((s) => s.trim().split(' ')[0]);
+    // using matchSrces (see above) as built-in matchAll
+    // is not compatible with project.
+    const srces = matchSrces(srcset, /(\S*[^,\s])(\s+([\d.]+)(x|w))?/g)
     for (const src of srces) {
-      if (!isRemoteOrEmbedded(src)) {
-        pageDeps.images.add(getDistPath(src, { astroConfig, srcPath }));
+      if (!isRemoteOrEmbedded(src[1])) {
+        pageDeps.images.add(getDistPath(src[1], { astroConfig, srcPath }));
+      }
+    }
+  });
+
+  // Add in srcset check for <source>
+  $('source[srcset]').each((_i, el) => {
+    const srcset = $(el).attr('srcset') || '';
+    // using matchSrces (see above) as built-in matchAll
+    // is not compatible with project.
+    const srces = matchSrces(srcset, /(\S*[^,\s])(\s+([\d.]+)(x|w))?/g)
+    for (const src of srces) {
+      if (!isRemoteOrEmbedded(src[1])) {
+        pageDeps.images.add(getDistPath(src[1], { astroConfig, srcPath }));
       }
     }
   });

--- a/packages/astro/src/build.ts
+++ b/packages/astro/src/build.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import { performance } from 'perf_hooks';
 import glob from 'tiny-glob';
 import hash from 'shorthash';
+import srcsetParse from 'srcset-parse';
 import { fileURLToPath } from 'url';
 import type { AstroConfig, BuildOutput, BundleMap, PageDependencies, RouteData, RuntimeMode, ScriptInfo } from './@types/astro';
 import { bundleCSS } from './build/bundle/css.js';
@@ -20,6 +21,9 @@ import type { LogOptions } from './logger';
 import { debug, defaultLogDestination, defaultLogLevel, error, info, warn } from './logger.js';
 import { createRuntime, LoadResult } from './runtime.js';
 
+// This package isn't real ESM, so have to coerce it
+const matchSrcset: typeof srcsetParse = (srcsetParse as any).default;
+
 const defaultLogging: LogOptions = {
   level: defaultLogLevel,
   dest: defaultLogDestination,
@@ -29,19 +33,6 @@ const defaultLogging: LogOptions = {
 function isRemoteOrEmbedded(url: string) {
   return url.startsWith('http://') || url.startsWith('https://') || url.startsWith('//') || url.startsWith('data:');
 }
-
-/**
- * This function taken from https://github.com/molefrog/srcset-parse as unable
- * to add it as a working dependency (don't know why.)
- * RegExp used below also from same project.
- */
- const matchSrces = (str: string, regex: RegExp): RegExpExecArray[] => {
-  let match = null,
-    result = [];
-
-  while ((match = regex.exec(str)) !== null) result.push(match);
-  return result;
-};
 
 /** The primary build action */
 export async function build(astroConfig: AstroConfig, logging: LogOptions = defaultLogging): Promise<0 | 1> {
@@ -351,12 +342,9 @@ export function findDeps(html: string, { astroConfig, srcPath }: { astroConfig: 
 
   $('img[srcset]').each((_i, el) => {
     const srcset = $(el).attr('srcset') || '';
-    // using matchSrces (see above) as built-in matchAll
-    // is not compatible with project.
-    const srces = matchSrces(srcset, /(\S*[^,\s])(\s+([\d.]+)(x|w))?/g)
-    for (const src of srces) {
-      if (!isRemoteOrEmbedded(src[1])) {
-        pageDeps.images.add(getDistPath(src[1], { astroConfig, srcPath }));
+    for (const src of matchSrcset(srcset)) {
+      if (!isRemoteOrEmbedded(src.url)) {
+        pageDeps.images.add(getDistPath(src.url, { astroConfig, srcPath }));
       }
     }
   });
@@ -364,12 +352,9 @@ export function findDeps(html: string, { astroConfig, srcPath }: { astroConfig: 
   // Add in srcset check for <source>
   $('source[srcset]').each((_i, el) => {
     const srcset = $(el).attr('srcset') || '';
-    // using matchSrces (see above) as built-in matchAll
-    // is not compatible with project.
-    const srces = matchSrces(srcset, /(\S*[^,\s])(\s+([\d.]+)(x|w))?/g)
-    for (const src of srces) {
-      if (!isRemoteOrEmbedded(src[1])) {
-        pageDeps.images.add(getDistPath(src[1], { astroConfig, srcPath }));
+    for (const src of matchSrcset(srcset)) {
+      if (!isRemoteOrEmbedded(src.url)) {
+        pageDeps.images.add(getDistPath(src.url, { astroConfig, srcPath }));
       }
     }
   });

--- a/packages/astro/test/fixtures/astro-assets/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-assets/src/pages/index.astro
@@ -6,5 +6,27 @@
 <body>
   <h1>Icons</h1>
   <img src="/_astro/src/images/twitter.png" srcset="/_astro/src/images/twitter.png 1x, /_astro/src/images/twitter@2x.png 2x, /_astro/src/images/twitter@3x.png 3x" />
+  <!--
+    In Astro (0.20.4 and below) these srcsets will cause a build fail.
+    Error (for Assets Test)
+    [build] file:///astro/packages/astro/test/fixtures/astro-assets/src/pages/index.astro: could not find "/_astro/src/pages/h-300/medium_cafe_B1iTdD0C.jpg"
+  -->
+  <img srcset="https://ik.imagekit.io/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg, https://ik.imagekit.io/demo/tr:w-450,h-450/medium_cafe_B1iTdD0C.jpg 600w, https://ik.imagekit.io/demo/tr:w-600,h-600/medium_cafe_B1iTdD0C.jpg 800w">
+  <img srcset="https://ik.imagekit.io/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg, https://ik.imagekit.io/demo/tr:w-450,h-450/medium_cafe_B1iTdD0C.jpg 1.5x, https://ik.imagekit.io/demo/tr:w-600,h-600/medium_cafe_B1iTdD0C.jpg 2x">
+  <!--
+    A srcset in <source> does not trigger an error in aforementioned versions
+    as no checking is done for this tag (a good way to circumvent the check.)
+  -->
+  <picture>
+    <!--
+      This will cause build fail
+      [build] file:///astro/packages/astro/test/fixtures/astro-assets/src/pages/index.astro: could not find "/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg"
+    -->
+    <!-- <source srcset="/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg, /demo/tr:w-450,h-450/medium_cafe_B1iTdD0C.jpg 600w, /demo/tr:w-600,h-600/medium_cafe_B1iTdD0C.jpg 800w"> -->
+    <!--
+      This will pass
+    -->
+    <source srcset="https://ik.imagekit.io/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg, https://ik.imagekit.io/demo/tr:w-450,h-450/medium_cafe_B1iTdD0C.jpg 600w, https://ik.imagekit.io/demo/tr:w-600,h-600/medium_cafe_B1iTdD0C.jpg 800w">
+  </picture>
 </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9672,6 +9672,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+srcset-parse@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/srcset-parse/-/srcset-parse-1.1.0.tgz#73f787f38b73ede2c5af775e0a3465579488122b"
+  integrity sha512-JWp4cG2eybkvKA1QUHGoNK6JDEYcOnSuhzNGjZuYUPqXreDl/VkkvP2sZW7Rmh+icuCttrR9ccb2WPIazyM/Cw==
+
 sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"


### PR DESCRIPTION
Refactored from #1317

## Changes

- Improved functionality of `<img>` `srcset` checking as original failed when URL contained a comma ( `,` ).
- Added `srcset` checking for `<source>`

## Testing

- Added test to current assets test (`packages/astro/test/fixtures/astro-assets/src/pages/index.astro`) rather than create a separate one 

## Docs

N/A