### PR TITLE
Add migration guide for Tailwind CSS

### DIFF
--- a/docs/src/pages/migration/0.21.0.md
+++ b/docs/src/pages/migration/0.21.0.md
@@ -208,6 +208,20 @@ Autoprefixer is no longer run by default. To enable:
      },
    };
    ```
+### Tailwind CSS
+
+Ensure you have PostCSS installed. This was optional in previous releases, but is required now:
+
+1. Intall the latest version of postcss (`npm i -D postcss`)
+2. Create a `postcss.config.cjs` file at the root of your project with:
+   ```js
+   module.exports = {
+     plugins: {
+       tailwindcss: {},
+     },
+   };
+   ```
+For more information, read the [Tailwind CSS documentation](https://tailwindcss.com/docs/installation#add-tailwind-as-a-post-css-plugin)
 
 [snowpack]: https://www.snowpack.dev
 [vite]: https://vitejs.dev


### PR DESCRIPTION
Added some proposed changes to help others migrate their Astro projects built with Tailwind CSS, over to the new version (0.21.0).

## Changes

- Updated documentation to help others migrate to the new version.

## Testing

- To validate this change, you can migrate from a 0.20 Astro project using Tailwind CSS and install the latest version of Astro (0.21.0). You will notice Tailwind CSS stopped working if you didn't have postcss installed. Installing postcss solves this issue.

## Docs

- Updated the docs to include some steps I had to do in order to get it to work

