### PR TITLE
Fix AstroComponent check

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -30,7 +30,7 @@ async function _render(child: any): Promise<any> {
   }
   // Add a comment explaining why each of these are needed.
   // Maybe create clearly named function for what this is doing.
-  else if (child instanceof AstroComponent || child.toString() === '[object AstroComponent]') {
+  else if (child instanceof AstroComponent || Object.prototype.toString.call(child) === '[object AstroComponent]') {
     return await renderAstroComponent(child);
   } else {
     return child;


### PR DESCRIPTION
## Changes

- Code currently runs `child.toString()` an objects that might not have `toString`.
- Changes check from `child.toString() === '[object AstroComponent]'` to `Object.prototype.toString.call(child) === '[object AstroComponent]'`.

```astro
---
import * as ms from 'ms';
---
{ms}
```

That should throw an error like "Cannot convert object to primitive value" but the `toString` check might be throwing before we can get it.

## Testing

This has not been tested.

## Docs

bug fix only