### PR TITLE
Fix RegExp#test in Config test

### DIFF
--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -22,7 +22,7 @@ describe('config', () => {
 
       proc.stdout.setEncoding('utf8');
       for await (const chunk of proc.stdout) {
-        if (/Local:/.it(chunk)) {
+        if (/Local:/.test(chunk)) {
           expect(chunk).to.include('127.0.0.1');
           break;
         }
@@ -40,7 +40,7 @@ describe('config', () => {
 
       process.stdout.setEncoding('utf8');
       for await (const chunk of process.stdout) {
-        if (/Server started/.it(chunk)) {
+        if (/Server started/.test(chunk)) {
           break;
         }
       }


### PR DESCRIPTION
## Changes

- Test included `/Local:/.it(chunk)` and `/Server started/.it(chunk)`.
- RegExp#it is not a function.
- Test updated to `/Local:/.test(chunk)` and `/Server started/.test(chunk)`.

## Testing

fixes test

## Docs

test fix only