### PR TITLE
Patch: Example Nanostores Update

### DIFF
--- a/docs/src/pages/getting-started.md
+++ b/docs/src/pages/getting-started.md
@@ -30,7 +30,9 @@ npm init astro -- --template [GITHUB_USER]/[REPO_NAME]/path/to/example
 
 ### Online Playgrounds
 
-If you're interested in playing around with Astro in the browser, you can use an online code editor like Stackblitz, CodeSandbox, Gitpod, or GitHub Codespaces. Click the "Open in Stackblitz" link in any of the examples in our [examples library](https://github.com/snowpackjs/astro/tree/main/examples). Or, [click here](https://stackblitz.com/fork/astro) to start a new project in [Stackblitz](https://stackblitz.com/fork/astro).
+If you're interested in playing around with Astro in the browser, you can instantly spin up a new Astro project with our UI at [astro.new](https://astro.new/).
+
+You can try Astro in online code editors like Stackblitz, CodeSandbox, Gitpod, and GitHub Codespaces. Click the "Open in Stackblitz" link in any of the examples in our [examples library](https://github.com/snowpackjs/astro/tree/main/examples). Or, [click here](https://stackblitz.com/fork/astro) to start a new project in [Stackblitz](https://stackblitz.com/fork/astro).
 
 ## Learn Astro
 

--- a/examples/with-nanostores/package.json
+++ b/examples/with-nanostores/package.json
@@ -9,7 +9,10 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "nanostores": "^0.3.3"
+    "@nanostores/preact": "^0.1.2",
+    "@nanostores/react": "^0.1.2",
+    "@nanostores/vue": "^0.4.1",
+    "nanostores": "^0.5.6"
   },
   "devDependencies": {
     "@astrojs/renderer-solid": "^0.2.0",

--- a/examples/with-nanostores/src/components/AdminsPreact.jsx
+++ b/examples/with-nanostores/src/components/AdminsPreact.jsx
@@ -1,5 +1,5 @@
 import { h, Fragment } from 'preact';
-import { useStore } from 'nanostores/preact';
+import { useStore } from '@nanostores/preact';
 
 import { admins } from '../store/admins.js';
 import { counter, increaseCounter, decreaseCounter } from '../store/counter.js';

--- a/examples/with-nanostores/src/components/AdminsReact.jsx
+++ b/examples/with-nanostores/src/components/AdminsReact.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useStore } from 'nanostores/react';
+import { useStore } from '@nanostores/react';
 
 import { admins } from '../store/admins.js';
 import { counter, increaseCounter, decreaseCounter } from '../store/counter.js';

--- a/examples/with-nanostores/src/components/AdminsSvelte.svelte
+++ b/examples/with-nanostores/src/components/AdminsSvelte.svelte
@@ -1,10 +1,8 @@
 <script>
-  import { getValue } from 'nanostores'
-
   import { users } from '../store/users.js';
   import { counter, increaseCounter, decreaseCounter } from '../store/counter.js';
 
-  const list = getValue(users).filter(user => user.isAdmin);
+  const list = users.get().filter((user) => user.isAdmin);
 </script>
 
 <h1>Svelte</h1>

--- a/examples/with-nanostores/src/components/AdminsVue.vue
+++ b/examples/with-nanostores/src/components/AdminsVue.vue
@@ -1,21 +1,23 @@
 <template>
-  <h1>Vue</h1>
-  <ul>
-    <li v-for="user in list" :key="user.name">
-      {{ JSON.stringify(user, null, 2) }}
-    </li>
-  </ul>
   <div>
-    <h3>Counter</h3>
-    <p>{{ count }}</p>
-    <button @click="decreaseCounter">-1</button>
-    <button @click="increaseCounter">+1</button>
+    <h1>Vue</h1>
+    <ul>
+      <li v-for="user in list" :key="user.name">
+        {{ JSON.stringify(user, null, 2) }}
+      </li>
+    </ul>
+    <div>
+      <h3>Counter</h3>
+      <p>{{ count }}</p>
+      <button @click="decreaseCounter">-1</button>
+      <button @click="increaseCounter">+1</button>
+    </div>
+    <br />
   </div>
-  <br />
 </template>
 
 <script>
-import { useStore } from 'nanostores/vue';
+import { useStore } from '@nanostores/vue';
 
 import { admins } from '../store/admins.js';
 import { counter, increaseCounter, decreaseCounter } from '../store/counter.js';

--- a/examples/with-nanostores/src/store/admins.js
+++ b/examples/with-nanostores/src/store/admins.js
@@ -1,7 +1,7 @@
-import { createDerived } from 'nanostores';
+import { computed } from 'nanostores';
 
 import { users } from './users.js';
 
-const admins = createDerived(users, (list) => list.filter((user) => user.isAdmin));
+const admins = computed(users, (list) => list.filter((user) => user.isAdmin));
 
 export { admins };

--- a/examples/with-nanostores/src/store/counter.js
+++ b/examples/with-nanostores/src/store/counter.js
@@ -1,15 +1,13 @@
-import { createStore, getValue } from 'nanostores';
+import { atom } from 'nanostores';
 
-const counter = createStore(() => {
-  counter.set(0);
-});
+const counter = atom(0);
 
 function increaseCounter() {
-  counter.set(getValue(counter) + 1);
+  counter.set(counter.get() + 1);
 }
 
 function decreaseCounter() {
-  counter.set(getValue(counter) - 1);
+  counter.set(counter.get() - 1);
 }
 
 export { counter, increaseCounter, decreaseCounter };

--- a/examples/with-nanostores/src/store/users.js
+++ b/examples/with-nanostores/src/store/users.js
@@ -1,27 +1,25 @@
-import { createStore, getValue } from 'nanostores';
+import { atom } from 'nanostores';
 
-const users = createStore(() => {
-  users.set([
-    {
-      name: 'Imanadmin',
-      age: 2,
-      isAdmin: true,
-    },
-    {
-      name: 'Imnotadmin',
-      age: 35,
-      isAdmin: false,
-    },
-    {
-      name: 'Wowsomuchadmin',
-      age: 3634,
-      isAdmin: true,
-    },
-  ]);
-});
+const users = atom([
+  {
+    name: 'Imanadmin',
+    age: 2,
+    isAdmin: true,
+  },
+  {
+    name: 'Imnotadmin',
+    age: 35,
+    isAdmin: false,
+  },
+  {
+    name: 'Wowsomuchadmin',
+    age: 3634,
+    isAdmin: true,
+  },
+]);
 
 const addUser = function addUser(user) {
-  users.set([...getValue(users), user]);
+  users.set([...users.get(), user]);
 };
 
 export { users, addUser };


### PR DESCRIPTION
## Changes

- What does this change?
- Change example with-nanostores to use new nanostore version (`^0.5.6`)
- Change example code with-nanostores to use non deprecated function

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
- Manual run by running the example (npm install, npm run dev)

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

- Last example using deprecated functions on nanostores (getValue, createStore), which has been changed on nanostores documentation to atom, atom.get()