### PR TITLE
minor adjustments for astro@next

### DIFF
--- a/examples/portfolio-svelte/package.json
+++ b/examples/portfolio-svelte/package.json
@@ -10,8 +10,5 @@
   },
   "devDependencies": {
     "astro": "^0.21.0-next.1"
-  },
-  "snowpack": {
-    "workspaceRoot": "../.."
   }
 }

--- a/examples/portfolio-svelte/src/components/MainHead.astro
+++ b/examples/portfolio-svelte/src/components/MainHead.astro
@@ -8,6 +8,6 @@ const { title = 'Jeanine White: Personal Site', description = 'The personal site
 <title>{title}</title>
 
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-<link rel="stylesheet" type="text/css" href="/_astro/src/scss/global.css">
+<link rel="stylesheet" type="text/css" href="/src/scss/global.scss">
 <link rel="preconnect" href="https://fonts.gstatic.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;700;900&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Changes

Comparing it to the react portfolio the url for the global.scss has changed in astro@next 
- This commit changes the URL for global.scss accordingly 

## Testing

In combination with astro@next I had / have problems getting the styles working in this example.
Tried it on stackblitz without success. It seems like postcss or some scss compiler dep is missing.
Couldn't figure out the problem + asked on discord. At least I adjusted in a way as it is in the react portfolio example.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
bug fix only