### PR TITLE
fix: avoid infinite loops in `crawlCSS`

### DIFF
--- a/.changeset/six-rockets-jump.md
+++ b/.changeset/six-rockets-jump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix CSS scanning bug that could lead to infinite loops

--- a/packages/astro/src/core/ssr/css.ts
+++ b/packages/astro/src/core/ssr/css.ts
@@ -18,6 +18,9 @@ export function getStylesForURL(filePath: URL, viteServer: vite.ViteDevServer): 
   function crawlCSS(entryModule: string, scanned = new Set<string>()) {
     const moduleName = idToModuleMap.get(entryModule);
     if (!moduleName) return;
+    if (!moduleName.id) return;
+    // mark the entrypoint as scanned to avoid an infinite loop
+    scanned.add(moduleName.id)
     for (const importedModule of moduleName.importedModules) {
       if (!importedModule.id || scanned.has(importedModule.id)) continue;
       const ext = path.extname(importedModule.id.toLowerCase());


### PR DESCRIPTION
## Changes

- We had a bug in `crawlCSS` that would create infinite loops
- The entry module was never marked as scanned, only the packages which it imported.
- This fix preemptively marks the entry module as scanned so that it does not recurse into itself.

## Testing

Tested manually. Can use the following as a test case, as well. https://stackblitz.com/edit/github-b1hhg9?file=src%2Flayouts%2Fpage.astro

## Docs

Bug fix only