### PR TITLE
Clean up styling for framework-* examples

### DIFF
--- a/examples/framework-multiple/src/components/PreactCounter.tsx
+++ b/examples/framework-multiple/src/components/PreactCounter.tsx
@@ -8,12 +8,12 @@ export function PreactCounter({ children }) {
 
   return (
     <>
-      <div className="counter">
+      <div class="counter">
         <button onClick={subtract}>-</button>
         <pre>{count}</pre>
         <button onClick={add}>+</button>
       </div>
-      <div className="children">{children}</div>
+      <div class="counter-message">{children}</div>
     </>
   );
 }

--- a/examples/framework-multiple/src/components/ReactCounter.jsx
+++ b/examples/framework-multiple/src/components/ReactCounter.jsx
@@ -13,7 +13,7 @@ export function Counter({ children }) {
         <pre>{count}</pre>
         <button onClick={add}>+</button>
       </div>
-      <div className="children">{children}</div>
+      <div className="counter-message">{children}</div>
     </>
   );
 }

--- a/examples/framework-multiple/src/components/SolidCounter.tsx
+++ b/examples/framework-multiple/src/components/SolidCounter.tsx
@@ -13,7 +13,7 @@ export default function SolidCounter({ children }) {
         <pre>{count()}</pre>
         <button onClick={add}>+</button>
       </div>
-      <div class="children">{children}</div>
+      <div class="counter-message">{children}</div>
     </>
   );
 }

--- a/examples/framework-multiple/src/components/SvelteCounter.svelte
+++ b/examples/framework-multiple/src/components/SvelteCounter.svelte
@@ -13,10 +13,10 @@
 </script>
 
 <div class="counter">
-    <button on:click={subtract}>-</button>
-    <pre>{ count }</pre>
-    <button on:click={add}>+</button>
+  <button on:click={subtract}>-</button>
+  <pre>{ count }</pre>
+  <button on:click={add}>+</button>
 </div>
-<div class="children">
-    <slot />
+<div class="counter-message">
+  <slot />
 </div>

--- a/examples/framework-multiple/src/components/VueCounter.vue
+++ b/examples/framework-multiple/src/components/VueCounter.vue
@@ -4,7 +4,7 @@
     <pre>{{ count }}</pre>
     <button @click="add()">+</button>
   </div>
-  <div class="children">
+  <div class="counter-message">
     <slot />
   </div>
 </template>

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -13,58 +13,39 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 ---
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-
-        <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-
-    <style>
-        :global(:root) {
-            font-family: system-ui;
-            padding: 2em 0;
-        }
-        :global(.counter) {
-            display: grid;
-            grid-template-columns: repeat(3, minmax(0, 1fr));
-            place-items: center;
-            font-size: 2em;
-            margin-top: 2em;
-        }
-        :global(.children) {
-            display: grid;
-            place-items: center;
-            margin-bottom: 2em;
-        }
-    </style>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="stylesheet" type="text/css" href={Astro.resolve('../styles/global.css')}>
   </head>
   <body>
-      <main>
+    <main>
 
-        <react.Counter client:visible>
-            <h1>Hello React!</h1>
-            <p>What's up?</p>
-        </react.Counter>
+      <react.Counter client:visible>
+        <h1>Hello React!</h1>
+        <p>What's up?</p>
+      </react.Counter>
 
-        <PreactCounter client:visible>
-          <h1>Hello Preact!</h1>
-        </PreactCounter>
+      <PreactCounter client:visible>
+        <h1>Hello Preact!</h1>
+      </PreactCounter>
 
-        <SolidCounter client:visible>
-          <h1>Hello Solid!</h1>
-        </SolidCounter>
+      <SolidCounter client:visible>
+        <h1>Hello Solid!</h1>
+      </SolidCounter>
 
-        <VueCounter client:visible>
-            <h1>Hello Vue!</h1>
-        </VueCounter>
+      <VueCounter client:visible>
+        <h1>Hello Vue!</h1>
+      </VueCounter>
 
-        <SvelteCounter client:visible>
-            <h1>Hello Svelte!</h1>
-        </SvelteCounter>
+      <SvelteCounter client:visible>
+        <h1>Hello Svelte!</h1>
+      </SvelteCounter>
 
