### PR TITLE
fix middleware order to prevent HMR issues

### DIFF
--- a/.changeset/heavy-boxes-deliver.md
+++ b/.changeset/heavy-boxes-deliver.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix middleware order

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -83,8 +83,8 @@ export class AstroDevServer {
 
     // Setup the dev server and connect it to Vite (via middleware)
     this.viteServer = await this.createViteServer();
-    this.app.use((req, res, next) => this.handleRequest(req, res, next));
     this.app.use(this.viteServer.middlewares);
+    this.app.use((req, res, next) => this.handleRequest(req, res, next));
     this.app.use((req, res, next) => this.renderError(req, res, next));
 
     // Listen on port (and retry if taken)


### PR DESCRIPTION
## Changes
- Vite middleware can tackle HMR webhooks and exact asset references before our router
- Vite assets are always more specific than our user routes, which means they should run first to prevent getting caught by a super flexible route like `/*`
- Fixes that issue where HMR events get reported as `/` routing errors in the console

## Testing
- Covered by existing tests (actual behavior shouldn't have been impacted, but dev server should run faster and not log as many false errors)

## Docs
- N/A