### PR TITLE
fix: Improve Vite config merging

### DIFF
--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -55,14 +55,16 @@ class AstroBuilder {
     const { logging, origin } = this;
     const timer: Record<string, number> = { viteStart: performance.now() };
     const viteConfig = await createVite(
-      {
-        mode: this.mode,
-        server: {
-          hmr: { overlay: false },
-          middlewareMode: 'ssr',
+      vite.mergeConfig(
+        {
+          mode: this.mode,
+          server: {
+            hmr: { overlay: false },
+            middlewareMode: 'ssr',
+          },
         },
-        ...(this.config.vite || {}),
-      },
+        this.config.vite || {}
+      ),
       { astroConfig: this.config, logging }
     );
     const viteServer = await vite.createServer(viteConfig);

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -222,14 +222,16 @@ export class AstroDevServer {
 
   private async createViteServer() {
     const viteConfig = await createVite(
-      {
-        mode: 'development',
-        server: {
-          middlewareMode: 'ssr',
-          host: this.hostname,
+      vite.mergeConfig(
+        {
+          mode: 'development',
+          server: {
+            middlewareMode: 'ssr',
+            host: this.hostname,
+          },
         },
-        ...(this.config.vite || {}),
-      },
+        this.config.vite || {}
+      ),
       { astroConfig: this.config, logging: this.logging, devServer: this }
     );
     const viteServer = await vite.createServer(viteConfig);


### PR DESCRIPTION
## Changes
Fixes #1755. In some instances, when users would pass in values to `vite` in `astro.config.mjs` they would override the defaults instead of deeply-merging.

## Testing

This one is tricky! I wrote a test to try and catch this bug, but it is not in the PR because it was passing initially. But when testing locally I could easily replicate the bug.

Testing locally I could see a difference before and after this fix, but it’s difficult to capture accurately in a test (this might need a dev test which we don’t have at the moment).

## Docs

No docs needed
