### PR TITLE
fix: HMR regression

### DIFF
--- a/.changeset/beige-hairs-design.md
+++ b/.changeset/beige-hairs-design.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix HMR regression

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -24,9 +24,6 @@ const ALWAYS_EXTERNAL = new Set([
   'unified',
   'whatwg-url',
 ]);
-const ALWAYS_NOEXTERNAL = new Set([
-  'astro', // This is only because Vite's native ESM doesn't resolve "exports" correctly.
-]);
 
 // note: ssr is still an experimental API hence the type omission
 type ViteConfigWithSSR = vite.InlineConfig & { ssr?: { external?: string[]; noExternal?: string[] } };
@@ -69,7 +66,6 @@ export async function createVite(inlineConfig: ViteConfigWithSSR, { astroConfig,
     // Note: SSR API is in beta (https://vitejs.dev/guide/ssr.html)
     ssr: {
       external: [...ALWAYS_EXTERNAL],
-      noExternal: [...ALWAYS_NOEXTERNAL],
     },
   };
 

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -22,7 +22,10 @@ const ALWAYS_EXTERNAL = new Set([
   'shiki',
   'shorthash',
   'unified',
-  'whatwg-url',
+  'whatwg-url'
+]);
+const ALWAYS_NOEXTERNAL = new Set([
+  'astro', // This is only because Vite's native ESM doesn't resolve "exports" correctly.
 ]);
 
 // note: ssr is still an experimental API hence the type omission
@@ -66,6 +69,7 @@ export async function createVite(inlineConfig: ViteConfigWithSSR, { astroConfig,
     // Note: SSR API is in beta (https://vitejs.dev/guide/ssr.html)
     ssr: {
       external: [...ALWAYS_EXTERNAL],
+      noExternal: [...ALWAYS_NOEXTERNAL],
     },
   };
 


### PR DESCRIPTION
## Changes

- HMR was broken. Now it's not.
- The problem was that Vite was ignoring `astro/runtime/client/hmr.js` because we had set `ssr.noExternal: ['astro']`. The result was that `import.meta.hot` was always undefined. The fix was to inline the contents of `astro/runtime/client/hmr.js` directly rather than load them through `import 'astro/runtime/client/hmr.js'`.

## Testing

Manually, we don't have dev server tests

## Docs

Bug fix only