### PR TITLE
Add value to staticPaths cache before we await it

### DIFF
--- a/.changeset/gold-deers-cry.md
+++ b/.changeset/gold-deers-cry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve getStaticPaths memoization to successfully store values in the cache

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -81,8 +81,8 @@ function getParams(array: string[]) {
 }
 
 async function getStaticPathsMemoized(runtimeConfig: AstroRuntimeConfig, component: string, mod: any, args: GetStaticPathsArgs): Promise<GetStaticPathsResult> {
-  runtimeConfig.cache.staticPaths[component] = runtimeConfig.cache.staticPaths[component] || (await mod.exports.getStaticPaths(args)).flat();
-  return runtimeConfig.cache.staticPaths[component];
+  runtimeConfig.cache.staticPaths[component] = runtimeConfig.cache.staticPaths[component] || mod.exports.getStaticPaths(args);
+  return (await runtimeConfig.cache.staticPaths[component]).flat();
 }
 
 /** Pass a URL to Astro to resolve and build */


### PR DESCRIPTION
Fixes https://github.com/snowpackjs/astro/issues/1454

## Changes

- Reworks the logic of `getStaticPathsMemoized()` to store the promise before awaiting it.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
