### PR TITLE
Adding CodeSandbox config file to all the "next" examples

### DIFF
--- a/examples/blog-multiple-authors/sandbox.config.json
+++ b/examples/blog-multiple-authors/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/blog/sandbox.config.json
+++ b/examples/blog/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/docs/sandbox.config.json
+++ b/examples/docs/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-lit/sandbox.config.json
+++ b/examples/framework-lit/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-multiple/sandbox.config.json
+++ b/examples/framework-multiple/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-preact/sandbox.config.json
+++ b/examples/framework-preact/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-react/sandbox.config.json
+++ b/examples/framework-react/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-solid/sandbox.config.json
+++ b/examples/framework-solid/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-svelte/sandbox.config.json
+++ b/examples/framework-svelte/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/framework-vue/sandbox.config.json
+++ b/examples/framework-vue/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/minimal/sandbox.config.json
+++ b/examples/minimal/sandbox.config.json
@@ -1,0 +1,9 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000
+  }
+}

--- a/examples/minimal/sandbox.config.json
+++ b/examples/minimal/sandbox.config.json
@@ -4,6 +4,8 @@
   "view": "browser",
   "template": "node",
   "container": {
-    "port": 3000
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
   }
 }

--- a/examples/portfolio-svelte/sandbox.config.json
+++ b/examples/portfolio-svelte/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": false,
+    "view": "browser",
+    "template": "node",
+    "container": {
+      "port": 3000,
+      "startScript": "start",
+      "node": "14"
+    }
+  }

--- a/examples/portfolio-svelte/sandbox.config.json
+++ b/examples/portfolio-svelte/sandbox.config.json
@@ -1,11 +1,11 @@
 {
-    "infiniteLoopProtection": true,
-    "hardReloadOnChange": false,
-    "view": "browser",
-    "template": "node",
-    "container": {
-      "port": 3000,
-      "startScript": "start",
-      "node": "14"
-    }
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
   }
+}

--- a/examples/portfolio/sandbox.config.json
+++ b/examples/portfolio/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": false,
+    "view": "browser",
+    "template": "node",
+    "container": {
+      "port": 3000,
+      "startScript": "start",
+      "node": "14"
+    }
+  }

--- a/examples/portfolio/sandbox.config.json
+++ b/examples/portfolio/sandbox.config.json
@@ -1,11 +1,11 @@
 {
-    "infiniteLoopProtection": true,
-    "hardReloadOnChange": false,
-    "view": "browser",
-    "template": "node",
-    "container": {
-      "port": 3000,
-      "startScript": "start",
-      "node": "14"
-    }
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
   }
+}

--- a/examples/with-markdown-plugins/sandbox.config.json
+++ b/examples/with-markdown-plugins/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/with-markdown/sandbox.config.json
+++ b/examples/with-markdown/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": false,
+    "view": "browser",
+    "template": "node",
+    "container": {
+        "port": 3000,
+        "startScript": "start",
+        "node": "14"
+    }
+}

--- a/examples/with-markdown/sandbox.config.json
+++ b/examples/with-markdown/sandbox.config.json
@@ -1,11 +1,11 @@
 {
-    "infiniteLoopProtection": true,
-    "hardReloadOnChange": false,
-    "view": "browser",
-    "template": "node",
-    "container": {
-        "port": 3000,
-        "startScript": "start",
-        "node": "14"
-    }
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
 }

--- a/examples/with-nanostores/sandbox.config.json
+++ b/examples/with-nanostores/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}

--- a/examples/with-tailwindcss/sandbox.config.json
+++ b/examples/with-tailwindcss/sandbox.config.json
@@ -1,0 +1,11 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 3000,
+    "startScript": "start",
+    "node": "14"
+  }
+}


### PR DESCRIPTION
## Changes

- each "next" example on main now has a sandbox.config.json file which specifies to open port 3000 on start.
- Previously, the browser preview in CodeSandbox showed "Upgrade required" instead of the example's home page, and an offer to open port 3000 (which, if accepted would then create the expected browser preview, but could confuse someone who didn't know about this).
- Now, these examples do open on port 3000 and the example looks like it should in the browser preview upon start.

## Testing

I tested a handful of these by using CodeSandbox's quick open URL shortcut githubBOX.com/sarah11918/astro/examples/blog etc. and making sure that when the CodeSandbox container started up, the correct main example page's index was loaded in the browser preview. 

## Docs

No docs updated. CodeSandbox configuration change only.
