### PR TITLE
[next] Gracefully handle <Markdown> without content

### DIFF
--- a/packages/astro/components/Markdown.astro
+++ b/packages/astro/components/Markdown.astro
@@ -12,21 +12,27 @@ interface InternalProps extends Props {
 
 let { content, class: className } = Astro.props as InternalProps;
 let html = null;
+let htmlContent = '';
 
 const { privateRenderMarkdownDoNotUse: renderMarkdown } = (Astro as any);
 
 // If no content prop provided, use the slot.
 if (!content) {
   const { privateRenderSlotDoNotUse: renderSlot } = (Astro as any);
-  content = dedent(await renderSlot('default'));
+  content = await renderSlot('default');
+  if (content.trim().length > 0) {
+    content = dedent(content);
+  }
 }
 
-const htmlContent = await renderMarkdown(content, {
-  mode: 'md',
-  $: {
-    scopedClassName: className
-  }
-});
+if (content) {
+  htmlContent = await renderMarkdown(content, {
+    mode: 'md',
+    $: {
+      scopedClassName: className
+    }
+  });
+}
 
 html = htmlContent;
 ---


### PR DESCRIPTION
## Changes

- Keeps Astro from crashing when using `<Markdown><!-- comment --></Markdown>`

## Testing

Manually

## Docs

Bug fix only
