### PR TITLE
Use setup-node action's caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
-
-      - name: Get yarn cache directory
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Set dependencies cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('yarn.lock') }}
-            ${{ runner.os }}-${{ matrix.node_version }}-
+          cache: 'yarn'
 
       - name: Debug
         run: yarn versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,19 +58,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-
-      - name: Get yarn cache directory
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Set dependencies cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('yarn.lock') }}
-            ${{ runner.os }}-${{ matrix.node_version }}-
+          cache: 'yarn'
 
       - name: Debug
         run: yarn versions
@@ -96,19 +84,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-
-      - name: Get yarn cache directory
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Set dependencies cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('yarn.lock') }}
-            ${{ runner.os }}-${{ matrix.node_version }}-
+          cache: 'yarn'
 
       - name: Debug
         run: yarn versions


### PR DESCRIPTION
## Changes

- remove boilerplate caching code `setup-node@v2` provides, it might take one run to re-initialize the dependency cache

## Testing

I've updated this successfully for various `npm` and `yarn` projects with similar boilerplate caching steps.

## Docs

This is mostly a cleanup task.
