### PR TITLE
Enable tests

### DIFF
--- a/packages/astro/test/astro-client-only.test.js
+++ b/packages/astro/test/astro-client-only.test.js
@@ -1,5 +1,5 @@
 /**
- * UNCOMMENT: when "window is not defined" error fixed in Vite
+ * UNCOMMENT: fix "Error: Unable to render PersistentCounter because it is null!"
 import { expect } from 'chai';
 import cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
@@ -11,7 +11,6 @@ before(async () => {
   await fixture.build();
 });
 
-// TODO: fix "window is not defined" error in Vite
 describe('Client only components', () => {
   it('Loads pages using client:only hydrator', async () => {
     const html = await fixture.readFile('/index.html');

--- a/packages/astro/test/astro-styles-ssr.test.js
+++ b/packages/astro/test/astro-styles-ssr.test.js
@@ -87,8 +87,7 @@ describe('Styles SSR', () => {
     expect(wrapper).to.have.lengthOf(1);
   });
 
-  // TODO: add dynamic class scoping in compiler
-  it.skip('Astro scoped styles', async () => {
+  it('Astro scoped styles', async () => {
     const html = await fixture.readFile('/index.html');
     const $ = cheerio.load(html);
 
@@ -111,10 +110,13 @@ describe('Styles SSR', () => {
     expect(el1.attr('class')).to.equal(`blue ${scopedClass}`);
     expect(el2.attr('class')).to.equal(`visible ${scopedClass}`);
 
-    const css = $('style').text();
+    let css = '';
+    $('style').each((_, el) => {
+      css += $(el).html();
+    });
 
     // test 4: CSS generates as expected
-    expect(css.toString()).to.equal(`.blue.${scopedClass}{color:powderblue}.color\\:blue.${scopedClass}{color:powderblue}.visible.${scopedClass}{display:block}`);
+    expect(css).to.include(`.blue.${scopedClass}{color:powderblue;}.color\\:blue.${scopedClass}{color:powderblue;}.visible.${scopedClass}{display:block;}`);
   });
 
   it('Astro scoped styles skipped without <style>', async () => {
@@ -125,19 +127,10 @@ describe('Styles SSR', () => {
     expect($('#no-scope').attr('class')).to.equal(undefined);
   });
 
-  // TODO: add behavior in compiler
-  it.skip('Astro scoped styles can be passed to child components', async () => {
+  it('Astro scoped styles can be passed to child components', async () => {
     const html = await fixture.readFile('/index.html');
     const $ = cheerio.load(html);
 
-    let scopedClass;
-    $('style')
-      .html()
-      .replace(/outer\.(astro-[A-Za-z0-9-]+)/, (match, p1) => {
-        scopedClass = p1;
-        return match;
-      });
-
-    expect($('#passed-in').attr('class')).to.equal(`outer ${scopedClass}`);
+    expect($('#passed-in').attr('class')).to.match(/outer astro-[A-Z0-9]+ astro-[A-Z0-9]+/);
   });
 });

--- a/packages/astro/test/fixtures/astro-client-only/src/components/PersistentCounter.svelte
+++ b/packages/astro/test/fixtures/astro-client-only/src/components/PersistentCounter.svelte
@@ -1,4 +1,3 @@
-
 <script>
   import './logResize';
 
@@ -8,15 +7,14 @@
   function add() {
     count += 1;
   }
-  
+
   function subtract() {
     count -= 1;
   }
 </script>
-  
+
 <div class="counter">
   <button on:click={subtract}>-</button>
   <pre>{ count }</pre>
   <button on:click={add}>+</button>
 </div>
-  

--- a/packages/astro/test/fixtures/astro-client-only/src/components/logResize.js
+++ b/packages/astro/test/fixtures/astro-client-only/src/components/logResize.js
@@ -1,3 +1,3 @@
 window.addEventListener("resize", function() {
-    console.log("window resized");
+  console.log("window resized");
 });

--- a/packages/astro/test/markdown.test.js
+++ b/packages/astro/test/markdown.test.js
@@ -1,5 +1,3 @@
-/**
- * UNCOMMENT: add markdown support
 import { expect } from 'chai';
 import cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
@@ -28,12 +26,9 @@ describe('Markdown tests', () => {
   });
 
   it('Can load a realworld markdown page with Astro', async () => {
-    const html = await fixture.fetch('/realworld/index.html');
+    const html = await fixture.readFile('/realworld/index.html');
     const $ = cheerio.load(html);
 
     expect($('pre')).to.have.lengthOf(7);
   });
 });
-*/
-
-it.skip('is skipped', () => {});

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -39,7 +39,7 @@ describe('React Components', () => {
     expect($('#pure')).to.have.lengthOf(1);
   });
 
-  // TODO: fix ocmpiler bug
+  // TODO: fix compiler bug
   it.skip('Includes reactroot on hydrating components', async () => {
     const html = await fixture.readFile('/index.html');
     const $ = cheerio.load(html);


### PR DESCRIPTION
## Changes

Enables tests from previous compiler changes. This mostly uncomments tests except for: 

- the ongoing build work (blocking most tests still commented)
- `<!doctype>` insertion (do we want to add this?)
- https://github.com/snowpackjs/astro/pull/1771
- https://github.com/snowpackjs/astro/pull/1743

After the above, any remaining tests are very minor in scope. In fact many of them may be outdated and we should review the ones left to see if it’s still missing behavior or not.

## Testing

Tests should pass

## Docs

No docs needed.