### PR TITLE
Fix/check content type

### DIFF
--- a/packages/astro/components/Markdown.astro
+++ b/packages/astro/components/Markdown.astro
@@ -20,7 +20,7 @@ const { privateRenderMarkdownDoNotUse: renderMarkdown } = (Astro as any);
 if (!content) {
   const { privateRenderSlotDoNotUse: renderSlot } = (Astro as any);
   content = await renderSlot('default');
-  if (content.trim().length > 0) {
+  if (content !== undefined && content !== null) {
     content = dedent(content);
   }
 }

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -144,6 +144,6 @@ describe('Astro Markdown', () => {
   it("doesn't occurs TypeError when no elements", async () => {
     const html = await fixture.readFile('/no-elements/index.html');
     // render html without error
-    expect(!!html).to.equal(true);
+    expect(html).to.be.ok;
   });
 });

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -140,4 +140,10 @@ describe('Astro Markdown', () => {
     // test Markdown rendered correctly via content prop
     expect($('h1').text()).to.equal('Foo');
   });
+
+  it("doesn't occurs TypeError when no elements", async () => {
+    const html = await fixture.readFile('/no-elements/index.html');
+    // render html without error
+    expect(html).to.equal(true);
+  });
 });

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -144,6 +144,6 @@ describe('Astro Markdown', () => {
   it("doesn't occurs TypeError when no elements", async () => {
     const html = await fixture.readFile('/no-elements/index.html');
     // render html without error
-    expect(html).to.equal(true);
+    expect(!!html).to.equal(true);
   });
 });

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/no-elements.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/no-elements.astro
@@ -1,0 +1,5 @@
+---
+import { Markdown } from 'astro/components';
+---
+
+<Markdown></Markdown>


### PR DESCRIPTION
## Changes
resolve #1753 
I added type guard to avoid TypeError when describing `Markdown` component with no children. 

## Testing
I added the test case about this.

## Docs
bug fix only
