### PR TITLE
Support top-level alias prop

### DIFF
--- a/packages/astro/src/@types/astro-core.ts
+++ b/packages/astro/src/@types/astro-core.ts
@@ -45,6 +45,12 @@ export interface AstroUserConfig {
    */
   public?: string;
   /**
+   * Object or Array of Objects defining aliases used to replace values in import statements.
+   * 
+   * Use absolute paths beginning with a slash. Relative alias values will be used as-is and will not be resolved into file system paths.
+   */
+  alias?: vite.AliasOptions;
+  /**
    * Framework component renderers enable UI framework rendering (static and dynamic).
    * When you define this in your configuration, all other defaults are disabled.
    * Default: [

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -37,6 +37,14 @@ export const AstroConfigSchema = z.object({
     .optional()
     .default('./dist')
     .transform((val) => new URL(val)),
+  alias: z.union([
+    z.object({
+      find: z.union([ z.string(), z.instanceof(RegExp) ]),
+      replacement: z.string(),
+      customResolver: z.optional(z.any())
+    }).array(),
+    z.record(z.string()),
+  ]).optional(),
   renderers: z.array(z.string()).optional().default(['@astrojs/renderer-svelte', '@astrojs/renderer-vue', '@astrojs/renderer-react', '@astrojs/renderer-preact']),
   markdownOptions: z
     .object({

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -55,6 +55,9 @@ export async function createVite(inlineConfig: ViteConfigWithSSR, { astroConfig,
     ],
     publicDir: fileURLToPath(astroConfig.public),
     root: fileURLToPath(astroConfig.projectRoot),
+    resolve: {
+      alias: astroConfig.alias
+    },
     server: {
       force: true, // force dependency rebuild (TODO: enabled only while next is unstable; eventually only call in "production" mode?)
       hmr: process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'production' ? false : undefined, // disable HMR for test


### PR DESCRIPTION
## Changes

This adds support for a top-level `alias` prop in Astro configuration, forwarded to [Vite’s `resolve.alias`](https://vitejs.dev/config/#resolve-alias).

```js
export default {
  vite: {
    resolve: {
      alias: {
        @components: '/src/components',
      }
    }
  }
}
```

This PR may not be necessary if the solution in #1747 is accepted, which offers a much better developer experience.

## Testing

This was tested manually.

## Docs

Documentation in #1751.