### PR TITLE
Support custom elements

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -145,13 +145,7 @@ export async function renderComponent(result: SSRResult, displayName: string, Co
   }
   const probableRendererNames = guessRenderers(metadata.componentUrl);
 
-  /** Type of value for `Component`, distinguishing `null` from an `object` reference. */
-  const typeOfComponent = Component === null ? 'null' : typeof Component;
-
-  /** Whether `Component` requires a renderer to be displayed. */
-  const isRenderRequiredComponent = renderers.length === 0 && (typeOfComponent === 'function' || typeOfComponent === 'object');
-
-  if (isRenderRequiredComponent) {
+  if (Array.isArray(renderers) && renderers.length === 0 && typeof Component !== 'string') {
     const message = `Unable to render ${metadata.displayName}! 
 
 There are no \`renderers\` set in your \`astro.config.mjs\` file.

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -145,7 +145,13 @@ export async function renderComponent(result: SSRResult, displayName: string, Co
   }
   const probableRendererNames = guessRenderers(metadata.componentUrl);
 
-  if (Array.isArray(renderers) && renderers.length === 0) {
+  /** Type of value for `Component`, distinguishing `null` from an `object` reference. */
+  const typeOfComponent = Component === null ? 'null' : typeof Component;
+
+  /** Whether `Component` requires a renderer to be displayed. */
+  const isRenderRequiredComponent = renderers.length === 0 && (typeOfComponent === 'function' || typeOfComponent === 'object');
+
+  if (isRenderRequiredComponent) {
     const message = `Unable to render ${metadata.displayName}! 
 
 There are no \`renderers\` set in your \`astro.config.mjs\` file.


### PR DESCRIPTION
## Changes

- Fixes regression where Astro stopped supporting non-object/non-function components, e.g. custom elements.
- Resolves https://github.com/snowpackjs/astro/issues/1853

## Testing

- cannot confirm locally
- local tests are failing before making any change

## Docs

bug fix only