### PR TITLE
Remove additional newlines added to HTML

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -17,7 +17,7 @@ export type { Metadata } from './metadata';
 async function _render(child: any): Promise<any> {
   child = await child;
   if (Array.isArray(child)) {
-    return (await Promise.all(child.map((value) => _render(value)))).join('\n');
+    return (await Promise.all(child.map((value) => _render(value)))).join('');
   } else if (typeof child === 'function') {
     // Special: If a child is a function, call it automatically.
     // This lets you do {() => ...} without the extra boilerplate
@@ -375,7 +375,7 @@ export async function renderPage(result: SSRResult, Component: AstroComponentFac
   if (needsHydrationStyles) {
     styles.push(renderElement('style', { props: { 'astro-style': true }, children: 'astro-root, astro-fragment { display: contents; }' }));
   }
-  return template.replace('</head>', styles.join('\n') + scripts.join('\n') + '</head>');
+  return template.replace('</head>', styles.join('') + scripts.join('') + '</head>');
 }
 
 export async function renderAstroComponent(component: InstanceType<typeof AstroComponent>) {

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -375,7 +375,7 @@ export async function renderPage(result: SSRResult, Component: AstroComponentFac
   if (needsHydrationStyles) {
     styles.push(renderElement('style', { props: { 'astro-style': true }, children: 'astro-root, astro-fragment { display: contents; }' }));
   }
-  return template.replace('</head>', styles.join('') + scripts.join('') + '</head>');
+  return template.replace('</head>', styles.join('\n') + scripts.join('\n') + '</head>');
 }
 
 export async function renderAstroComponent(component: InstanceType<typeof AstroComponent>) {

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -174,7 +174,7 @@ export async function main() {
         return indent + importStatements.join('\n');
       })
       .replace(/^(\s*)<!-- ASTRO:COMPONENT_MARKUP -->/gm, (_, indent) => {
-        return components.map((ln) => indent + ln).join('\n');
+        return components.map((ln) => indent + ln).join('');
       });
     await fs.promises.writeFile(pageFileLoc, newContent);
   }

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -174,7 +174,7 @@ export async function main() {
         return indent + importStatements.join('\n');
       })
       .replace(/^(\s*)<!-- ASTRO:COMPONENT_MARKUP -->/gm, (_, indent) => {
-        return components.map((ln) => indent + ln).join('');
+        return components.map((ln) => indent + ln).join('\n');
       });
     await fs.promises.writeFile(pageFileLoc, newContent);
   }


### PR DESCRIPTION
## Changes

- Astro adds newlines to resolved arrays (components rendered within `map()` for example)
- This space is not authored space, and causes issues within strictly formatted blocks (`<pre>`, `<textarea>`, `white-space: pre`, etc.).
- This removes the additional newlines.

## Testing

Effects were observed when migrating https://astro.build/blog/introducing-astro/

## Docs

bug fix only