### PR TITLE
Warn on missing pages directory

### DIFF
--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -36,6 +36,7 @@ function resolveArgs(flags: Arguments): CLIState {
     sitemap: typeof flags.sitemap === 'boolean' ? flags.sitemap : undefined,
     port: typeof flags.port === 'number' ? flags.port : undefined,
     config: typeof flags.config === 'string' ? flags.config : undefined,
+    hostname: typeof flags.hostname === 'string' ? flags.hostname : undefined,
   };
 
   if (flags.version) {
@@ -109,8 +110,11 @@ export async function cli(args: string[]) {
   if (flags.silent) logging.level = 'silent';
   let config: AstroConfig;
   try {
+    console.log('test', 1, { cwd: projectRoot, filename: options.config });
     config = await loadConfig({ cwd: projectRoot, filename: options.config });
+    console.log('test', 2, { devOptions: config.devOptions, options });
     mergeCLIFlags(config, options);
+    console.log('test', 3);
   } catch (err) {
     if (err instanceof z.ZodError) {
       console.log(formatConfigError(err));

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -110,11 +110,8 @@ export async function cli(args: string[]) {
   if (flags.silent) logging.level = 'silent';
   let config: AstroConfig;
   try {
-    console.log('test', 1, { cwd: projectRoot, filename: options.config });
     config = await loadConfig({ cwd: projectRoot, filename: options.config });
-    console.log('test', 2, { devOptions: config.devOptions, options });
     mergeCLIFlags(config, options);
-    console.log('test', 3);
   } catch (err) {
     if (err instanceof z.ZodError) {
       console.log(formatConfigError(err));

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -48,7 +48,7 @@ class AstroBuilder {
     const port = config.devOptions.port; // no need to save this (don’t rely on port in builder)
     this.logging = options.logging;
     this.origin = config.buildOptions.site ? new URL(config.buildOptions.site).origin : `http://localhost:${port}`;
-    this.manifest = createRouteManifest({ config });
+    this.manifest = createRouteManifest({ config }, this.logging);
   }
 
   async build() {

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -76,7 +76,7 @@ export class AstroDevServer {
     this.site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
     this.devRoot = this.site ? this.site.pathname : '/';
     this.url = new URL(this.devRoot, this.origin);
-    this.manifest = createRouteManifest({ config });
+    this.manifest = createRouteManifest({ config }, this.logging);
   }
 
   async start() {
@@ -250,7 +250,7 @@ export class AstroDevServer {
         return;
       }
       this.routeCache = {};
-      this.manifest = createRouteManifest({ config: this.config });
+      this.manifest = createRouteManifest({ config: this.config }, this.logging);
     });
     viteServer.watcher.on('unlink', (file) => {
       // Only rebuild routes if deleted file is a page.
@@ -258,7 +258,7 @@ export class AstroDevServer {
         return;
       }
       this.routeCache = {};
-      this.manifest = createRouteManifest({ config: this.config });
+      this.manifest = createRouteManifest({ config: this.config }, this.logging);
     });
     viteServer.watcher.on('change', () => {
       // No need to rebuild routes on file content changes.

--- a/packages/astro/src/core/ssr/routing.ts
+++ b/packages/astro/src/core/ssr/routing.ts
@@ -83,7 +83,7 @@ interface Item {
 }
 
 /** Create manifest of all static routes */
-export function createRouteManifest({ config, cwd }: { config: AstroConfig; cwd?: string }): ManifestData {
+export function createRouteManifest({ config, cwd }: { config: AstroConfig; cwd?: string }, logging: LogOptions): ManifestData {
   const components: string[] = [];
   const routes: RouteData[] = [];
 
@@ -194,7 +194,13 @@ export function createRouteManifest({ config, cwd }: { config: AstroConfig; cwd?
     });
   }
 
-  walk(fileURLToPath(config.pages), [], []);
+  if (fs.existsSync(config.pages)) {
+    walk(fileURLToPath(config.pages), [], []);
+  } else {
+    const pagesDirRootRelative = config.pages.href.slice(config.projectRoot.href.length);
+
+    warn(logging, 'astro', `Missing pages directory: ${pagesDirRootRelative}`);
+  }
 
   return {
     routes,

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -21,12 +21,15 @@ describe('config', () => {
       const proc = devCLI(cwdURL, args);
 
       proc.stdout.setEncoding('utf8');
+
       for await (const chunk of proc.stdout) {
         if (/Local:/.test(chunk)) {
           expect(chunk).to.include('127.0.0.1');
           break;
         }
       }
+
+      proc.kill();
     });
   });
 
@@ -36,14 +39,17 @@ describe('config', () => {
       const cwdURL = new URL(cwd, import.meta.url);
       const configPath = new URL('./config/my-config.mjs', cwdURL).pathname;
       const args = ['--config', configPath];
-      const process = devCLI(cwdURL, args);
+      const proc = devCLI(cwdURL, args);
 
-      process.stdout.setEncoding('utf8');
-      for await (const chunk of process.stdout) {
+      proc.stdout.setEncoding('utf8');
+
+      for await (const chunk of proc.stdout) {
         if (/Server started/.test(chunk)) {
           break;
         }
       }
+
+      proc.kill();
     });
   });
 

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -14,7 +14,7 @@ describe('config', () => {
       expect(hostnameFixture.config.devOptions.hostname).to.equal('0.0.0.0');
     });
 
-    it.skip('can be specified via --hostname flag', async () => {
+    it('can be specified via --hostname flag', async () => {
       const cwd = './fixtures/config-hostname/';
       const cwdURL = new URL(cwd, import.meta.url);
       const args = ['--hostname', '127.0.0.1'];

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -14,7 +14,7 @@ describe('config', () => {
       expect(hostnameFixture.config.devOptions.hostname).to.equal('0.0.0.0');
     });
 
-    it('can be specified via --hostname flag', async () => {
+    it.skip('can be specified via --hostname flag', async () => {
       const cwd = './fixtures/config-hostname/';
       const cwdURL = new URL(cwd, import.meta.url);
       const args = ['--hostname', '127.0.0.1'];


### PR DESCRIPTION
## Changes

- Before: When the pages directory does not exist, Astro throws an internal error that is less helpful to users.
- After: When the pages directory does not exist, Astro warns users that no pages directory exists.
- Resolves https://github.com/snowpackjs/astro/issues/1889

**Example**
```log
astro dev

08:00 AM [astro] Missing pages directory: src/pages/
08:00 AM [astro] Server started                               297ms
08:00 AM [astro] Local: http://localhost:3000/
```

## Testing

no tests added

## Docs

bug fix only