### PR TITLE
Restore astro typings

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -4,6 +4,7 @@
   "author": "Skypack",
   "license": "MIT",
   "type": "module",
+  "types": "./dist/types/@types/astro-core.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/astro.git",


### PR DESCRIPTION
## Changes

This restores typings to `astro@next` by adding the appropriate `types` key back to `package.json`.

Without it, the following code reports an error in VSCode, because it "_Cannot find module 'astro' or its corresponding type declarations_".

**Note**:
In Astro v0.20, the `types` path was `./dist/types/@types/public.d.ts`.
In Astro v0.21, the `types` path is now `./dist/types/@types/astro-core.d.ts`.

## Testing

This was tested by manually adding `types` to an installation of Astro.

## Docs

typing fix only