### PR TITLE
Add vite back as a dependency

### DIFF
--- a/.changeset/friendly-dingos-lie.md
+++ b/.changeset/friendly-dingos-lie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds missing vite dependency, vixing svelte and vue

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -100,6 +100,7 @@
     "strip-ansi": "^7.0.1",
     "supports-esm": "^1.0.0",
     "tsconfig-resolver": "^3.0.1",
+    "vite": "^2.6.10",
     "yargs-parser": "^20.2.9",
     "zod": "^3.8.1"
   },


### PR DESCRIPTION
## Changes

- `vite` needs to be a dependency since a few plugins, specifically svelte and vue, depend on it existing even though they do not depend on it themselves.

## Testing

Locally in the example project

## Docs

N/A