### PR TITLE
Remove prism warning when no language is provided

### DIFF
--- a/packages/markdown/remark/src/remark-prism.ts
+++ b/packages/markdown/remark/src/remark-prism.ts
@@ -12,7 +12,7 @@ function runHighlighter(lang: string, code: string) {
   let classLanguage = `language-${lang}`
 
   if (lang == null) {
-    console.warn('Prism.astro: No language provided.');
+    lang = 'shell';
   }
 
   const ensureLoaded = (lang: string) => {

--- a/packages/markdown/remark/src/remark-prism.ts
+++ b/packages/markdown/remark/src/remark-prism.ts
@@ -12,7 +12,7 @@ function runHighlighter(lang: string, code: string) {
   let classLanguage = `language-${lang}`
 
   if (lang == null) {
-    lang = 'shell';
+    lang = 'plaintext';
   }
 
   const ensureLoaded = (lang: string) => {


### PR DESCRIPTION
## Changes

- Removes the prism warning seen in the starter template.

## Testing

No

## Docs

No