### PR TITLE
Remove reference to nonexistent `/guides/wasm.md`

### DIFF
--- a/docs/src/pages/guides/imports.md
+++ b/docs/src/pages/guides/imports.md
@@ -108,7 +108,7 @@ It can also be useful to place images in the `public/`-folder as explained on th
 const wasm = await WebAssembly.instantiateStreaming(fetch('/example.wasm'));
 ```
 
-Astro supports loading WASM files directly into your application using the browser's [`WebAssembly`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly) API. Read our [WASM guide](/guides/wasm) to learn more.
+Astro supports loading WASM files directly into your application using the browser's [`WebAssembly`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly) API.
 
 ## NPM Packages
 


### PR DESCRIPTION

## Changes

- Removes the link to `/guides/wasm`
- Maybe we could instead actually flesh out what *using wasm with astro* means? Is this something where we could pull prior art from <https://github.com/snowpackjs/astro-repl>?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
