### PR TITLE
fix npm init flag handling in create-astro

### DIFF
--- a/.changeset/real-cats-act.md
+++ b/.changeset/real-cats-act.md
@@ -2,4 +2,4 @@
 'create-astro': patch
 ---
 
-Fix issue with latest version of npm init flag handling
+Fix issue with v7.x+ versions of npm init, which changed default flag handling

--- a/.changeset/real-cats-act.md
+++ b/.changeset/real-cats-act.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fix issue with latest version of npm init flag handling

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -9,7 +9,7 @@ import { FRAMEWORKS, COUNTER_COMPONENTS } from './frameworks.js';
 import { TEMPLATES } from './templates.js';
 import { createConfig } from './config.js';
 
-// NOTE: In the latest version of npm, the default behavior of `npm init` was changed
+// NOTE: In the v7.x version of npm, the default behavior of `npm init` was changed
 // to no longer require `--` to pass args and instead pass `--` directly to us. This 
 // broke our arg parser, since `--` is a special kind of flag. Filtering for `--` here 
 // fixes the issue so that create-astro now works on all npm version.

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -8,7 +8,13 @@ import yargs from 'yargs-parser';
 import { FRAMEWORKS, COUNTER_COMPONENTS } from './frameworks.js';
 import { TEMPLATES } from './templates.js';
 import { createConfig } from './config.js';
-const args = yargs(process.argv);
+
+// NOTE: In the latest version of npm, the default behavior of `npm init` was changed
+// to no longer require `--` to pass args and instead pass `--` directly to us. This 
+// broke our arg parser, since `--` is a special kind of flag. Filtering for `--` here 
+// fixes the issue so that create-astro now works on all npm version.
+const cleanArgv = process.argv.filter(arg => arg !== '--')
+const args = yargs(cleanArgv);
 prompts.override(args);
 
 export function mkdirp(dir: string) {


### PR DESCRIPTION
## Changes

- In the latest version of npm, the default behavior of `npm init` was changed  to no longer require `--` to pass args and instead pass `--` directly to us. 
- This broke our arg parser, since `--` is a special kind of flag. 
- Filtering for `--` here fixes the issue so that create-astro now works on all npm version.

## Testing

Tested locally. No way to test for this in our current test suite since this part of the logic happens in setup.

## Docs

N/A