### PR TITLE
Improve WASM panic error

### DIFF
--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -178,7 +178,6 @@ export class AstroDevServer {
       return [];
     } catch (e) {
       const err = e as Error;
-      viteServer.ssrFixStacktrace(err);
       // eslint-disable-next-line
       console.error(err.stack);
       viteServer.ws.send({
@@ -302,7 +301,6 @@ export class AstroDevServer {
       res.write(html);
       res.end();
     } catch (err: any) {
-      this.viteServer.ssrFixStacktrace(err);
       this.viteServer.ws.send({ type: 'error', err });
       const statusCode = 500;
       const html = errorTemplate({
@@ -310,6 +308,8 @@ export class AstroDevServer {
         title: 'Internal Error',
         tabTitle: '500: Error',
         message: stripAnsi(err.message),
+        url: err.url || undefined,
+        stack: stripAnsi(err.stack),
       });
       info(this.logging, 'astro', msg.req({ url: pathname, statusCode: 500, reqTime: performance.now() - reqStart }));
       res.writeHead(statusCode, {

--- a/packages/astro/src/core/dev/template/error.ts
+++ b/packages/astro/src/core/dev/template/error.ts
@@ -1,14 +1,23 @@
 import { encode } from 'html-entities';
 
 interface ErrorTemplateOptions {
-  statusCode?: number;
-  tabTitle: string;
-  title: string;
+  /** a short description of the error */
   message: string;
+  /** information about where the error occurred */
+  stack?: string;
+  /** HTTP error code */
+  statusCode?: number;
+  /** HTML <title> */
+  tabTitle: string;
+  /** page title */
+  title: string;
+  /** show user a URL for more info or action to take */
+  url?: string;
 }
 
 /** Display internal 404 page (if user didn’t provide one) */
-export function errorTemplate({ title, message, statusCode, tabTitle }: ErrorTemplateOptions): string {
+export function errorTemplate({ title, url, message, stack, statusCode, tabTitle }: ErrorTemplateOptions): string {
+  let error = url ? message.replace(url, '') : message;
   return `<!doctype html>
 <html lang="en">
   <head>
@@ -19,12 +28,15 @@ export function errorTemplate({ title, message, statusCode, tabTitle }: ErrorTem
         background-color: #101010;
         color: #d0d0d0;
         font-family: monospace;
-        line-height: 1.6;
+        line-height: 1.5;
         margin: 0;
       }
       .wrapper {
         padding-left: 2rem;
         padding-right: 2rem;
+      }
+      a {
+        color: #ff5d01;
       }
       h1 {
         font-weight: 800;
@@ -33,7 +45,7 @@ export function errorTemplate({ title, message, statusCode, tabTitle }: ErrorTem
       }
       pre {
         color: #999;
-        font-size: 1.4em;
+        font-size: 1.2em;
         margin-top: 0;
         max-width: 60em;
       }
@@ -45,7 +57,9 @@ export function errorTemplate({ title, message, statusCode, tabTitle }: ErrorTem
   <body>
     <main class="wrapper">
       <h1>${statusCode ? `<span class="statusCode">${statusCode}</span> ` : ''}${title}</h1>
-      <pre><code>${encode(message)}</code></pre>
+      <pre><code>${encode(error)}</code></pre>
+      ${url ? `<a target="_blank" href="${url}">${url}</a>` : ''}
+      <pre><code>${encode(stack)}</code></pre>
     </main>
   </body>
 </html>

--- a/packages/astro/src/core/ssr/index.ts
+++ b/packages/astro/src/core/ssr/index.ts
@@ -81,7 +81,7 @@ async function errorHandler(e: unknown, viteServer: vite.ViteDevServer, filePath
   const anyError = e as any;
   if (anyError.errors) {
     const { location, pluginName, text } = (e as BuildResult).errors[0];
-    const err = new Error(text) as SSRError;
+    const err = e as SSRError;
     if (location) err.loc = { file: location.file, line: location.line, column: location.column };
     const frame = codeFrame(await fs.promises.readFile(filePath, 'utf8'), err.loc);
     err.frame = frame;
@@ -89,7 +89,6 @@ async function errorHandler(e: unknown, viteServer: vite.ViteDevServer, filePath
     err.message = `${location?.file}: ${text}
 ${frame}
 `;
-    err.stack = anyError.stack;
     if (pluginName) err.plugin = pluginName;
     throw err;
   }

--- a/packages/astro/test/fixtures/wasm-panic-error/src/pages/index.astro
+++ b/packages/astro/test/fixtures/wasm-panic-error/src/pages/index.astro
@@ -1,0 +1,3 @@
+
+<!-- bad code -->
+{[...new Array(20)].map(() => (<div>))}

--- a/packages/astro/test/wasm-panic-error.test.js
+++ b/packages/astro/test/wasm-panic-error.test.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+let fixture;
+
+before(async () => {
+  fixture = await loadFixture({ projectRoot: './fixtures/wasm-panic-error' });
+});
+
+describe('compiler error', () => {
+  it('throws helpful error', async () => {
+    try {
+      await fixture.build();
+
+      // should err
+      expect(true).to.be.false;
+    } catch (err) {
+      // test err thrown contains filepath
+      expect(err.stack).to.include('wasm-panic-error/src/pages/index.astro');
+
+      // test err thrown contains "unrecoverable error"
+      expect(err.message || err.toString()).to.include('Uh oh, the Astro compiler encountered an unrecoverable error!');
+    }
+  });
+});


### PR DESCRIPTION
## Changes

If a user enters invalid syntax, e.g.:

```astro
{[].map(() => (<div>))}
```

They’ll get a compiler panic error:

**Before**

![Screen Shot 2021-11-09 at 15 17 30](https://user-images.githubusercontent.com/1369770/141016241-89f21d6f-b799-4845-a02e-6a57df75489c.png)

**After**
Clickable link! 🎉 

![Screen Shot 2021-11-10 at 17 43 34](https://user-images.githubusercontent.com/1369770/141216562-63abd607-b176-4644-b528-d9893b2275ad.png)

Issue link contains the breaking code (courtesy of @natemoo-re)

![Screen Shot 2021-11-10 at 16 54 47](https://user-images.githubusercontent.com/1369770/141216990-2234d091-1138-4e6e-b195-7a01b408b2d8.png)

Also improves error display for some errors in component SSR:

![Screen Shot 2021-11-10 at 19 11 03](https://user-images.githubusercontent.com/1369770/141224785-176b65cd-9480-4862-a117-cb108f116d8f.png)



## Testing

Test added

## Docs

No docs needed