### PR TITLE
Update comparison to reflect Gatsby SSR Support

### DIFF
--- a/docs/src/pages/comparing-astro-vs-other-tools.md
+++ b/docs/src/pages/comparing-astro-vs-other-tools.md
@@ -68,7 +68,7 @@ By contrast, Astro automatically builds your client-side JavaScript & CSS for yo
 
 Gatsby uses React to render your website. Astro is more flexible: you are free to build UI with any popular component library (React, Preact, Vue, Svelte, Solid and others) or Astro's HTML-like component syntax which is similar to HTML + JSX.
 
-Today, both Gatsby and Astro support Static Site Generation (SSG) only. Gatsby has support for incremental rebuilds, while Astro only supports full site rebuilds. Astro has stated plans to support Server-Side Rendering (SSR) in a future release, while Gatsby supports SSR in version 4.
+Today, both Gatsby and Astro support Static Site Generation (SSG) only. Gatsby has support for incremental rebuilds, while Astro only supports full site rebuilds. Astro has stated plans to support Server-Side Rendering (SSR) in a future release, while Gatsby supports SSR in version 4 up.
 
 Gatsby requires a custom GraphQL API for working with all of your site content. While some developers enjoy this model, a common criticism of Gatsby is that this model becomes too complex and difficult to maintain over time, especially as sites grow. Astro has no GraphQL requirement, and instead provides familiar APIs (like `fetch()` and top-level `await`) for data loading close to where the data is needed.
 

--- a/docs/src/pages/comparing-astro-vs-other-tools.md
+++ b/docs/src/pages/comparing-astro-vs-other-tools.md
@@ -68,7 +68,7 @@ By contrast, Astro automatically builds your client-side JavaScript & CSS for yo
 
 Gatsby uses React to render your website. Astro is more flexible: you are free to build UI with any popular component library (React, Preact, Vue, Svelte, Solid and others) or Astro's HTML-like component syntax which is similar to HTML + JSX.
 
-Gatsby v4 supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Today, Astro only supports Static Site Generation (SSG).
+Gatsby v4 supports both Static Site Generation (SSG) with incremental rebuilds, Deferred Static Generation (DSG), and Server-Side Rendering (SSR). Today, Astro only supports Static Site Generation (SSG).
 
 Gatsby requires a custom GraphQL API for working with all of your site content. While some developers enjoy this model, a common criticism of Gatsby is that this model becomes too complex and difficult to maintain over time, especially as sites grow. Astro has no GraphQL requirement, and instead provides familiar APIs (like `fetch()` and top-level `await`) for data loading close to where the data is needed.
 

--- a/docs/src/pages/comparing-astro-vs-other-tools.md
+++ b/docs/src/pages/comparing-astro-vs-other-tools.md
@@ -68,7 +68,7 @@ By contrast, Astro automatically builds your client-side JavaScript & CSS for yo
 
 Gatsby uses React to render your website. Astro is more flexible: you are free to build UI with any popular component library (React, Preact, Vue, Svelte, Solid and others) or Astro's HTML-like component syntax which is similar to HTML + JSX.
 
-Today, both Gatsby and Astro support Static Site Generation (SSG) only. Gatsby has support for incremental rebuilds, while Astro only supports full site rebuilds. Astro has stated plans to support Server-Side Rendering (SSR) in a future release, while Gatsby has no plans to support SSR.
+Today, both Gatsby and Astro support Static Site Generation (SSG) only. Gatsby has support for incremental rebuilds, while Astro only supports full site rebuilds. Astro has stated plans to support Server-Side Rendering (SSR) in a future release, while Gatsby supports SSR in version 4.
 
 Gatsby requires a custom GraphQL API for working with all of your site content. While some developers enjoy this model, a common criticism of Gatsby is that this model becomes too complex and difficult to maintain over time, especially as sites grow. Astro has no GraphQL requirement, and instead provides familiar APIs (like `fetch()` and top-level `await`) for data loading close to where the data is needed.
 

--- a/docs/src/pages/comparing-astro-vs-other-tools.md
+++ b/docs/src/pages/comparing-astro-vs-other-tools.md
@@ -68,7 +68,7 @@ By contrast, Astro automatically builds your client-side JavaScript & CSS for yo
 
 Gatsby uses React to render your website. Astro is more flexible: you are free to build UI with any popular component library (React, Preact, Vue, Svelte, Solid and others) or Astro's HTML-like component syntax which is similar to HTML + JSX.
 
-Today, both Gatsby and Astro support Static Site Generation (SSG) only. Gatsby has support for incremental rebuilds, while Astro only supports full site rebuilds. Astro has stated plans to support Server-Side Rendering (SSR) in a future release, while Gatsby supports SSR in version 4 up.
+Gatsby v4 supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Today, Astro only supports Static Site Generation (SSG).
 
 Gatsby requires a custom GraphQL API for working with all of your site content. While some developers enjoy this model, a common criticism of Gatsby is that this model becomes too complex and difficult to maintain over time, especially as sites grow. Astro has no GraphQL requirement, and instead provides familiar APIs (like `fetch()` and top-level `await`) for data loading close to where the data is needed.
 


### PR DESCRIPTION
According to https://v4.gatsbyjs.com/docs/how-to/rendering-options/using-server-side-rendering/, Gatsby now supports SSR by version 4, so the comparison's information is outdated. This PR changes the comparison to reflect that Gatsby now supports SSR

## Changes

- Updated comparison to reflect Gatsby supporting SSR

## Testing

None because no code was changed

## Docs

See changes
