### PR TITLE
fix markdown-remark audit warning

### DIFF
--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -12,6 +12,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
+    "preinstall": "npx npm-force-resolutons",
     "prepublish": "yarn build",
     "build": "astro-scripts build \"src/**/*.ts\" && tsc -p tsconfig.json",
     "postbuild": "astro-scripts copy \"src/**/*.js\"",
@@ -44,5 +45,8 @@
     "@types/github-slugger": "^1.3.0",
     "@types/prismjs": "^1.16.6",
     "gray-matter": "^4.0.3"
+  },
+  "resolutions": {
+    "trim": "1.0.1"
   }
 }


### PR DESCRIPTION
## Changes

- Fixes audit warning when installing `astro`, which is coming from `@astrojs/markdown-remark`.
- Audit warning comes from `trim` package.
- `trim` package is used by `remark-parse`, which is used by `remark-mdx`, which is used by `@astrojs/markdown-remark`.
- Solution is to force `trim` to a higher version thru `resolutions` (for yarn + `postinstall` fix for npm users).
- [Solution source](https://twitter.com/wesbos/status/1311353159386791939/photo/1)

## Testing

this was not tested

## Docs

bug fix only