### PR TITLE
Update Tailwind PostCSS sample config in docs

### DIFF
--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -224,8 +224,10 @@ module.exports = {
 ```js
 // postcss.config.cjs
 module.exports = {
-  tailwind: {},
-};
+  plugins: {
+    tailwindcss: {},
+  },
+}
 ```
 
 Now you're ready to write Tailwind! Our recommended approach is to create a `src/styles/global.css` file (or whatever you‘d like to name your global stylesheet) with [Tailwind utilities][tailwind-utilities] like so:


### PR DESCRIPTION
## Changes

- Corrects the documented `postcss.config.cjs` for setting up Tailwind
  - The previously documented config leaves `@tailwind` directives unchanged
  - See [Tailwind PostCSS plugin docs](https://tailwindcss.com/docs/installation#add-tailwind-as-a-post-css-plugin) and the Astro `with-tailwind` [example config](https://github.com/snowpackjs/astro/blob/fff00e45f00f8534ec5fe66302d8c44639b34499/examples/with-tailwindcss/postcss.config.js)


## Testing

- No tests added since this only affects docs
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- Updates the "Styling" docs
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
