### PR TITLE
fix: `client:only` behavior with a single renderer

### DIFF
--- a/.changeset/slimy-turtles-boil.md
+++ b/.changeset/slimy-turtles-boil.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix client:only behavior when only a single renderer is configured

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -168,6 +168,10 @@ Did you mean to enable ${formatList(probableRendererNames.map((r) => '`' + r + '
       const rendererName = metadata.hydrateArgs;
       renderer = renderers.filter(({ name }) => name === `@astrojs/renderer-${rendererName}` || name === rendererName)[0];
     }
+    // Attempt: user only has a single renderer, default to that
+    if (!renderer && renderers.length === 1) {
+      renderer = renderers[0]
+    }
     // Attempt: can we guess the renderer from the export extension?
     if (!renderer) {
       const extname = metadata.componentUrl?.split('.').pop();


### PR DESCRIPTION
## Changes

- Closes https://github.com/snowpackjs/astro/issues/1958
- I introduced a regression with `client:only` behavior in 0.21.
- When a user only has a single renderer and is using `client:only`, we now default to that renderer.

## Testing

Manually

## Docs

Bug fix only
