### PR TITLE
Add hydration to Solid renderer

### DIFF
--- a/packages/renderers/renderer-solid/client.js
+++ b/packages/renderers/renderer-solid/client.js
@@ -1,16 +1,11 @@
-import { createComponent } from 'solid-js';
-import { render } from 'solid-js/web';
+import { hydrate, createComponent } from 'solid-js/web';
 
 export default (element) => (Component, props, childHTML) => {
-  // Solid's `render` does not replace the element's children.
-  // Deleting the root's children is necessary before calling `render`.
-  element.replaceChildren();
-
   const children = document.createElement('astro-fragment');
   children.innerHTML = childHTML;
 
-  // Using Solid's `render` method ensures that a `root` is created
+  // Using Solid's `hydrate` method ensures that a `root` is created
   // in order to properly handle reactivity. It also handles
   // components that are not native HTML elements.
-  render(() => createComponent(Component, { ...props, children }), element);
+  hydrate(() => createComponent(Component, { ...props, children }), element);
 };

--- a/packages/renderers/renderer-solid/index.js
+++ b/packages/renderers/renderer-solid/index.js
@@ -2,17 +2,18 @@ export default {
   name: '@astrojs/renderer-solid',
   client: './client',
   server: './server',
-  knownEntrypoints: ['solid-js', 'solid-js/web'],
-  external: ['solid-js/web/dist/server.js', 'solid-js/dist/server.js', 'babel-preset-solid'],
+  knownEntrypoints: ['solid-js', 'solid-js/web', 'solid-js/store'],
+  external: ['solid-js/web/dist/server.js', 'solid-js/store/dist/server.js', 'solid-js/dist/server.js', 'babel-preset-solid'],
   jsxImportSource: 'solid-js',
   jsxTransformOptions: async ({ isSSR }) => {
     const [{ default: solid }] = await Promise.all([import('babel-preset-solid')]);
     const options = {
-      presets: [solid({}, { generate: isSSR ? 'ssr' : 'dom' })],
+      presets: [solid({}, { generate: isSSR ? 'ssr' : 'dom', hydratable: true })],
     };
 
     if (isSSR) {
       options.alias = {
+        'solid-js/store': 'solid-js/store/dist/server.js',
         'solid-js/web': 'solid-js/web/dist/server.js',
         'solid-js': 'solid-js/dist/server.js',
       };

--- a/packages/renderers/renderer-solid/server.js
+++ b/packages/renderers/renderer-solid/server.js
@@ -1,24 +1,23 @@
-import { createComponent } from 'solid-js';
-import { renderToStringAsync, ssr } from 'solid-js/web/dist/server.js';
+import { renderToString, ssr, createComponent } from 'solid-js/web/dist/server.js';
 
-async function check(Component, props, children) {
+function check(Component, props, children) {
   if (typeof Component !== 'function') return false;
 
-  const { html } = await renderToStaticMarkup(Component, props, children);
+  const { html } = renderToStaticMarkup(Component, props, children);
   return typeof html === 'string';
 }
 
-async function renderToStaticMarkup(Component, props, children) {
-  const html = await renderToStringAsync(
-    () => () =>
+function renderToStaticMarkup(Component, props, children) {
+  const html = renderToString(
+    () =>
       createComponent(Component, {
         ...props,
         // In Solid SSR mode, `ssr` creates the expected structure for `children`.
         // In Solid client mode, `ssr` is just a stub.
-        children: ssr([`<astro-fragment>${children}</astro-fragment>`]),
+        children: ssr(`<astro-fragment>${children}</astro-fragment>`),
       })
   );
-  return { html };
+  return { html: `<script>window._$HYDRATION||(window._$HYDRATION={events:[],completed:new WeakSet})</script>` + html };
 }
 
 export default {

--- a/packages/renderers/renderer-solid/server.js
+++ b/packages/renderers/renderer-solid/server.js
@@ -17,7 +17,7 @@ function renderToStaticMarkup(Component, props, children) {
         children: ssr(`<astro-fragment>${children}</astro-fragment>`),
       })
   );
-  return { html: `<script>window._$HYDRATION||(window._$HYDRATION={events:[],completed:new WeakSet})</script>` + html };
+  return { html: html + `<script>window._$HYDRATION||(window._$HYDRATION={events:[],completed:new WeakSet})</script>` };
 }
 
 export default {

--- a/packages/renderers/renderer-solid/static-html.js
+++ b/packages/renderers/renderer-solid/static-html.js
@@ -1,4 +1,4 @@
-import { createComponent } from 'solid-js';
+import { ssr } from 'solid-js/web/dist/server.js';
 
 /**
  * Astro passes `children` as a string of HTML, so we need
@@ -6,7 +6,7 @@ import { createComponent } from 'solid-js';
  */
 const StaticHtml = ({ innerHTML }) => {
   if (!innerHTML) return null;
-  return () => createComponent('astro-fragment', { innerHTML });
+  return ssr(`<astro-fragment>${innerHTML }</astro-fragment>`);
 };
 
 export default StaticHtml;


### PR DESCRIPTION
## Changes

This change updates Solid's renderer to hydrate instead of delete all the elements in the browser and recreate them. That being said there are some other considerations here.

Solid currently doesn't support multiple asynchronous hydration roots. Since components in Astro can be hydrated at any time there is no guarantee of synchronous execution. This can cause conflicts with automatic data serialization and event replaying. To avoid pitfalls this PR disables both of these features.

In so, I have changed the renderer to be synchronous (ie.. renderToString) during static generation. The impact is that Suspense will now only run in the browser and any async data fetching will need to happen outside of the Solid Components if you wish it to happen on the server. If a user chooses to use Suspense, the static page will contain the loading placeholder and at hydration time in the browser it will do the data fetch and replace the content.

This is definitely a tradeoff as previous to this change one could feasibly use Solid with server-side Suspense to render purely static components. However, app with "hydration" would have completely re-run in the client up to this point anyway which means fetching meant to be server only would have been running in the browser and likely have not worked anyway. I think it is prudent to restrict Solid's advanced features until we can provide an update with proper support.

Also added aliases for Stores which are another subpackage that ships with Solid.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