-        <A />
-        
-        <Renamed />
+      <A />
 
-      </main>
+      <Renamed />
+
+    </main>
   </body>
 </html>

--- a/examples/framework-multiple/src/styles/global.css
+++ b/examples/framework-multiple/src/styles/global.css
@@ -1,0 +1,21 @@
+html,
+body {
+  font-family: system-ui;
+  margin: 0;
+}
+
+body {
+  padding: 2rem;
+}
+
+.counter {
+  display: grid;
+  font-size: 2em;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2em;
+  place-items: center;
+}
+
+.counter-message {
+  text-align: center;
+}

--- a/examples/framework-preact/src/components/Counter.css
+++ b/examples/framework-preact/src/components/Counter.css
@@ -1,0 +1,11 @@
+.counter {
+  display: grid;
+  font-size: 2em;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2em;
+  place-items: center;
+}
+
+.counter-message {
+  text-align: center;
+}

--- a/examples/framework-preact/src/components/Counter.tsx
+++ b/examples/framework-preact/src/components/Counter.tsx
@@ -1,5 +1,6 @@
 import { h, Fragment } from 'preact';
 import { useState } from 'preact/hooks';
+import './Counter.css';
 
 export default function Counter({ children }) {
   const [count, setCount] = useState(0);
@@ -8,12 +9,12 @@ export default function Counter({ children }) {
 
   return (
     <>
-      <div className="counter">
+      <div class="counter">
         <button onClick={subtract}>-</button>
         <pre>{count}</pre>
         <button onClick={add}>+</button>
       </div>
-      <div className="children">{children}</div>
+      <div class="counter-message">{children}</div>
     </>
   );
 }

--- a/examples/framework-preact/src/pages/index.astro
+++ b/examples/framework-preact/src/pages/index.astro
@@ -11,21 +11,13 @@ import Counter from '../components/Counter.tsx'
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <style>
-      :global(:root) {
+      html,
+      body {
         font-family: system-ui;
-        padding: 2em 0;
+        margin: 0;
       }
-      :global(.counter) {
-        display: grid;
-        font-size: 2em;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        margin-top: 2em;
-        place-items: center;
-      }
-      :global(.children) {
-        display: grid;
-        margin-bottom: 2em;
-        place-items: center;
+      body {
+        padding: 2rem;
       }
     </style>
   </head>

--- a/examples/framework-react/src/components/Counter.css
+++ b/examples/framework-react/src/components/Counter.css
@@ -1,0 +1,11 @@
+.counter {
+  display: grid;
+  font-size: 2em;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2em;
+  place-items: center;
+}
+
+.counter-message {
+  text-align: center;
+}

--- a/examples/framework-react/src/components/Counter.jsx
+++ b/examples/framework-react/src/components/Counter.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import './Counter.css';
 
 export default function Counter({ children, count: initialCount }) {
   const [count, setCount] = useState(initialCount);
@@ -12,7 +13,7 @@ export default function Counter({ children, count: initialCount }) {
         <pre>{count}</pre>
         <button onClick={add}>+</button>
       </div>
-      <div className="children">{children}</div>
+      <div className="counter-message">{children}</div>
     </>
   );
 }

--- a/examples/framework-react/src/pages/index.astro
+++ b/examples/framework-react/src/pages/index.astro
@@ -14,21 +14,13 @@ const someProps = {
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <style>
-      :global(:root) {
+      html,
+      body {
         font-family: system-ui;
-        padding: 2em 0;
+        margin: 0;
       }
-      :global(.counter) {
-        display: grid;
-        font-size: 2em;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        margin-top: 2em;
-        place-items: center;
-      }
-      :global(.children) {
-        display: grid;
-        margin-bottom: 2em;
-        place-items: center;
+      body {
+        padding: 2rem;
       }
     </style>
   </head>

--- a/examples/framework-solid/src/components/Counter.css
+++ b/examples/framework-solid/src/components/Counter.css
@@ -1,0 +1,11 @@
+.counter {
+  display: grid;
+  font-size: 2em;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 3em;
+  place-items: center;
+}
+
+.counter-message {
+  text-align: center;
+}

--- a/examples/framework-solid/src/components/Counter.jsx
+++ b/examples/framework-solid/src/components/Counter.jsx
@@ -1,4 +1,5 @@
 import { createSignal } from 'solid-js';
+import './Counter.css';
 
 export default function Counter({ children }) {
   const [count, setCount] = createSignal(0);

--- a/examples/framework-solid/src/pages/index.astro
+++ b/examples/framework-solid/src/pages/index.astro
@@ -6,19 +6,14 @@ import Counter from '../components/Counter.jsx';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <style global>
-      :root {
+    <style>
+      html,
+      body {
         font-family: system-ui;
+        margin: 0;
       }
-      .counter {
-        display: grid;
-        font-size: 2em;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        margin-top: 3em;
-        place-items: center;
-      }
-      .counter-message {
-        text-align: center;
+      body {
+        padding: 2rem;
       }
     </style>
   </head>

--- a/examples/framework-svelte/src/components/Counter.svelte
+++ b/examples/framework-svelte/src/components/Counter.svelte
@@ -15,6 +15,19 @@
   <pre>{ count }</pre>
   <button on:click={add}>+</button>
 </div>
-<div class="children">
+<div class="message">
   <slot />
 </div>
+
+<style>
+  .counter{
+    display: grid;
+    font-size: 2em;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin-top: 2em;
+    place-items: center;
+  }
+  .message {
+    text-align: center;
+  }
+</style>

--- a/examples/framework-svelte/src/pages/index.astro
+++ b/examples/framework-svelte/src/pages/index.astro
@@ -12,21 +12,13 @@ import Counter from '../components/Counter.svelte'
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <style>
-      :global(:root) {
+      html,
+      body {
         font-family: system-ui;
-        padding: 2em 0;
+        margin: 0;
       }
-      :global(.counter) {
-        display: grid;
-        font-size: 2em;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        margin-top: 2em;
-        place-items: center;
-      }
-      :global(.children) {
-        display: grid;
-        margin-bottom: 2em;
-        place-items: center;
+      body {
+        padding: 2rem;
       }
     </style>
   </head>

--- a/examples/framework-vue/src/components/Counter.vue
+++ b/examples/framework-vue/src/components/Counter.vue
@@ -4,7 +4,7 @@
     <pre>{{ count }}</pre>
     <button @click="add()">+</button>
   </div>
-  <div class="children">
+  <div class="counter-message">
     <slot />
   </div>
 </template>
@@ -25,3 +25,16 @@ export default {
   },
 };
 </script>
+
+<style>
+.counter {
+  display: grid;
+  font-size: 2em;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2em;
+  place-items: center;
+}
+.counter-message {
+  text-align: center;
+}
+</style>

--- a/examples/framework-vue/src/pages/index.astro
+++ b/examples/framework-vue/src/pages/index.astro
@@ -12,21 +12,13 @@ import Counter from '../components/Counter.vue'
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <style>
-      :global(:root) {
+      html,
+      body {
         font-family: system-ui;
-        padding: 2em 0;
+        margin: 0;
       }
-      :global(.counter) {
-        display: grid;
-        font-size: 2em;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        margin-top: 2em;
-        place-items: center;
-      }
-      :global(.children) {
-        display: grid;
-        margin-bottom: 2em;
-        place-items: center;
+      body {
+        padding: 2rem;
       }
     </style>
   </head>


### PR DESCRIPTION
## Changes

Examples are how we teach people to use Astro! But some of our examples’ styling doesn’t follow our own [recommended best practices](https://docs.astro.build/guides/styling/).

Without affecting the look of the examples at all, the following changes were made:

1. Removed usage of `:global()` when it wasn’t necessary
2. But kept global CSS in all cases (simply moved the styles to be more manageable)
2. Moved styling into components, which encourages good style scoping and improves CSS tree-shaking 
3. Simplified some CSS, such as removing CSS grid when it wasn’t needed
4. When styles are shared between components, use a global `<link>` tag rather than page styles (which would easily break for users as they added pages)

The overall goal was to **keep styling simple** (it’s an example) while still **following best practices** (i.e. don’t require users to have to rethink the foundation too much).

## Testing

Manually tested; all examples changed appear visually identical to previous version

## Docs

No docs changes needed