### PR TITLE
[lit] Automatically detect `customElements.define()` and `@customElement()` calls

### DIFF
--- a/.changeset/gorgeous-parents-build.md
+++ b/.changeset/gorgeous-parents-build.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/renderer-lit': minor
+'astro': patch
+---
+
+Add support for automatically detecting @customElement("my-element")`and`customElements.define("my-element", MyElement)` when using Lit SSR.

--- a/examples/framework-lit/src/components/Counter.js
+++ b/examples/framework-lit/src/components/Counter.js
@@ -1,7 +1,5 @@
 import { LitElement, html } from 'lit';
 
-export const tagName = 'my-counter';
-
 class Counter extends LitElement {
   static get properties() {
     return {
@@ -31,4 +29,4 @@ class Counter extends LitElement {
   }
 }
 
-customElements.define(tagName, Counter);
+customElements.define('my-counter', Counter);

--- a/examples/framework-lit/src/components/Greeting.ts
+++ b/examples/framework-lit/src/components/Greeting.ts
@@ -1,0 +1,14 @@
+import {html, css, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+@customElement('simple-greeting')
+export class SimpleGreeting extends LitElement {
+  static styles = css`p { color: blue }`;
+
+  @property()
+  name = 'Somebody';
+
+  render() {
+    return html`<p>Hello, ${this.name}!</p>`;
+  }
+}

--- a/examples/framework-lit/src/components/Test.js
+++ b/examples/framework-lit/src/components/Test.js
@@ -1,7 +1,5 @@
 import { LitElement, html } from 'lit';
 
-export const tagName = 'calc-add';
-
 class CalcAdd extends LitElement {
   static get properties() {
     return {
@@ -16,4 +14,5 @@ class CalcAdd extends LitElement {
   }
 }
 
+const tagName = 'calc-add'
 customElements.define(tagName, CalcAdd);

--- a/examples/framework-lit/src/pages/index.astro
+++ b/examples/framework-lit/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Lorem from '../components/Lorem.astro';
 import '../components/Test.js';
 import '../components/Counter.js';
+import '../components/Greeting.ts';
 ---
 
 <!doctype html>
@@ -15,5 +16,6 @@ import '../components/Counter.js';
     <my-counter client:load />
     <Lorem />
     <calc-add num={33} />
+    <simple-greeting name="World" />
   </body>
 </html>

--- a/examples/framework-lit/tsconfig.json
+++ b/examples/framework-lit/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "moduleResolution": "node"
+  "moduleResolution": "node",
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
 }

--- a/packages/astro/src/runtime/server/metadata.ts
+++ b/packages/astro/src/runtime/server/metadata.ts
@@ -41,7 +41,7 @@ class Metadata {
       const id = specifier.startsWith('.') ? new URL(specifier, this.fileURL).pathname : specifier;
       for (const [key, value] of Object.entries(module)) {
         if (isCustomElement) {
-          if (key === 'tagName' && Component === value) {
+          if ((key === 'tagName' || key === '__astroTagName') && Component === value) {
             return {
               componentExport: key,
               componentUrl: id,

--- a/packages/renderers/renderer-lit/index.js
+++ b/packages/renderers/renderer-lit/index.js
@@ -1,3 +1,5 @@
+import pluginLit from './vite-plugin-lit.js';
+
 // NOTE: @lit-labs/ssr uses syntax incompatible with anything < Node v13.9.0.
 // Throw an error if using that Node version.
 
@@ -13,6 +15,9 @@ export default {
   hydrationPolyfills: ['./hydration-support.js'],
   viteConfig() {
     return {
+      plugins: [
+        pluginLit(),
+      ],
       optimizeDeps: {
         include: [
           '@astrojs/renderer-lit/client-shim.js',

--- a/packages/renderers/renderer-lit/vite-plugin-lit.js
+++ b/packages/renderers/renderer-lit/vite-plugin-lit.js
@@ -1,0 +1,106 @@
+import { parse } from 'acorn';
+import { walk } from 'estree-walker';
+import MagicString from 'magic-string';
+
+/**
+ * Determine if Vite is in SSR mode based on options
+ * https://github.com/vitejs/vite/discussions/5109#discussioncomment-1450726
+ *
+ * @param options boolean | { ssr: boolean }
+ * @returns boolean
+ */
+function isSSR(options) {
+  if (options === undefined) {
+    return false;
+  }
+  if (typeof options === 'boolean') {
+    return options;
+  }
+  if (typeof options == 'object') {
+    return !!options.ssr;
+  }
+  return false;
+}
+
+// This matches any JS-like file (that we know of)
+// See https://regex101.com/r/Cgofir/1
+const SUPPORTED_FILES = /\.([cm]?js|jsx|[cm]?ts|tsx)$/;
+const IGNORED_MODULES = [/astro\/dist\/runtime\/server/, /\/renderer-lit\/server/, /\/@lit\//];
+
+function scanForTagName(code) {
+  const ast = parse(code, {
+    sourceType: 'module'
+  })
+
+  let tagName;
+  walk(ast, {
+    enter(node, parent) {
+      if (tagName) {
+        return this.skip();
+      }
+      // Matches `customElement("my-component")`, which is Lit's @customElement("my-component") decorator
+      if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === 'customElement') {
+        const arg = node.arguments[0];
+        if (arg.type === 'Literal') {
+          tagName = arg.raw
+        }
+      }
+      // Matches `customElements.define("my-component", thing)`
+      if (node.type === 'MemberExpression' && node.object.name === 'customElements' && node.property.name === 'define') {
+        const arg = parent.arguments[0];
+        if (arg.type === 'Literal') {
+          tagName = arg.raw
+        } else {
+          tagName = arg.name
+        }
+      }
+    }
+  })
+
+  return tagName;
+}
+
+/**
+ * @returns {import('vite').Plugin}
+ */
+export default function pluginLit() {
+  return {
+    name: '@astrojs/vite-plugin-lit',
+    enforce: 'post',
+    async transform(code, id, opts) {
+      const ssr = isSSR(opts);
+      // If this isn't an SSR pass, `fetch` will already be available!
+      if (!ssr) {
+        return null;
+      }
+      // Only transform JS-like files
+      if (!id.match(SUPPORTED_FILES)) {
+        return null;
+      }
+      // Optimization: only run on probable matches
+      if (!code.includes('customElement') && !code.includes('lit')) {
+        return null;
+      }
+      // Ignore specific modules
+      for (const ignored of IGNORED_MODULES) {
+        if (id.match(ignored)) {
+          return null;
+        }
+      }
+
+      const tagName = scanForTagName(code);
+      if (!tagName) {
+        return null;
+      }
+    
+      const s = new MagicString(code);
+      s.append(`export const __astroTagName = ${tagName};`);
+      const result = s.toString();
+      const map = s.generateMap({
+        source: id,
+        includeContent: true,
+      });
+      return { code: result, map };
+    },
+  };
+}


### PR DESCRIPTION
## Changes

- Removes the need for manual `export const tagName = "my-element";`
- Supports `customElements.define("my-element", MyElement)` calls
- Supports Lit's `@customElements("my-element")` decorator

## Testing

Manually, updating the `framework-lit` example

## Docs

Will do be before merge.
