### PR TITLE
DOC 📘: Add `theme-color` meta tag to sites

### DIFF
--- a/docs/src/components/HeadCommon.astro
+++ b/docs/src/components/HeadCommon.astro
@@ -1,6 +1,7 @@
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width">
+<meta name="theme-color" content="#ff5e00"/>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="sitemap" href="/sitemap.xml"/>

--- a/www/src/components/BaseHead.astro
+++ b/www/src/components/BaseHead.astro
@@ -11,6 +11,7 @@ const { title, description, image = 'https://astro.build/social.jpg?v=1', canoni
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
+<meta name="theme-color" content="#ff5e00"/>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="sitemap" href="/sitemap.xml"/>


### PR DESCRIPTION
## Changes

- Adds `<meta name="theme-color" content="#ff5e00"/>` to both `www` and `docs`
This both lets browsers reflect this color + provides Discord embeds a nice accent color

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
