### PR TITLE
Add back in support for children

### DIFF
--- a/packages/astro/src/internal/index.ts
+++ b/packages/astro/src/internal/index.ts
@@ -143,7 +143,7 @@ export async function renderSlot(result: any, slotted: string, fallback?: any) {
 
 export async function renderComponent(result: any, displayName: string, Component: unknown, _props: Record<string | number, any>, slots?: any) {
   Component = await Component;
-  const children = await renderSlot(result, slots.default);
+  const children = await renderSlot(result, slots?.default);
   const { renderers } = result._metadata;
 
   if (Component && (Component as any).isAstroComponentFactory) {

--- a/packages/astro/test/astro-children.test.js
+++ b/packages/astro/test/astro-children.test.js
@@ -1,6 +1,3 @@
-/**
- * UNCOMMENT when Component slots lands in new compiler
-
 import { expect } from 'chai';
 import cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
@@ -15,7 +12,6 @@ before(async () => {
   await fixture.build();
 });
 
-// TODO: waiting on Component slots
 describe('Component children', () => {
   it('Passes string children to framework components', async () => {
     const html = await fixture.readFile('/strings/index.html');
@@ -74,6 +70,3 @@ describe('Component children', () => {
     expect($svelte.children(':last-child').text().trim()).to.equal('Goodbye world');
   });
 });
-*/
-
-it.skip('is skipped', () => {});


### PR DESCRIPTION
## Changes

- Adds back in support for passing children into framework components

## Testing

Yep, astro-children.js is uncommented out.

## Docs

N/A