### PR TITLE
Update deploy script for gitlab pages

### DIFF
--- a/docs/src/pages/guides/deploy.md
+++ b/docs/src/pages/guides/deploy.md
@@ -161,8 +161,7 @@ jobs:
 ## GitLab Pages
 
 1. Set the correct `buildOptions.site` in `astro.config.mjs`.
-2. Set `build.outDir` in `astro.config.mjs` to `public`.
-3. Create a file called `.gitlab-ci.yml` in the root of your project with the content below. This will build and deploy your site whenever you make changes to your content:
+2. Create a file called `.gitlab-ci.yml` in the root of your project with the content below. This will build and deploy your site whenever you make changes to your content:
 
    ```yaml
    image: node:10.22.0
@@ -173,6 +172,7 @@ jobs:
      script:
        - npm install
        - npm run build
+       - rm -rf ./public/* && cp -r ./dist/* ./public
      artifacts:
        paths:
          - public


### PR DESCRIPTION
## Changes

As far as I could find, there is not a `build.outDir` inside of `astro.config.mjs`. I was looking at the types here: https://github.com/snowpackjs/astro/blob/main/packages/astro/src/@types/config.ts. Also, when I would attempt to run the command it would not output it to the public directory which makes me think this option was removed at some point, although it may have existed at some point in time.

For this reason, I think it's easier to just add a script to remove all contents of `public` and plop in everything output to the `dist` folder. This should get everything working as one would expect.

## Testing

- Tested against my own repo in GitLab

## Docs

- Updated the docs to reflect a correct configuration for GitLab pages
