### PR TITLE
docs: update link to AstroUserConfig type definitions

### DIFF
--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -5,7 +5,7 @@ title: Configuration Reference
 
 To configure Astro, add an `astro.config.mjs` file in the root of your project. All settings are optional.
 
-You can view the full configuration API (including information about default configuration) on [GitHub.](https://github.com/snowpackjs/astro/blob/latest/packages/astro/src/@types/astro.ts)
+You can view the full configuration API (including information about default configuration) on [GitHub.](https://github.com/snowpackjs/astro/blob/main/packages/astro/src/%40types/astro.ts)
 
 ```js
 // Example: astro.config.mjs

--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -5,7 +5,7 @@ title: Configuration Reference
 
 To configure Astro, add an `astro.config.mjs` file in the root of your project. All settings are optional.
 
-You can view the full configuration API (including information about default configuration) on [GitHub.](https://github.com/snowpackjs/astro/blob/main/packages/astro/src/%40types/astro.ts)
+You can view the full configuration API (including information about default configuration) on [GitHub.](https://github.com/snowpackjs/astro/blob/latest/packages/astro/src/%40types/astro.ts)
 
 ```js
 // Example: astro.config.mjs


### PR DESCRIPTION
## Changes

- fix broken link in configuration-reference.md  
(#1960)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No tests. Just update the documentation.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

This updates `/docs/src/pages/reference/configuration-reference.md`
