### PR TITLE
fix a typo in blog astro-019 '''astro -> ```astro

### DIFF
--- a/www/src/pages/blog/astro-019.astro
+++ b/www/src/pages/blog/astro-019.astro
@@ -174,11 +174,11 @@ let lang = 'en';
 
           ## ICYMI (In case you missed it)
 
-          [Github added official support](https://twitter.com/astrodotbuild/status/1423001137905651714?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1423001137905651714%7Ctwgr%5E%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fastro.build%2Fblog%2Fastro-019%2F) for `.astro` files and `'''astro` syntax highlighting across their entire platform. Not to be outdone, CodeSandbox [quickly followed up](https://twitter.com/codesandbox/status/1425438635357257728) with support of their own! 
+          [Github added official support](https://twitter.com/astrodotbuild/status/1423001137905651714?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1423001137905651714%7Ctwgr%5E%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fastro.build%2Fblog%2Fastro-019%2F) for `.astro` files and ```` ```astro```` syntax highlighting across their entire platform. Not to be outdone, CodeSandbox [quickly followed up](https://twitter.com/codesandbox/status/1425438635357257728) with support of their own! 
           
           This is such a huge milestone for Astro, especially considering how young the project is! Thank you to everyone who used Astro, created projects, and showed these platforms how valuable Astro really is.
 
-          <blockquote class="twitter-tweet"><p lang="en" dir="ltr">It&#39;s official! 🎉 <a href="https://twitter.com/github?ref_src=twsrc%5Etfw">@github</a> now supports syntax highlighting for .astro files!<br><br>You can also use code blocks starting with &quot;'''astro&quot; to get proper highlighting in Markdown files, issues, and PR comments! <a href="https://t.co/CDiGw66Qw6">pic.twitter.com/CDiGw66Qw6</a></p>&mdash; Astro (@astrodotbuild) <a href="https://twitter.com/astrodotbuild/status/1423001137905651714?ref_src=twsrc%5Etfw">August 4, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+          <blockquote class="twitter-tweet"><p lang="en" dir="ltr">It&#39;s official! 🎉 <a href="https://twitter.com/github?ref_src=twsrc%5Etfw">@github</a> now supports syntax highlighting for .astro files!<br><br>You can also use code blocks starting with ```` ```astro```` to get proper highlighting in Markdown files, issues, and PR comments! <a href="https://t.co/CDiGw66Qw6">pic.twitter.com/CDiGw66Qw6</a></p>&mdash; Astro (@astrodotbuild) <a href="https://twitter.com/astrodotbuild/status/1423001137905651714?ref_src=twsrc%5Etfw">August 4, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
           ## 👋
 


### PR DESCRIPTION
## Changes

Fixed  a typo in the blog post astro-019

    '''astro -> ```astro

Four backticks are used to escape three backticks in the content. 

## Testing

Manually run `npm run dev` under the `www` directory and checked the page rendered by the browser.

Before (the current version at https://astro.build/blog/astro-019)

![image](https://user-images.githubusercontent.com/114114/135568038-10dfef6c-1840-4140-92d1-64d604327956.png)

After (the preview version rendered by vercel at https://astro-www-git-fork-weakish-markdown-syntax-typo-479862-pikapkg.vercel.app/blog/astro-019)

![image](https://user-images.githubusercontent.com/114114/135568092-098210a0-e6b3-442f-8cb8-c08251505b8b.png)

## Docs

This is a documentation change.
