### PR TITLE
Update `@astrojs/compiler`

### DIFF
--- a/.changeset/curvy-years-kiss.md
+++ b/.changeset/curvy-years-kiss.md
@@ -1,0 +1,9 @@
+---
+'astro': patch
+---
+
+Fix issue with `style` and `script` processing where siblings would be skipped
+
+Fix `Fragment` and `<>` handling for backwards compatability
+
+Fix CSS `--custom-proprty` parsing when using scoped CSS

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -52,7 +52,7 @@
     "test": "mocha --parallel --timeout 15000"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.2.23",
+    "@astrojs/compiler": "^0.2.24",
     "@astrojs/language-server": "^0.7.16",
     "@astrojs/markdown-remark": "^0.4.0-next.0",
     "@astrojs/markdown-support": "0.3.1",

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -90,10 +90,16 @@ export async function renderSlot(_result: any, slotted: string, fallback?: any) 
   return fallback;
 }
 
+export const Fragment = Symbol("Astro.Fragment");
+
 export async function renderComponent(result: SSRResult, displayName: string, Component: unknown, _props: Record<string | number, any>, slots: any = {}) {
   Component = await Component;
   const children = await renderSlot(result, slots?.default);
   const { renderers } = result._metadata;
+
+  if (Component === Fragment) {
+    return children;
+  }
 
   if (Component && (Component as any).isAstroComponentFactory) {
     const output = await renderToString(result, Component as any, _props, slots);

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,10 +106,10 @@
     "@algolia/logger-common" "4.10.5"
     "@algolia/requester-common" "4.10.5"
 
-"@astrojs/compiler@^0.2.23":
-  version "0.2.23"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.2.23.tgz#ebc705521ed5ce89d37ebfc0c3392ec6c0d7ec47"
-  integrity sha512-RjQXt4AFQqUYzjzbwFKBDqTnj2yfBnwPROHmFD40ONaIXaeHYcVvHKC3zrXqO8PIVRpQOlvFw9V3CWZD6rG7pw==
+"@astrojs/compiler@^0.2.24":
+  version "0.2.24"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.2.24.tgz#1e737989a0f3da00d785d48081935417cbaf8745"
+  integrity sha512-BiS5nQIlRYB7kroay4zBtNgdzaW14RIh+Lpwbi9WcZ0oSRiq5LVa/lOgr6fKRClmmDQn56TX7LBWqy5gh68e7w==
   dependencies:
     typescript "^4.3.5"
 


### PR DESCRIPTION
## Changes

- Fixes the bugs outlined in https://github.com/snowpackjs/astro-compiler-next/blob/main/lib/compiler/CHANGELOG.md#0224
- Adds backwards-compat support for `<Fragment>` and `<>`

## Testing

Manual

## Docs

N/A