### PR TITLE
Support `lang="postcss"`

### DIFF
--- a/.changeset/big-mangos-bow.md
+++ b/.changeset/big-mangos-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Support `lang="postcss"` in addition to `lang="pcss"`

--- a/packages/astro/src/core/ssr/css.ts
+++ b/packages/astro/src/core/ssr/css.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { viteifyURL } from '../util.js';
 
 // https://vitejs.dev/guide/features.html#css-pre-processors
-export const STYLE_EXTENSIONS = new Set(['.css', '.pcss', '.scss', '.sass', '.styl', '.stylus', '.less']);
+export const STYLE_EXTENSIONS = new Set(['.css', '.pcss', '.postcss', '.scss', '.sass', '.styl', '.stylus', '.less']);
 
 /** find unloaded styles */
 export function getStylesForURL(filePath: URL, viteServer: vite.ViteDevServer): Set<string> {


### PR DESCRIPTION
## Changes

- Supports `lang="postcss"` in addition to `lang="pcss"`
  - The [PostCSS Language Support](https://marketplace.visualstudio.com/items?itemName=csstools.postcss) extension supports `.postcss` files. We should as well.
  - Vite supports the following style extensions: [`css|less|sass|scss|styl|stylus|pcss|postcss`](https://github.com/vitejs/vite/blob/5987a77dce6c2e078a4b929be7165b90faf96f8c/packages/vite/src/node/plugins/css.ts#L85)
- Closes https://github.com/snowpackjs/astro/issues/1947

## Testing

TBD, we don't have any style preprocessor tests

## Docs

Bug fix only
