### PR TITLE
Allow inline code blocks to wrap lines

### DIFF
--- a/docs/public/index.css
+++ b/docs/public/index.css
@@ -198,6 +198,7 @@ code:not([class*='language']) {
   margin: calc(var(--padding-block) * -1) -0.125em;
   border-radius: var(--border-radius);
   box-shadow: 0 2px 1px 0 rgba(0, 0, 0, 0.08);
+  word-break: break-word;
 }
 
 pre > code:not([class*='language']) {

--- a/examples/blog/public/blog.css
+++ b/examples/blog/public/blog.css
@@ -212,6 +212,7 @@ code:not([class*='language']) {
   padding: var(--padding-block) var(--padding-inline);
   margin: calc(var(--padding-block) * -1) -0.125em;
   border-radius: var(--border-radius);
+  word-break: break-word;
 }
 
 pre > code:not([class*='language']) {

--- a/examples/docs/public/index.css
+++ b/examples/docs/public/index.css
@@ -202,6 +202,7 @@ code:not([class*='language']) {
   margin: calc(var(--padding-block) * -1) -0.125em;
   border-radius: var(--border-radius);
   box-shadow: 0 2px 1px 0 rgba(0, 0, 0, 0.08);
+  word-break: break-word;
 }
 
 pre > code:not([class*='language']) {

--- a/www/src/scss/blog.scss
+++ b/www/src/scss/blog.scss
@@ -226,6 +226,7 @@ code:not([class*='language']) {
   padding: var(--padding-block) var(--padding-inline);
   margin: calc(var(--padding-block) * -1) -0.125em;
   border-radius: var(--border-radius);
+  word-break: break-word;
 }
 
 pre > code:not([class*='language']) {


### PR DESCRIPTION
## Changes

This adds `word-break: break-word;` to inline code css to allow long inline code blocks to wrap lines and not blow out of the container.  @jasikpark noticed the issue in a few recent blog posts, so it seemed worthwhile to add this to the themes/examples.

Before:
![image](https://user-images.githubusercontent.com/4616705/141354770-3c05dd30-032e-4557-8d45-88e0da8d5721.png)


After:
![image](https://user-images.githubusercontent.com/4616705/141354844-c328feaa-a2ab-462b-8f18-2c77241dba82.png)


## Testing

I added a long code block, as seen in the screenshots above, and verified that my css change had the intended effect.

## Docs

No doc changes needed, just a tweak to the default styles.
