### PR TITLE
chore: add alt type

### DIFF
--- a/examples/blog/src/components/BlogPost.astro
+++ b/examples/blog/src/components/BlogPost.astro
@@ -6,6 +6,7 @@ export interface Props {
   author: string;
   publishDate: string;
   heroImage: string;
+  alt: string;
 }
 
 const { title, author, publishDate, heroImage, alt } = Astro.props;


### PR DESCRIPTION
## Changes
add string type to the props `alt` in the blog example.
<img width="1067" alt="スクリーンショット 2021-10-01 22 02 58" src="https://user-images.githubusercontent.com/62130798/135625142-bf022e75-43e9-475b-8d9f-e2f931256174.png">
 

## Testing
only tiny type fix

## Docs
only tiny type fix
