### PR TITLE
Add polyfill scripts to result.scripts

### DIFF
--- a/.changeset/rare-cars-lick.md
+++ b/.changeset/rare-cars-lick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Lit renderer built

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -224,8 +224,12 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 
   // This is used to add polyfill scripts to the page, if the renderer needs them.
   if (renderer?.polyfills?.length) {
-    let polyfillScripts = renderer.polyfills.map((src) => `<script type="module">import "${src}";</script>`).join('');
-    html = html + polyfillScripts;
+    for(const src of renderer.polyfills) {
+      result.scripts.add({
+        props: { type: 'module' },
+        children: `import "${src}";`,
+      });
+    }
   }
 
   if (!hydration) {

--- a/packages/astro/test/custom-elements.test.js
+++ b/packages/astro/test/custom-elements.test.js
@@ -47,8 +47,8 @@ describe('Custom Elements', () => {
     expect($('my-element template[shadowroot=open]')).to.have.lengthOf(1);
 
     // Hydration
-    // test 3: Component and polyfill scripts included
-    expect($('script[type=module]')).to.have.lengthOf(2);
+    // test 3: Component and polyfill scripts bundled together
+    expect($('script[type=module]')).to.have.lengthOf(1);
   });
 
   it('Polyfills are added even if not hydrating', async () => {


### PR DESCRIPTION
## Changes

- Fixes Lit example in prod
- Makes these be normal scripts that are added to the head. This ensures they are picked up and built.

## Testing

Tested manually

## Docs

N/A