### PR TITLE
Fix CSS transform

### DIFF
--- a/packages/astro/src/core/ssr/css.ts
+++ b/packages/astro/src/core/ssr/css.ts
@@ -4,7 +4,6 @@ import path from 'path';
 
 // https://vitejs.dev/guide/features.html#css-pre-processors
 export const STYLE_EXTENSIONS = new Set(['.css', '.pcss', '.scss', '.sass', '.styl', '.stylus', '.less']);
-export const PREPROCESSOR_EXTENSIONS = new Set(['.pcss', '.scss', '.sass', '.styl', '.stylus', '.less']);
 
 /** find unloaded styles */
 export function getStylesForID(id: string, viteServer: vite.ViteDevServer): Set<string> {

--- a/packages/astro/src/vite-plugin-astro/styles.ts
+++ b/packages/astro/src/vite-plugin-astro/styles.ts
@@ -1,6 +1,6 @@
 import type vite from '../core/vite';
 
-import { PREPROCESSOR_EXTENSIONS } from '../core/ssr/css.js';
+import { STYLE_EXTENSIONS } from '../core/ssr/css.js';
 
 export type TransformHook = (code: string, id: string, ssr?: boolean) => Promise<vite.TransformResult>;
 
@@ -23,7 +23,7 @@ interface TransformWithViteOptions {
 /** Transform style using Vite hook */
 export async function transformWithVite({ value, attrs, transformHook, id, ssr }: TransformWithViteOptions): Promise<vite.TransformResult | null> {
   const lang = (`.${attrs.lang}` || '').toLowerCase(); // add leading "."; don’t be case-sensitive
-  if (!PREPROCESSOR_EXTENSIONS.has(lang)) {
+  if (!STYLE_EXTENSIONS.has(lang)) {
     return null; // only preprocess langs supported by Vite
   }
   return transformHook(value, id + `?astro&type=style&lang${lang}`, ssr);


### PR DESCRIPTION
## Changes

Tiny potential bug @matthewp and I ran across: we weren’t transforming `.css` only within Astro `<style>` tags. That may be an issue when people have set up PostCSS / Tailwind, or other transformations need to happen.

This doesn’t affect any examples; just improves style consistency across contexts.

## Testing

No tests added; tests shouldn’t break

## Docs

No docs