### PR TITLE
Fix `<style>` and `<script hoist>` ordering

### DIFF
--- a/.changeset/stale-keys-draw.md
+++ b/.changeset/stale-keys-draw.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix bug with <style> and <script hoist> ordering

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -372,9 +372,11 @@ export async function renderPage(result: SSRResult, Component: AstroComponentFac
   const template = await renderToString(result, Component, props, children);
   const styles = Array.from(result.styles)
     .filter(uniqueElements)
+    .reverse()
     .map((style) => renderElement('style', style));
   const scripts = Array.from(result.scripts)
     .filter(uniqueElements)
+    .reverse()
     .map((script) => renderElement('script', script));
   return template.replace('</head>', styles.join('\n') + scripts.join('\n') + '</head>');
 }


### PR DESCRIPTION
## Changes

- `.astro` files render child-first, which means our `<style>` and `<script hoist>` order is the exact opposite of what it should be.
- This reverses the order before printing.

## Testing

Manually

## Docs

Bug fix only
