### PR TITLE
fix(lit-renderer): certain reactive props not init correctly

### DIFF
--- a/.changeset/gentle-donkeys-rule.md
+++ b/.changeset/gentle-donkeys-rule.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/renderer-lit': patch
+---
+
+renderer-lit will bind to properties rather than attributes fixing certain binding issues

--- a/packages/astro/test/fixtures/lit-element/src/components/my-element.js
+++ b/packages/astro/test/fixtures/lit-element/src/components/my-element.js
@@ -3,9 +3,26 @@ import { LitElement, html } from 'lit';
 export const tagName = 'my-element';
 
 export class MyElement extends LitElement {
+  static properties = {
+    bool: {type: Boolean},
+    str: {type: String},
+    obj: {type: Object},
+  }
+
+  constructor() {
+    super();
+    this.bool = true;
+    this.str = 'not initialized';
+    this.obj = {data: null};
+    // not a reactive property
+    this.foo = 'not initialized';
+  }
   render() {
     return html`
       <div>Testing...</div>
+      <div id="bool">${this.bool}</div>
+      <div id="str">${this.str}</div>
+      <div id="data">data: ${this.obj.data}</div>
     `;
   }
 }

--- a/packages/astro/test/fixtures/lit-element/src/components/my-element.js
+++ b/packages/astro/test/fixtures/lit-element/src/components/my-element.js
@@ -5,7 +5,7 @@ export const tagName = 'my-element';
 export class MyElement extends LitElement {
   static properties = {
     bool: {type: Boolean},
-    str: {type: String},
+    str: {type: String, attribute: 'str-attr'},
     obj: {type: Object},
   }
 
@@ -20,7 +20,7 @@ export class MyElement extends LitElement {
   render() {
     return html`
       <div>Testing...</div>
-      <div id="bool">${this.bool}</div>
+      <div id="bool">${this.bool ? 'A' : 'B'}</div>
       <div id="str">${this.str}</div>
       <div id="data">data: ${this.obj.data}</div>
     `;

--- a/packages/astro/test/fixtures/lit-element/src/pages/index.astro
+++ b/packages/astro/test/fixtures/lit-element/src/pages/index.astro
@@ -9,7 +9,7 @@ import '../components/my-element.js';
 <body>
   <my-element
       foo="bar"
-      str={'initialized'}
+      str-attr={'initialized'}
       bool={false}
       obj={{data: 1}}>
   </my-element>

--- a/packages/astro/test/fixtures/lit-element/src/pages/index.astro
+++ b/packages/astro/test/fixtures/lit-element/src/pages/index.astro
@@ -7,6 +7,11 @@ import '../components/my-element.js';
   <title>LitElements</title>
 </head>
 <body>
-  <my-element foo="bar"></my-element>
+  <my-element
+      foo="bar"
+      str={'initialized'}
+      bool={false}
+      obj={{data: 1}}>
+  </my-element>
 </body>
 </html>

--- a/packages/astro/test/lit-element.test.js
+++ b/packages/astro/test/lit-element.test.js
@@ -46,7 +46,7 @@ describe('LitElement test', () => {
     // by default objects will be stringifed to [object Object]
     expect(stripExpressionMarkers($('my-element').html())).to.include(`<div id="data">data: 1</div>`);
 
-    // test ^: reactive properties are not rendered as attributes
+    // test 6: reactive properties are not rendered as attributes
     expect($('my-element').attr('obj')).to.equal(undefined);
     expect($('my-element').attr('bool')).to.equal(undefined);
     expect($('my-element').attr('str')).to.equal(undefined);

--- a/packages/astro/test/lit-element.test.js
+++ b/packages/astro/test/lit-element.test.js
@@ -5,7 +5,7 @@ import { loadFixture } from './test-utils.js';
 let fixture;
 
 const NODE_VERSION = parseFloat(process.versions.node);
-const LIT_PART = (content) => `<!--lit-part-->${content}<!--/lit-part-->`;
+const stripExpressionMarkers = (html) => html.replace(/<!--\/?lit-part-->/g, '')
 
 before(async () => {
   // @lit-labs/ssr/ requires Node 13.9 or higher
@@ -35,21 +35,21 @@ describe('LitElement test', () => {
     expect($('my-element').html()).to.include(`<div>Testing...</div>`);
 
     // test 3: string reactive property set
-    expect($('my-element').html()).to.include(`<div id="str">${LIT_PART('initialized')}</div>`);
+    expect(stripExpressionMarkers($('my-element').html())).to.include(`<div id="str">initialized</div>`);
 
     // test 4: boolean reactive property correctly set
     // <my-element bool="false"> Lit will equate to true because it uses
     // this.hasAttribute to determine its value
-    expect($('my-element').html()).to.include(`<div id="bool">${LIT_PART('false')}</div>`);
+    expect(stripExpressionMarkers($('my-element').html())).to.include(`<div id="bool">B</div>`);
 
     // test 5: object reactive property set
     // by default objects will be stringifed to [object Object]
-    expect($('my-element').html()).to.include(`<div id="data">data: ${LIT_PART('1')}</div>`);
+    expect(stripExpressionMarkers($('my-element').html())).to.include(`<div id="data">data: 1</div>`);
 
-    // test 6: reactive properties are not rendered as attributes
-    expect($('my-element').attr('str')).to.equal(undefined);
-    expect($('my-element').attr('bool')).to.equal(undefined);
+    // test ^: reactive properties are not rendered as attributes
     expect($('my-element').attr('obj')).to.equal(undefined);
+    expect($('my-element').attr('bool')).to.equal(undefined);
+    expect($('my-element').attr('str')).to.equal(undefined);
   });
 
   // Skipped because not supported by Lit

--- a/packages/astro/test/lit-element.test.js
+++ b/packages/astro/test/lit-element.test.js
@@ -5,6 +5,7 @@ import { loadFixture } from './test-utils.js';
 let fixture;
 
 const NODE_VERSION = parseFloat(process.versions.node);
+const LIT_PART = (content) => `<!--lit-part-->${content}<!--/lit-part-->`;
 
 before(async () => {
   // @lit-labs/ssr/ requires Node 13.9 or higher
@@ -27,11 +28,28 @@ describe('LitElement test', () => {
     const html = await fixture.readFile('/index.html');
     const $ = cheerio.load(html);
 
-    // test 1: attributes rendered
+    // test 1: attributes rendered – non reactive properties
     expect($('my-element').attr('foo')).to.equal('bar');
 
     // test 2: shadow rendered
     expect($('my-element').html()).to.include(`<div>Testing...</div>`);
+
+    // test 3: string reactive property set
+    expect($('my-element').html()).to.include(`<div id="str">${LIT_PART('initialized')}</div>`);
+
+    // test 4: boolean reactive property correctly set
+    // <my-element bool="false"> Lit will equate to true because it uses
+    // this.hasAttribute to determine its value
+    expect($('my-element').html()).to.include(`<div id="bool">${LIT_PART('false')}</div>`);
+
+    // test 5: object reactive property set
+    // by default objects will be stringifed to [object Object]
+    expect($('my-element').html()).to.include(`<div id="data">data: ${LIT_PART('1')}</div>`);
+
+    // test 6: reactive properties are not rendered as attributes
+    expect($('my-element').attr('str')).to.equal(undefined);
+    expect($('my-element').attr('bool')).to.equal(undefined);
+    expect($('my-element').attr('obj')).to.equal(undefined);
   });
 
   // Skipped because not supported by Lit

--- a/packages/renderers/renderer-lit/server.js
+++ b/packages/renderers/renderer-lit/server.js
@@ -28,8 +28,13 @@ function* render(tagName, attrs, children) {
   const instance = new LitElementRenderer(tagName);
 
   // LitElementRenderer creates a new element instance, so copy over.
+  const Ctr = getCustomElementConstructor(tagName);
   for (let [name, value] of Object.entries(attrs)) {
-    instance.setAttribute(name, value);
+    if (name in Ctr.prototype) {
+      instance.setProperty(name, value);
+    } else {
+      instance.setAttribute(name, value);
+    }
   }
 
   yield `<${tagName}`;

--- a/packages/renderers/renderer-lit/server.js
+++ b/packages/renderers/renderer-lit/server.js
@@ -37,6 +37,8 @@ function* render(tagName, attrs, children) {
     }
   }
 
+  instance.connectedCallback();
+
   yield `<${tagName}`;
   yield* instance.renderAttributes();
   yield `>`;

--- a/packages/renderers/renderer-lit/server.js
+++ b/packages/renderers/renderer-lit/server.js
@@ -2,14 +2,6 @@ import './server-shim.js';
 import '@lit-labs/ssr/lib/render-lit-html.js';
 import { LitElementRenderer } from '@lit-labs/ssr/lib/lit-element-renderer.js';
 
-const reservedReactProperties = new Set([
-  'children',
-  'localName',
-  'ref',
-  'style',
-  'className',
-]);
-
 function isCustomElementTag(name) {
   return typeof name === 'string' && /-/.test(name);
 }
@@ -38,15 +30,6 @@ function* render(tagName, attrs, children) {
   // LitElementRenderer creates a new element instance, so copy over.
   const Ctr = getCustomElementConstructor(tagName);
   for (let [name, value] of Object.entries(attrs)) {
-    // check if this is a property reserved by JSX parser
-    if (reservedReactProperties.has(name)) {
-      console.warn(
-        `${tagName} contains property ${name} which is a ` +
-          `reserved property. It will be used by Astro and not set on ` +
-          `the element.`
-      );
-      continue;
-    }
     // check if this is a reactive property
     if (name in Ctr.prototype) {
       instance.setProperty(name, value);

--- a/packages/renderers/renderer-lit/server.js
+++ b/packages/renderers/renderer-lit/server.js
@@ -2,6 +2,14 @@ import './server-shim.js';
 import '@lit-labs/ssr/lib/render-lit-html.js';
 import { LitElementRenderer } from '@lit-labs/ssr/lib/lit-element-renderer.js';
 
+const reservedReactProperties = new Set([
+  'children',
+  'localName',
+  'ref',
+  'style',
+  'className',
+]);
+
 function isCustomElementTag(name) {
   return typeof name === 'string' && /-/.test(name);
 }
@@ -30,6 +38,16 @@ function* render(tagName, attrs, children) {
   // LitElementRenderer creates a new element instance, so copy over.
   const Ctr = getCustomElementConstructor(tagName);
   for (let [name, value] of Object.entries(attrs)) {
+    // check if this is a property reserved by JSX parser
+    if (reservedReactProperties.has(name)) {
+      console.warn(
+        `${tagName} contains property ${name} which is a ` +
+          `reserved property. It will be used by Astro and not set on ` +
+          `the element.`
+      );
+      continue;
+    }
+    // check if this is a reactive property
     if (name in Ctr.prototype) {
       instance.setProperty(name, value);
     } else {


### PR DESCRIPTION
## Changes

This change sets properties on lit-elements rather than just attributes if the bound item is detected to be a reactive property.

## Testing

Added tests to test:

- standard string property
- boolean property
  - `bool="false"` will equate to `true` as Lit uses `hasAttribute`
- object property
  - `obj={{data: true}}` as an attribute will be stringified to `[object Object]` which Lit will interpret as `null`
- check that none of those properties are rendered as attributes

**NOTE TO REVIEWERS:** I had to check the inner html of these components because checking `$(tagname).prop(propName)` would equate to `undefined` in the testing environment. Also, checking html where there is a lit binding will output `<!--lit-part-->...<!--/lit-part-->` which may cause a brittle test if the lit-part name is changed upstream. Am welcome to any other suggestions here if that doesn't work for y'all.

## Docs

_Bug fix only_
