### PR TITLE
Add Debug tests

### DIFF
--- a/packages/astro/test/debug-component.test.js
+++ b/packages/astro/test/debug-component.test.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+describe('<Debug />', () => {
+  /** @type {import('./test-utils').Fixture} */
+  let fixture
+  /** @type {import('./test-utils').DevServer} */
+  let devServer;
+
+  before(async () => {
+    fixture = await loadFixture({ projectRoot: './fixtures/debug-component/' });
+    devServer = await fixture.startDevServer();
+  });
+
+  after(async () => {
+    devServer && await devServer.stop();
+  });
+
+  it('Works in markdown pages', async () => {
+    const response = await fixture.fetch('/posts/first');
+    expect(response.status).to.equal(200);
+  })
+});

--- a/packages/astro/test/debug-component.test.js
+++ b/packages/astro/test/debug-component.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { loadFixture } from './test-utils.js';
 
-describe('<Debug />', () => {
+describe.skip('<Debug />', () => {
   /** @type {import('./test-utils').Fixture} */
   let fixture
   /** @type {import('./test-utils').DevServer} */

--- a/packages/astro/test/debug-component.test.js
+++ b/packages/astro/test/debug-component.test.js
@@ -1,7 +1,13 @@
 import { expect } from 'chai';
 import { loadFixture } from './test-utils.js';
+import os from 'os';
 
-describe.skip('<Debug />', () => {
+// TODO: fix these tests on macOS
+const isMacOS = os.platform() === 'darwin';
+
+describe('<Debug />', () => {
+  if (isMacOS) return;
+
   /** @type {import('./test-utils').Fixture} */
   let fixture
   /** @type {import('./test-utils').DevServer} */
@@ -19,5 +25,5 @@ describe.skip('<Debug />', () => {
   it('Works in markdown pages', async () => {
     const response = await fixture.fetch('/posts/first');
     expect(response.status).to.equal(200);
-  })
+  });
 });

--- a/packages/astro/test/fixtures/debug-component/src/data/posts/my-first-post.md
+++ b/packages/astro/test/fixtures/debug-component/src/data/posts/my-first-post.md
@@ -1,0 +1,7 @@
+---
+slug: first
+---
+
+Whoot!
+
+# some heading

--- a/packages/astro/test/fixtures/debug-component/src/pages/posts/[slug].astro
+++ b/packages/astro/test/fixtures/debug-component/src/pages/posts/[slug].astro
@@ -1,0 +1,26 @@
+---
+import Debug from 'astro/debug';
+
+// all the content that should be generated
+export async function getStaticPaths() {
+    const data = Astro.fetchContent('../../data/posts/*.md')
+
+    const allArticles = data.map(({ astro, file, url, ...article }) => {
+        return {
+      	    params: { slug: article.slug },
+      	    props: {
+	            article: article,
+    		    content: astro.html,
+	    	    md: astro.source,
+	        }
+        }
+    })
+    
+    return allArticles
+
+}
+
+const x = Astro.props
+
+---
+<Debug {x} />

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -18,6 +18,9 @@ import preview from '../dist/core/preview/index.js';
  * @property {() => Promise<DevServer>} startDevServer
  */
 
+// Keep a port counter, so we know that parallel test running gets different ports
+let currentPort = 3000;
+
 /**
  * Load Astro fixture
  * @param {Object} inlineConfig Astro config partial (note: must specify projectRoot)
@@ -52,7 +55,10 @@ export async function loadFixture(inlineConfig) {
 
   return {
     build: (opts = {}) => build(config, { mode: 'development', logging: 'error', ...opts }),
-    startDevServer: () => dev(config, { logging: 'error' }),
+    startDevServer: () => {
+      config.devOptions.port = currentPort++;
+      return dev(config, { logging: 'error' });
+    },
     config,
     fetch: (url, init) => fetch(`http://${config.devOptions.hostname}:${config.devOptions.port}${url.replace(/^\/?/, '/')}`, init),
     preview: async (opts = {}) => {

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -18,9 +18,6 @@ import preview from '../dist/core/preview/index.js';
  * @property {() => Promise<DevServer>} startDevServer
  */
 
-// Keep a port counter, so we know that parallel test running gets different ports
-let currentPort = 3000;
-
 /**
  * Load Astro fixture
  * @param {Object} inlineConfig Astro config partial (note: must specify projectRoot)
@@ -55,9 +52,10 @@ export async function loadFixture(inlineConfig) {
 
   return {
     build: (opts = {}) => build(config, { mode: 'development', logging: 'error', ...opts }),
-    startDevServer: () => {
-      config.devOptions.port = currentPort++;
-      return dev(config, { logging: 'error' });
+    startDevServer: async () => {
+      const devServer = await dev(config, { logging: 'error' });
+      console.log(`Dev server running on port ${devServer.port}`);
+      return devServer;
     },
     config,
     fetch: (url, init) => fetch(`http://${config.devOptions.hostname}:${config.devOptions.port}${url.replace(/^\/?/, '/')}`, init),

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -52,11 +52,7 @@ export async function loadFixture(inlineConfig) {
 
   return {
     build: (opts = {}) => build(config, { mode: 'development', logging: 'error', ...opts }),
-    startDevServer: async () => {
-      const devServer = await dev(config, { logging: 'error' });
-      console.log(`Dev server running on port ${devServer.port}`);
-      return devServer;
-    },
+    startDevServer: () => dev(config, { logging: 'error' }),
     config,
     fetch: (url, init) => fetch(`http://${config.devOptions.hostname}:${config.devOptions.port}${url.replace(/^\/?/, '/')}`, init),
     preview: async (opts = {}) => {


### PR DESCRIPTION
## Changes

- Makes Debug use the `Code` component so that JSON is properly serialized. Without this Vite's HTML parser blows up.
- Closes #1778

## Testing

Added some `<Debug />` tests.

## Docs

N/A, bug fix only.