### PR TITLE
Fix for built scoped Vue styles

### DIFF
--- a/.changeset/serious-knives-hug.md
+++ b/.changeset/serious-knives-hug.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes Vue scoped styles when built

--- a/packages/astro/src/vite-plugin-build-css/index.ts
+++ b/packages/astro/src/vite-plugin-build-css/index.ts
@@ -59,7 +59,10 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin {
     name: PLUGIN_NAME,
 
     configResolved(resolvedConfig) {
-
+      // Our plugin needs to run before `vite:css-post` which does a lot of what we do
+      // for bundling CSS, but since we need to control CSS we should go first.
+      // We move to right before the vite:css-post plugin so that things like the
+      // Vue plugin go before us.
       const plugins = resolvedConfig.plugins as VitePlugin[];
       const viteCSSPostIndex = resolvedConfig.plugins.findIndex((p) => p.name === 'vite:css-post');
       if (viteCSSPostIndex !== -1) {

--- a/packages/astro/test/astro-styles-ssr.test.js
+++ b/packages/astro/test/astro-styles-ssr.test.js
@@ -2,25 +2,27 @@ import { expect } from 'chai';
 import cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
-let fixture;
-let index$;
-let bundledCSS;
+describe('Styles SSR', function() {
+  this.timeout(5000);
 
-before(async () => {
-  fixture = await loadFixture({
-    projectRoot: './fixtures/astro-styles-ssr/',
-    renderers: ['@astrojs/renderer-react', '@astrojs/renderer-svelte', '@astrojs/renderer-vue'],
+  let fixture;
+  let index$;
+  let bundledCSS;
+
+  before(async () => {
+    fixture = await loadFixture({
+      projectRoot: './fixtures/astro-styles-ssr/',
+      renderers: ['@astrojs/renderer-react', '@astrojs/renderer-svelte', '@astrojs/renderer-vue'],
+    });
+    await fixture.build();
+
+    // get bundled CSS (will be hashed, hence DOM query)
+    const html = await fixture.readFile('/index.html');
+    index$ = cheerio.load(html);
+    const bundledCSSHREF = index$('link[rel=stylesheet][href^=assets/]').attr('href');
+    bundledCSS = await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/'));
   });
-  await fixture.build();
 
-  // get bundled CSS (will be hashed, hence DOM query)
-  const html = await fixture.readFile('/index.html');
-  index$ = cheerio.load(html);
-  const bundledCSSHREF = index$('link[rel=stylesheet][href^=assets/]').attr('href');
-  bundledCSS = await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/'));
-});
-
-describe('Styles SSR', () => {
   describe('Astro styles', () => {
     it('HTML and CSS scoped correctly', async () => {
       const $ = index$;
@@ -94,8 +96,7 @@ describe('Styles SSR', () => {
       expect(bundledCSS).to.include('.vue-title{');
     });
 
-    // TODO: fix Vue scoped styles in build bug
-    it.skip('Scoped styles', async () => {
+    it('Scoped styles', async () => {
       const $ = index$;
       const el = $('#vue-scoped');
 


### PR DESCRIPTION
## Changes

- Closes #1844
- Uses similar logic as the Vite CSS build plugin, which removes "pure css" code from imported JavaScript since we are including it as link tags.
- Also uses the Vue plugin's transform function so that it correctly scopes scoped CSS. We need to do this ourselves becuase our plugin is "pre" to avoid the Vite CSS build plugin from claiming CSS.

## Testing

Tests unskipped.

## Docs

N/A