### PR TITLE
Updated blog index with demo day post

### DIFF
--- a/www/src/pages/blog/index.astro
+++ b/www/src/pages/blog/index.astro
@@ -67,6 +67,10 @@ let lang = 'en';
           <p>{description}</p>
         </section>
         <section>
+          <BlogPostPreview title="Astro Demo Day September Edition" publishDate="September 20, 2021" href="/blog/demo-day-2021-09">
+            <span>Astro September Demo Day was today and we had 4 amazing talks, including one with big announcements on the future direction of Astro.</span>
+          </BlogPostPreview>
+
           <BlogPostPreview title="Astro 0.19" publishDate="Wednesday, August 18 2021" href="/blog/astro-019">
             <span>Introducing: Next.js-inspired file routing • Astro.resolve() • client:only components • translations.</span>
           </BlogPostPreview>


### PR DESCRIPTION
Previously the index page of the blog was out of date, as mentioned by #1441. This PR fixes that.
I also could add the blog index to the website index header, but I did not because that is out of the scope of this PR and I was unsure whether there was another reason for there not being a link to the blog in the header.

## Changes

- The blog index page has been updated with the demo day post for September.

## Testing

None do to the change only being relevant to the blog.

## Docs

None do to the change only being relevant to the blog.
