### PR TITLE
Resolve vite client modules to vendored vite

### DIFF
--- a/.changeset/popular-plants-report.md
+++ b/.changeset/popular-plants-report.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for dev server not starting

--- a/packages/astro/vendor/vite/dist/node/chunks/dep-35df7f96.js
+++ b/packages/astro/vendor/vite/dist/node/chunks/dep-35df7f96.js
@@ -2996,9 +2996,9 @@ const NULL_BYTE_PLACEHOLDER = `__x00__`;
 const CLIENT_PUBLIC_PATH = `/@vite/client`;
 const ENV_PUBLIC_PATH = `/@vite/env`;
 // eslint-disable-next-line node/no-missing-require
-const CLIENT_ENTRY = require.resolve('vite/dist/client/client.mjs');
+const CLIENT_ENTRY = require.resolve('../../client/client.mjs');
 // eslint-disable-next-line node/no-missing-require
-const ENV_ENTRY = require.resolve('vite/dist/client/env.mjs');
+const ENV_ENTRY = require.resolve('../../client/env.mjs');
 const CLIENT_DIR = path__default.dirname(CLIENT_ENTRY);
 // ** READ THIS ** before editing `KNOWN_ASSET_TYPES`.
 //   If you add an asset to `KNOWN_ASSET_TYPES`, make sure to also add it


### PR DESCRIPTION
## Changes

- 6b9ec716ee10f7351c521b4677d5daceef9a45a7 removed vite as a dependency but i guess we actually did depend on it. Fix is to make our vendored version use the local copies of the client modules.

## Testing

Nope

## Docs

N/A