### PR TITLE
fix: header logo/nav/svg

### DIFF
--- a/www/src/components/MainHeader.astro
+++ b/www/src/components/MainHeader.astro
@@ -1,8 +1,10 @@
 <header class={`layout is-centered`}>
-  <article>
-    <h1>
-      <a href="/">
-        <svg class="logo" width="32" height="32" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <nav>
+    <div class="logoWrapper" itemscope itemtype="https://schema.org/Organization">
+      <a href="/" itemprop="url">
+        <svg class="logo" width="32" height="32" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="astroSvgTitle astroSvgDesc" role="img" itemprop="logo">
+          <title id="astroSvgTitle">Astro logo</title>
+          <desc id="astroSvgDesc">A white uppercase lambda-like icon with a flame emanating from the bottom.</desc>
           <style>
             #flame {
               fill: #ff5d01;
@@ -11,7 +13,6 @@
               fill: white;
             }
           </style>
-          <title>Astro</title>
           <path
             id="a"
             fill-rule="evenodd"
@@ -25,24 +26,36 @@
             d="M168.19 180.151c-7.139 6.105-21.39 10.268-37.804 10.268-20.147 0-37.033-6.272-41.513-14.707-1.602 4.835-1.961 10.367-1.961 13.902 0 0-1.056 17.355 11.015 29.426 0-6.268 5.081-11.349 11.349-11.349 10.743 0 10.731 9.373 10.721 16.977v.679c0 11.542 7.054 21.436 17.086 25.606a23.27 23.27 0 01-2.339-10.2c0-11.008 6.463-15.107 13.974-19.87 5.976-3.79 12.616-8.001 17.192-16.449a31.024 31.024 0 003.743-14.82c0-3.299-.513-6.479-1.463-9.463z"
           />
         </svg>
-        <span>Astro</span>
+        <span itemprop="name">Astro</span>
       </a>
-    </h1>
-    <a class="header-subitem" href="https://docs.astro.build/">
-      <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="book" class="svg-inline--fa fa-book fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M448 360V24c0-13.3-10.7-24-24-24H96C43 0 0 43 0 96v320c0 53 43 96 96 96h328c13.3 0 24-10.7 24-24v-16c0-7.5-3.5-14.3-8.9-18.7-4.2-15.4-4.2-59.3 0-74.7 5.4-4.3 8.9-11.1 8.9-18.6zM128 134c0-3.3 2.7-6 6-6h212c3.3 0 6 2.7 6 6v20c0 3.3-2.7 6-6 6H134c-3.3 0-6-2.7-6-6v-20zm0 64c0-3.3 2.7-6 6-6h212c3.3 0 6 2.7 6 6v20c0 3.3-2.7 6-6 6H134c-3.3 0-6-2.7-6-6v-20zm253.4 250H96c-17.7 0-32-14.3-32-32 0-17.6 14.4-32 32-32h285.4c-1.9 17.1-1.9 46.9 0 64z"></path></svg>
-      Documentation
-    </a>
-    <a class="header-subitem header-subitem-secondary" href="https://twitter.com/astrodotbuild">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"  viewBox="0 0 24 24"><path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/></svg>
-      Twitter
-    </a>
-    <a class="header-subitem header-subitem-secondary" href="https://github.com/snowpackjs/astro">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24">
-        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-      </svg>
-      GitHub
-    </a>
-  </article>
+    </div>
+    <ul role="list">
+      <li>
+        <a class="header-subitem" href="https://docs.astro.build/">
+          <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="book" class="svg-inline--fa fa-book fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+            <path fill="currentColor" d="M448 360V24c0-13.3-10.7-24-24-24H96C43 0 0 43 0 96v320c0 53 43 96 96 96h328c13.3 0 24-10.7 24-24v-16c0-7.5-3.5-14.3-8.9-18.7-4.2-15.4-4.2-59.3 0-74.7 5.4-4.3 8.9-11.1 8.9-18.6zM128 134c0-3.3 2.7-6 6-6h212c3.3 0 6 2.7 6 6v20c0 3.3-2.7 6-6 6H134c-3.3 0-6-2.7-6-6v-20zm0 64c0-3.3 2.7-6 6-6h212c3.3 0 6 2.7 6 6v20c0 3.3-2.7 6-6 6H134c-3.3 0-6-2.7-6-6v-20zm253.4 250H96c-17.7 0-32-14.3-32-32 0-17.6 14.4-32 32-32h285.4c-1.9 17.1-1.9 46.9 0 64z"></path>
+          </svg>
+          Documentation
+        </a>
+      </li>
+      <li>
+        <a class="header-subitem header-subitem-secondary" href="https://twitter.com/astrodotbuild">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"  viewBox="0 0 24 24">
+            <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/>
+          </svg>
+          Twitter
+        </a>
+      </li>
+      <li>
+        <a class="header-subitem header-subitem-secondary" href="https://github.com/snowpackjs/astro">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+          </svg>
+          GitHub
+        </a>
+      </li>
+    </ul>
+  </nav>
 </header>
 
 <style>
@@ -54,10 +67,14 @@ header {
 header.is-centered article {
   justify-content: center;
 }
-article {
+nav,
+nav ul {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+nav ul {
+  list-style: none;
 }
 .header-subitem {
   display: flex;
@@ -77,40 +94,34 @@ article {
   width: 1.5rem;
   height: 1.5rem;
 }
-
 @media (max-width: 40em) {
   .header-subitem-secondary {
     display: none;
   }
 }
-
 @media (max-width: 20em) {
   .header-subitem {
     display: none;
   }
 }
-
-h1 {
+.logoWrapper {
   margin: 0;
   font-size: 1.5rem;
   max-width: 100%;
   display: flex;
   flex-grow: 1;
 }
-
-.logo {
-  transform: translateY(0.25rem);
-}
-
-svg {
-  width: 2.5rem;
-  height: 2.5rem;
-}
-
-h1 a {
+.logoWrapper a {
   text-decoration: none;
   display: inline-flex;
   align-items: center;
   padding: 0 0.5rem 0 0;
+}
+.logo {
+  transform: translateY(0.25rem);
+}
+svg {
+  width: 2.5rem;
+  height: 2.5rem;
 }
 </style>


### PR DESCRIPTION
## Changes

Overall, improve Astro's site header:
- Remove duplicate h1 tag (an h1 tag was in header _and_ main).
- Remove article tags from header.
- Improved accessibility for the SVG logo, per guidelines from [this CSS Tricks article.](https://css-tricks.com/accessible-svgs/#2-inline-svg)
- Restructure navigation links into an unordered list with list role, guidelines from [5t3ph's HTML Recipes](https://htmlrecipes.dev/#navigation-links).
- Add [Logo structured data](https://developers.google.com/search/docs/advanced/structured-data/logo) because...why not?

## Testing

Ran `astro build` — no build errors 😁

## Docs

None changed