### PR TITLE
fix the preview command base URL

### DIFF
--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -23,7 +23,7 @@ interface PreviewServer {
 /** The primary dev action */
 export default async function preview(config: AstroConfig, { logging }: PreviewOptions): Promise<PreviewServer> {
   const startServerTime = performance.now();
-  const base = config.buildOptions.site ? new URL(config.buildOptions.site).pathname + '/' : '/';
+  const base = config.buildOptions.site ? new URL(config.buildOptions.site).pathname : '/';
 
   // Create the preview server, send static files out of the `dist/` directory.
   const server = http.createServer((req, res) => {


### PR DESCRIPTION
## Changes

- small bug fix for the preview command which was hosting at ` Local: http://localhost:3000//` by default