### PR TITLE
Fix: wrong relative links in api-reference file

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -122,7 +122,7 @@ When using the [Collections API](/core-concepts/collections), `createCollection(
 | `pageSize`  |                 `number`                 | Specify number of items per page (default: `25`).                                                          |
 | `routes`    |                `params[]`                | **Required for URL Params.** Return an array of all possible URL `param` values in `{ name: value }` form. |
 | `permalink` |         `({ params }) => string`         | **Required for URL Params.** Given a `param` object of `{ name: value }`, generate the final URL.\*        |
-| `rss`       | [RSS](/reference/api-reference#rss-feed) | Optional: generate an RSS 2.0 feed from this collection ([docs](/reference/api-reference#rss-feed))        |
+| `rss`       | [RSS](/docs/reference/api-reference.md#rss-feed) | Optional: generate an RSS 2.0 feed from this collection ([docs](/docs/reference/api-reference.md#rss-feed))        |
 
 _\* Note: don't create confusing URLs with `permalink`, e.g. rearranging params conditionally based on their values._
 


### PR DESCRIPTION
Relative links for the same in file navigation are wrong and lead to a 404 page because I suppose that the `reference/` directory was moved from the root directory to under the `docs/` directory but still uses the previous paths under the `createCollection()` section

## Changes

- Link updated from `/reference/api-reference#rss-feed` to `/docs/reference/api-reference.md#rss-feed`
- Link updated from `/reference/api-reference#rss-feed` to `/docs/reference/api-reference.md#rss-feed`

## Testing

This is an updated to the docs and was tested by directly updating the links in the browser

## Docs

This can be considered as a refactor
