### PR TITLE
Docs: Fixed typo in API Reference.

### DIFF
--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -107,7 +107,7 @@ This function is required because Astro is a static site builder. That means tha
 ---
 export async function getStaticPaths() {
   return [
-    { params: { /* required */ }, props: { /* optional */ },
+    { params: { /* required */ }, props: { /* optional */ } },
     { params: { ... } },
     { params: { ... } },
     // ...


### PR DESCRIPTION
## Changes

- Adds missing curly brace ('}') to API Reference example in the docs.

## Testing

- N/A (docs change only, grammatical fix)

## Docs

- Added missing curly brace to API Reference example.
