### PR TITLE
feat: expose `<Content />` component to `Astro.fetchContent`

### DIFF
--- a/.changeset/clever-cobras-notice.md
+++ b/.changeset/clever-cobras-notice.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Expose `<Content />` component to `Astro.fetchContent`

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -262,6 +262,7 @@ function createFetchContentFn(url: URL) {
         const urlSpec = new URL(spec, url).pathname;
         return {
           ...mod.frontmatter,
+          Content: mod.default,
           content: mod.metadata,
           file: new URL(spec, url),
           url: urlSpec.includes('/pages/') ? urlSpec.replace(/^.*\/pages\//, '/').replace(/(\/index)?\.md$/, '') : undefined,


### PR DESCRIPTION
## Changes

- Components in Markdown did not play nicely with `fetchContent`.
- This is a non-breaking change that was discussed with @FredKSchott. It's a small API update that allows Markdown + Components files to be rendered.

Example usage:
```astro
---
export function getStaticPaths() {
  const posts = Astro.fetchContent('../../data/blog-posts/*.md');
  return posts.map(p => ({
    params: { slug: p.file.pathname.split('/').pop().split('.').shift() },
    props: { post: p },
  }));
}

const { Content } = Astro.props.post;
---

<html lang={ lang ?? 'en' }>
  <head>
    <link rel="stylesheet" href={Astro.resolve('../../scss/blog.scss')} />
  </head>
  <body>
    <Content />
  </body>
</html>

```

## Testing

Manually

## Docs

No docs atm