### PR TITLE
fix: enable node builtins

### DIFF
--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -2,6 +2,7 @@ import type { AstroConfig } from '../@types/astro';
 import type { AstroDevServer } from './dev';
 import type { LogOptions } from './logger';
 
+import { builtinModules } from 'module';
 import { fileURLToPath } from 'url';
 import vite from './vite.js';
 import astroVitePlugin from '../vite-plugin-astro/index.js';
@@ -14,6 +15,7 @@ import { resolveDependency } from './util.js';
 
 // Some packages are just external, and that’s the way it goes.
 const ALWAYS_EXTERNAL = new Set([
+  ...builtinModules.map(name => `node:${name}`),
   '@sveltejs/vite-plugin-svelte',
   'estree-util-value-to-estree',
   'micromark-util-events-to-acorn',

--- a/packages/astro/test/builtins.test.js
+++ b/packages/astro/test/builtins.test.js
@@ -22,9 +22,10 @@ describe('Node builtins', () => {
     expect($('#dep-version').text()).to.equal('0.0.1');
   });
 
-  it('Throw if using the non-prefixed version', async () => {
-    const result = await fixture.readFile('/bare/index.html');
-    expect(result.status).to.equal(500);
-    expect(result.body).to.include('Use node:fs instead');
+  it('Can also be used with the non-prefixed version', async () => {
+    const html = await fixture.readFile('/bare/index.html');
+    const $ = cheerio.load(html);
+
+    expect($('h1').text()).to.equal('true');
   });
 });

--- a/packages/astro/test/builtins.test.js
+++ b/packages/astro/test/builtins.test.js
@@ -1,5 +1,3 @@
-/**
- * UNCOMMENT: Fix "Unexpected "\x00" bug
 import { expect } from 'chai';
 import cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
@@ -11,7 +9,6 @@ before(async () => {
   await fixture.build();
 });
 
-// TODO: find a way to build one file at-a-time (different fixtures?)
 describe('Node builtins', () => {
   it('Can be used with the node: prefix', async () => {
     // node:fs/promise is not supported in Node v12. Test currently throws.
@@ -31,6 +28,3 @@ describe('Node builtins', () => {
     expect(result.body).to.include('Use node:fs instead');
   });
 });
-*/
-
-it.skip('is skipped', () => {});

--- a/packages/astro/test/fixtures/builtins/src/components/Version.astro
+++ b/packages/astro/test/fixtures/builtins/src/components/Version.astro
@@ -1,5 +1,5 @@
 ---
-import fs from 'node:fs/promises';
+import { promises as fs } from 'node:fs';
 
 const url = new URL('../../package.json', import.meta.url);
 const json = await fs.readFile(url, 'utf-8');

--- a/packages/astro/test/fixtures/builtins/src/pages/bare.astro
+++ b/packages/astro/test/fixtures/builtins/src/pages/bare.astro
@@ -1,12 +1,12 @@
 ---
-import fs from 'fs';
+import { builtinModules } from 'module';
 ---
 
 <html>
 <head>
-<title>This should throw</title>
+<title>Bare node import</title>
 </head>
 <body>
-<h1>Test</h1>
+<h1>{Array.isArray(builtinModules)}</h1>
 </body>
 </html>


### PR DESCRIPTION
## Changes

- Enables `node:*` builtins.
- **TODO** disable unprefixed versions.

## Testing

Tests re-enabled.

## Docs

N/A