### PR TITLE
Use normalized path to detect layout files

### DIFF
--- a/.changeset/strong-bugs-confess.md
+++ b/.changeset/strong-bugs-confess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes layout file detection on non-unix environments

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -48,7 +48,7 @@ export default function astro({ config, devServer }: AstroPluginOptions): vite.P
       // pages and layouts should be transformed as full documents (implicit <head> <body> etc)
       // everything else is treated as a fragment
       const normalizedID = fileURLToPath(new URL(`file://${id}`));
-      const isPage = normalizedID.startsWith(fileURLToPath(config.pages)) || id.startsWith(fileURLToPath(config.layouts));
+      const isPage = normalizedID.startsWith(fileURLToPath(config.pages)) || normalizedID.startsWith(fileURLToPath(config.layouts));
       let source = await fs.promises.readFile(id, 'utf8');
       let tsResult: TransformResult | undefined;
 


### PR DESCRIPTION
## Changes

- Fixes layouts being rendered as fragments on non-unix environments

## Testing

Tested on Windows 10, using the [astro blog starter](https://github.com/snowpackjs/astro/tree/main/examples/blog)

## Docs

No changes
