### PR TITLE
switch from rm to unlink in order to preserve node 12 compatability in astro-create

### DIFF
--- a/.changeset/odd-owls-clean.md
+++ b/.changeset/odd-owls-clean.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+change rm to unlink for node 12 compatability

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -116,7 +116,7 @@ export async function main() {
       switch (file) {
         case 'CHANGELOG.md': {
           if (fs.existsSync(fileLoc)) {
-            await fs.promises.rm(fileLoc);
+            await fs.promises.unlink(fileLoc);
           }
           break;
         }


### PR DESCRIPTION
Running astro create with the doc template currently crashes with,

```UnhandledPromiseRejectionWarning: TypeError: fs.promises.rm is not a function```

This leaves a partially generated project that when run renders this cryptic error.

![image](https://user-images.githubusercontent.com/109635/135530654-4a988ce9-fe50-43b1-8953-f8643cf2b4d0.png)


The reason being that `.rm` wasn't added to Node till version 14.14.0. https://nodejs.org/docs/latest-v15.x/api/fs.html#fs_fspromises_rm_path_options

This just changes to the `unlink` variant for removing the file to prevent that crash in node 12.