### PR TITLE
fix: output `404.astro` to `404.html`

### DIFF
--- a/.changeset/twenty-hounds-approve.md
+++ b/.changeset/twenty-hounds-approve.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix regression with `astro build` 404.astro output

--- a/examples/minimal/src/pages/404.astro
+++ b/examples/minimal/src/pages/404.astro
@@ -1,1 +1,0 @@
-<h1>Oops you broke it!</h1>

--- a/examples/minimal/src/pages/404.astro
+++ b/examples/minimal/src/pages/404.astro
@@ -1,0 +1,1 @@
+<h1>Oops you broke it!</h1>

--- a/packages/astro/src/vite-plugin-build-html/index.ts
+++ b/packages/astro/src/vite-plugin-build-html/index.ts
@@ -21,7 +21,7 @@ const ASTRO_PAGE_PREFIX = '@astro-page';
 const ASTRO_SCRIPT_PREFIX = '@astro-script';
 
 const ASTRO_EMPTY = '@astro-empty';
-
+const STATUS_CODE_RE = /^\d{3}$/;
 const tagsWithSrcSet = new Set(['img', 'source']);
 
 const isAstroInjectedLink = (node: parse5.Element) => isStylesheetLink(node) && getAttribute(node, 'data-astro-injected') === '';
@@ -424,7 +424,17 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
         }
 
         const outHTML = parse5.serialize(document);
-        const outPath = npath.posix.join(pathname.substr(1), 'index.html');
+        const name = pathname.substr(1);
+        let outPath: string;
+
+        // Output directly to 400.html rather than 400/index.html
+        // Supports any other status codes, too
+        if (name.match(STATUS_CODE_RE)) {
+          outPath = npath.posix.join(`${name}.html`)
+        } else {
+          outPath = npath.posix.join(name, 'index.html')
+        }
+
         this.emitFile({
           fileName: outPath,
           source: outHTML,

--- a/packages/astro/src/vite-plugin-build-html/index.ts
+++ b/packages/astro/src/vite-plugin-build-html/index.ts
@@ -21,7 +21,7 @@ const ASTRO_PAGE_PREFIX = '@astro-page';
 const ASTRO_SCRIPT_PREFIX = '@astro-script';
 
 const ASTRO_EMPTY = '@astro-empty';
-const STATUS_CODE_RE = /^\d{3}$/;
+const STATUS_CODE_RE = /^404$/;
 const tagsWithSrcSet = new Set(['img', 'source']);
 
 const isAstroInjectedLink = (node: parse5.Element) => isStylesheetLink(node) && getAttribute(node, 'data-astro-injected') === '';
@@ -427,7 +427,7 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
         const name = pathname.substr(1);
         let outPath: string;
 
-        // Output directly to 400.html rather than 400/index.html
+        // Output directly to 404.html rather than 400/index.html
         // Supports any other status codes, too
         if (name.match(STATUS_CODE_RE)) {
           outPath = npath.posix.join(`${name}.html`)


### PR DESCRIPTION
## Changes

- Closes https://github.com/snowpackjs/astro/issues/1944
- There was a regression in v0.21 where `404.astro` would be built to `404/index.html`. This causes issues with most hosts.
- This PR updates `astro build` to directly output `STATUS_CODE.html`, where `STATUS_CODE` is any 3 digit sequence.

## Testing

Tested manually. Will add a test to catch future regressions.

## Docs

N/A, bug fix